### PR TITLE
feat(android): v1.1 添加域名 + Worker 配置 + D1 建删 + Tunnel 管理

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "jiamin.chen.orangecloud"
         minSdk = 31
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/PermissionModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/PermissionModels.kt
@@ -26,7 +26,7 @@ object PermissionCatalog {
         PermissionFeature("r2", R.string.perm_r2, R.string.perm_r2_desc, listOf(Scopes.R2_READ), listOf(Scopes.R2_WRITE)),
         PermissionFeature("d1", R.string.perm_d1, R.string.perm_d1_desc, listOf(Scopes.D1_READ), listOf(Scopes.D1_WRITE)),
         PermissionFeature("kv", R.string.perm_kv, R.string.perm_kv_desc, listOf(Scopes.KV_READ), listOf(Scopes.KV_WRITE)),
-        PermissionFeature("tunnels", R.string.perm_tunnels, R.string.perm_tunnels_desc, listOf(Scopes.TUNNEL_READ)),
+        PermissionFeature("tunnels", R.string.perm_tunnels, R.string.perm_tunnels_desc, listOf(Scopes.TUNNEL_READ), listOf(Scopes.TUNNEL_WRITE)),
         PermissionFeature("waf", R.string.perm_waf, R.string.perm_waf_desc, listOf(Scopes.WAF_READ), listOf(Scopes.WAF_WRITE)),
         PermissionFeature("zone_settings", R.string.perm_zone_settings, R.string.perm_zone_settings_desc, listOf(Scopes.ZONE_SETTINGS_READ), listOf(Scopes.ZONE_SETTINGS_WRITE, Scopes.CACHE_PURGE)),
         PermissionFeature("analytics", R.string.perm_analytics, R.string.perm_analytics_desc, listOf(Scopes.ACCOUNT_ANALYTICS_READ, Scopes.ANALYTICS_READ)),

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/Scopes.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/Scopes.kt
@@ -22,6 +22,7 @@ object Scopes {
     const val KV_READ = "workers-kv-storage.read"
     const val KV_WRITE = "workers-kv-storage.write"
     const val TUNNEL_READ = "argotunnel.read"
+    const val TUNNEL_WRITE = "argotunnel.write"
     const val WAF_READ = "zone-waf.read"
     const val WAF_WRITE = "zone-waf.write"
     const val ZONE_SETTINGS_READ = "zone-settings.read"
@@ -45,7 +46,7 @@ object Scopes {
         R2_READ, R2_WRITE,
         D1_READ, D1_WRITE,
         KV_READ, KV_WRITE,
-        TUNNEL_READ,
+        TUNNEL_READ, TUNNEL_WRITE,
         WAF_READ, WAF_WRITE,
         ZONE_SETTINGS_READ, ZONE_SETTINGS_WRITE, CACHE_PURGE,
         ACCOUNT_ANALYTICS_READ, ANALYTICS_READ,

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/network/CfApiClient.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/network/CfApiClient.kt
@@ -63,6 +63,18 @@ class CfApiClient @Inject constructor(
         executeRaw("DELETE", path, emptyList(), null, JSON_MEDIA_TYPE)
     }
 
+    /** JSON POST，只校验 success（写端点 result 可能为 null，如切换子域）。 */
+    suspend inline fun <reified B> postChecked(path: String, body: B) {
+        val payload = json.encodeToString(serializer<B>(), body).encodeToByteArray()
+        checkSuccess(executeRaw("POST", path, emptyList(), payload, JSON_MEDIA_TYPE))
+    }
+
+    /** JSON PUT，只校验 success（写端点 result 可能为 null）。 */
+    suspend inline fun <reified B> putChecked(path: String, body: B) {
+        val payload = json.encodeToString(serializer<B>(), body).encodeToByteArray()
+        checkSuccess(executeRaw("PUT", path, emptyList(), payload, JSON_MEDIA_TYPE))
+    }
+
     /** KV value 等非 JSON 信封端点：返回原始字节 */
     suspend fun getRaw(path: String, query: List<Pair<String, String>> = emptyList()): ByteArray =
         executeRaw("GET", path, query, null, null)
@@ -87,6 +99,39 @@ class CfApiClient @Inject constructor(
     /** 原始字节 PUT，只校验 success（R2 上传等 result 可能为 null）。 */
     suspend fun putRawVoid(path: String, body: ByteArray, contentType: String) {
         executeRaw("PUT", path, emptyList(), body, contentType)
+    }
+
+    /**
+     * 单 JSON part 的 multipart 请求（method 任意），只校验 success。
+     * Worker 改设置 PATCH .../settings 用——CF 要求 settings 作为 multipart form part 而非裸 JSON body。
+     */
+    suspend fun requestMultipartJsonChecked(
+        method: String,
+        path: String,
+        partName: String,
+        bodyJson: String,
+        query: List<Pair<String, String>> = emptyList(),
+    ) {
+        val boundary = "OrangeCloud-${UUID.randomUUID()}"
+        val sb = StringBuilder()
+        sb.append("--").append(boundary).append("\r\n")
+        sb.append("Content-Disposition: form-data; name=\"").append(partName).append("\"\r\n")
+        sb.append("Content-Type: application/json\r\n\r\n")
+        sb.append(bodyJson).append("\r\n")
+        sb.append("--").append(boundary).append("--\r\n")
+        val bytes = executeRaw(method, path, query, sb.toString().encodeToByteArray(), "multipart/form-data; boundary=$boundary")
+        checkSuccess(bytes)
+    }
+
+    /** 校验 2xx 响应体信封的 success（HTTP 200 但 success:false 时透出 CF 业务错误）。 */
+    @PublishedApi
+    internal fun checkSuccess(bytes: ByteArray) {
+        val env = runCatching {
+            json.decodeFromString(CfEnvelope.serializer(JsonElement.serializer()), bytes.decodeToString())
+        }.getOrNull()
+        if (env != null && !env.success) {
+            throw ApiError.Cloudflare(env.errors.map { ApiError.CfError(it.code, it.message) })
+        }
     }
 
     /** Snippets 创建/更新：multipart 带 metadata part + JS 模块文件 part（application/javascript+module）。 */

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/util/Clipboard.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/util/Clipboard.kt
@@ -1,0 +1,11 @@
+package jiamin.chen.orangecloud.core.util
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+
+/** 复制纯文本到系统剪贴板（用平台 API，不引 Compose 已弃用的 LocalClipboardManager）。 */
+fun copyToClipboard(context: Context, text: String, label: String = "orange-cloud") {
+    val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
+    manager.setPrimaryClip(ClipData.newPlainText(label, text))
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNew.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNew.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import jiamin.chen.orangecloud.BuildConfig
-import jiamin.chen.orangecloud.R
 import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -16,17 +15,13 @@ data class WhatsNewItem(val titleRes: Int, val detailRes: Int)
 /** 一个版本的「新功能」集合。version 须 == MARKETING_VERSION 基号。 */
 data class WhatsNewRelease(val version: String, val items: List<WhatsNewItem>)
 
-/** 按版本 curated 的「新功能」内容（对应 iOS WhatsNewContent.releases）。 */
+/**
+ * 按版本 curated 的「新功能」内容（对应 iOS WhatsNewContent.releases）。
+ * ⚠️ 内容是单一数据源：改 packages/changelog/android.json 后运行 `pnpm changelog:gen`，
+ *    会重新生成 WhatsNewReleases.generated.kt 与各 locale 的 whatsnew.xml 资源（勿手改）。
+ */
 object WhatsNewContent {
-    val releases: List<WhatsNewRelease> = listOf(
-        WhatsNewRelease(
-            version = "1.0",
-            items = listOf(
-                WhatsNewItem(R.string.whatsnew_1_0_oauth_title, R.string.whatsnew_1_0_oauth_detail),
-                WhatsNewItem(R.string.whatsnew_1_0_modules_title, R.string.whatsnew_1_0_modules_detail),
-            ),
-        ),
-    )
+    val releases: List<WhatsNewRelease> = whatsNewReleases
 
     fun releaseFor(version: String): WhatsNewRelease? = releases.firstOrNull { it.version == version }
 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
@@ -1,0 +1,20 @@
+package jiamin.chen.orangecloud.core.whatsnew
+
+import jiamin.chen.orangecloud.R
+
+// ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。
+internal val whatsNewReleases: List<WhatsNewRelease> = listOf(
+    WhatsNewRelease(
+        version = "1.1",
+        items = listOf(
+            WhatsNewItem(R.string.whatsnew_1_1_0_title, R.string.whatsnew_1_1_0_detail),
+        ),
+    ),
+    WhatsNewRelease(
+        version = "1.0",
+        items = listOf(
+            WhatsNewItem(R.string.whatsnew_1_0_0_title, R.string.whatsnew_1_0_0_detail),
+            WhatsNewItem(R.string.whatsnew_1_0_1_title, R.string.whatsnew_1_0_1_detail),
+        ),
+    ),
+)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/Models.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/Models.kt
@@ -26,6 +26,20 @@ data class Zone(
 @Serializable
 data class ZonePlan(val name: String)
 
+/**
+ * 新建 Zone（POST /zones）请求体。type="full"——Cloudflare 作权威 DNS，
+ * 响应返回分配的 name_servers，状态 pending，待用户在注册商处更换 NS 后激活。
+ */
+@Serializable
+data class CreateZoneRequest(
+    val name: String,
+    val type: String = "full",
+    val account: AccountRef,
+) {
+    @Serializable
+    data class AccountRef(val id: String)
+}
+
 /** DNS 记录（与 iOS Models/DNSRecord.swift 对应）。 */
 @Serializable
 data class DnsRecord(

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/SecurityModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/SecurityModels.kt
@@ -2,6 +2,7 @@ package jiamin.chen.orangecloud.data.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 // MARK: - WAF 自定义规则（Rulesets，phase = http_request_firewall_custom）
 
@@ -64,3 +65,83 @@ data class TunnelConnection(
     @SerialName("opened_at") val openedAt: String? = null,
     @SerialName("client_version") val clientVersion: String? = null,
 )
+
+/**
+ * 新建隧道（POST /accounts/{id}/cfd_tunnel）。固定远程托管（config_src=cloudflare），
+ * 只有远程托管隧道的 ingress 配置能经 API 管理。
+ */
+@Serializable
+data class CreateTunnelRequest(
+    val name: String,
+    @SerialName("config_src") val configSrc: String = "cloudflare",
+)
+
+// MARK: - 隧道配置（公共主机名 / ingress，仅远程托管）
+
+/** GET/PUT /configurations 的 result 外壳。 */
+@Serializable
+data class TunnelConfigResult(
+    @SerialName("tunnel_id") val tunnelId: String? = null,
+    val config: TunnelConfig? = null,
+)
+
+/**
+ * 隧道配置。整组 PUT；未建模的高级字段（originRequest）用 JsonElement 原样保留，避免回写丢失。
+ */
+@Serializable
+data class TunnelConfig(
+    val ingress: List<IngressRule>? = null,
+    @SerialName("warp-routing") val warpRouting: JsonElement? = null,
+    val originRequest: JsonElement? = null,
+)
+
+/** 单条 ingress 规则。catch-all（末尾兜底）只有 service、无 hostname。 */
+@Serializable
+data class IngressRule(
+    val hostname: String? = null,
+    val service: String,
+    val path: String? = null,
+    val originRequest: JsonElement? = null,
+) {
+    /** 是否为兜底规则（无 hostname，或 service 是 http_status 形态）。UI 列表里隐藏它。 */
+    val isCatchAll: Boolean
+        get() = hostname.isNullOrEmpty() || service.startsWith("http_status:")
+
+    /** 从 service 字符串识别协议种类（用于编辑表单回填）。 */
+    val serviceKind: IngressServiceKind
+        get() = IngressServiceKind.entries.firstOrNull { it.scheme.isNotEmpty() && service.startsWith(it.scheme) }
+            ?: IngressServiceKind.OTHER
+
+    /** 去掉协议前缀后的目标（host:port），OTHER 时为整串。 */
+    val serviceTarget: String
+        get() = serviceKind.let { if (it == IngressServiceKind.OTHER) service else service.removePrefix(it.scheme) }
+
+    companion object {
+        /** catch-all 兜底规则：无 hostname，把其余流量返回 404。 */
+        val catchAll = IngressRule(service = "http_status:404")
+    }
+}
+
+/** 公共主机名表单支持的服务协议。 */
+enum class IngressServiceKind(val scheme: String, val label: String) {
+    HTTP("http://", "HTTP"),
+    HTTPS("https://", "HTTPS"),
+    TCP("tcp://", "TCP"),
+    SSH("ssh://", "SSH"),
+    RDP("rdp://", "RDP"),
+    OTHER("", "");
+
+    /** 该协议的默认目标占位。 */
+    val targetPlaceholder: String
+        get() = when (this) {
+            HTTP, HTTPS -> "localhost:8000"
+            TCP -> "localhost:5432"
+            SSH -> "localhost:22"
+            RDP -> "localhost:3389"
+            OTHER -> "unix:/path/to.sock"
+        }
+}
+
+/** PUT /configurations 请求体：{ "config": { … } }。 */
+@Serializable
+data class TunnelConfigUpdate(val config: TunnelConfig)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/StorageModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/StorageModels.kt
@@ -49,6 +49,16 @@ data class D1QueryRequest(
     val params: List<String>? = null,
 )
 
+/**
+ * 新建数据库（POST /accounts/{id}/d1/database）请求体。primaryLocationHint 为空时
+ * 不编码进 JSON（explicitNulls=false），由 Cloudflare 就近放置。
+ */
+@Serializable
+data class D1CreateRequest(
+    val name: String,
+    @SerialName("primary_location_hint") val primaryLocationHint: String? = null,
+)
+
 /** PRAGMA table_info 解析后的列结构（运行期结构，非 API 模型）。 */
 data class D1Column(
     val name: String,

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/WorkerConfigModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/WorkerConfigModels.kt
@@ -1,0 +1,105 @@
+package jiamin.chen.orangecloud.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Workers 脚本管理（变量 / 密钥 / 触发器）相关模型（对应 iOS WorkerConfigModels.swift）。
+ * 源码读取端点在 OAuth 登录下被 Cloudflare 拒绝（cf=10405），故客户端不做脚本编辑，仅做配置管理。
+ *
+ * GET  /accounts/{a}/workers/scripts/{n}/settings    绑定 + 兼容性日期/标志
+ * PATCH .../settings (multipart settings part)        改绑定（变量），其余绑定回传 inherit
+ * GET/PUT/DELETE .../secrets                           密钥（仅名+类型，无值）
+ * GET/PUT .../schedules                                Cron 触发器（整组替换）
+ */
+
+// MARK: - 绑定与设置
+
+/**
+ * 脚本绑定（KV / D1 / R2 / 密钥 / 变量 等）。读展示与 inherit 回传只需 type/name；变量另读 text。
+ * 未建模的新绑定类型不致整页失败（缺字段降级为空串，调用方过滤空名）。
+ */
+@Serializable
+data class WorkerBinding(
+    val type: String = "",
+    val name: String = "",
+    val text: String? = null, // plain_text 变量的值；其余类型为 nil
+) {
+    val isSecret: Boolean get() = type == "secret_text" || type == "secrets_store_secret"
+    val isPlainText: Boolean get() = type == "plain_text"
+
+    /** 回传时转为 inherit（按名保留旧绑定，密钥值我们读不到也能保住）。 */
+    fun asInherit(): WorkerBindingInput = WorkerBindingInput(type = "inherit", name = name)
+}
+
+/** 脚本设置（GET .../settings）。 */
+@Serializable
+data class WorkerSettings(
+    val bindings: List<WorkerBinding> = emptyList(),
+    @SerialName("compatibility_date") val compatibilityDate: String? = null,
+    @SerialName("compatibility_flags") val compatibilityFlags: List<String>? = null,
+    @SerialName("usage_model") val usageModel: String? = null,
+    val logpush: Boolean? = null,
+) {
+    /** 过滤掉空名（容错解码降级）的有效绑定。 */
+    val validBindings: List<WorkerBinding> get() = bindings.filter { it.name.isNotEmpty() }
+
+    /** 把现有绑定整组转为 inherit，供「只改某个变量、其余保持」的安全回传。 */
+    fun inheritedBindings(excludingName: String? = null): List<WorkerBindingInput> =
+        validBindings.filter { it.name != excludingName }.map { it.asInherit() }
+}
+
+// MARK: - 上传 / 写入请求体
+
+/** PATCH settings 的单条绑定。inherit 只发 {type,name}；plain_text 发 {type,name,text}。 */
+@Serializable
+data class WorkerBindingInput(
+    val type: String,
+    val name: String,
+    val text: String? = null,
+)
+
+/** PATCH settings 的 settings part（改变量时回传：变更项 + 其余 inherit）。 */
+@Serializable
+data class WorkerSettingsPatch(
+    val bindings: List<WorkerBindingInput>,
+    @SerialName("compatibility_date") val compatibilityDate: String? = null,
+    @SerialName("compatibility_flags") val compatibilityFlags: List<String>? = null,
+)
+
+// MARK: - 密钥
+
+/** 密钥（GET .../secrets，仅名 + 类型，永不含值）。 */
+@Serializable
+data class WorkerSecret(
+    val name: String = "",
+    val type: String? = null,
+)
+
+/** 新建 / 更新密钥（PUT .../secrets）。 */
+@Serializable
+data class WorkerSecretInput(
+    val name: String,
+    val text: String,
+    val type: String = "secret_text",
+)
+
+// MARK: - Cron 触发器
+
+/** 单条 Cron 触发器（GET .../schedules）。 */
+@Serializable
+data class WorkerSchedule(
+    val cron: String = "",
+    @SerialName("created_on") val createdOn: String? = null,
+    @SerialName("modified_on") val modifiedOn: String? = null,
+)
+
+/** schedules 端点 result 形态 { schedules: [...] }。 */
+@Serializable
+data class WorkerSchedulesResult(
+    val schedules: List<WorkerSchedule> = emptyList(),
+)
+
+/** PUT .../schedules 的单条（整组替换，请求体是裸数组 [{cron}]）。 */
+@Serializable
+data class WorkerScheduleInput(val cron: String)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/WorkerRouteModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/WorkerRouteModels.kt
@@ -1,0 +1,70 @@
+package jiamin.chen.orangecloud.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Worker 的域名/路由模型（对应 iOS WorkerRouteModels.swift）。
+ * GET/POST /accounts/{a}/workers/scripts/{n}/subdomain   workers.dev 子域开关
+ * GET/PUT/DELETE /accounts/{a}/workers/domains            自定义域（按 service 过滤到本脚本）
+ * GET/POST/DELETE /zones/{z}/workers/routes               Zone 路由（pattern → script）
+ */
+
+// MARK: - workers.dev 子域
+
+/** 脚本的 workers.dev 子域路由状态。 */
+@Serializable
+data class WorkerSubdomain(
+    val enabled: Boolean = false,
+    @SerialName("previews_enabled") val previewsEnabled: Boolean? = null,
+)
+
+/** 切换 workers.dev 子域（POST body）。 */
+@Serializable
+data class WorkerSubdomainInput(val enabled: Boolean)
+
+// MARK: - 自定义域
+
+/** Worker 自定义域（账号级，service = 脚本名）。 */
+@Serializable
+data class WorkerCustomDomain(
+    val id: String = "",
+    val hostname: String = "",
+    val service: String? = null,
+    @SerialName("zone_id") val zoneId: String? = null,
+    @SerialName("zone_name") val zoneName: String? = null,
+    val environment: String? = null,
+)
+
+/** 挂载自定义域（PUT .../domains）。 */
+@Serializable
+data class WorkerCustomDomainInput(
+    val hostname: String,
+    val service: String,
+    @SerialName("zone_id") val zoneId: String,
+    val environment: String = "production",
+)
+
+// MARK: - Zone 路由
+
+/** Zone 级 Worker 路由（GET /zones/{z}/workers/routes）。 */
+@Serializable
+data class WorkerRoute(
+    val id: String = "",
+    val pattern: String = "",
+    val script: String? = null,
+)
+
+/** 新建路由（POST，body {pattern, script}）。 */
+@Serializable
+data class WorkerRouteInput(
+    val pattern: String,
+    val script: String,
+)
+
+/** 带 zone 上下文的路由（路由本身按 zone 查询，聚合展示/删除时需带 zone）。运行期结构，非 API 模型。 */
+data class ScopedWorkerRoute(
+    val zoneId: String,
+    val zoneName: String,
+    val route: WorkerRoute,
+)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/SecurityRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/SecurityRepository.kt
@@ -2,7 +2,11 @@ package jiamin.chen.orangecloud.data.repository
 
 import jiamin.chen.orangecloud.core.network.ApiError
 import jiamin.chen.orangecloud.core.network.CfApiClient
+import jiamin.chen.orangecloud.data.model.CreateTunnelRequest
 import jiamin.chen.orangecloud.data.model.Tunnel
+import jiamin.chen.orangecloud.data.model.TunnelConfig
+import jiamin.chen.orangecloud.data.model.TunnelConfigResult
+import jiamin.chen.orangecloud.data.model.TunnelConfigUpdate
 import jiamin.chen.orangecloud.data.model.WafEntrypointUpdate
 import jiamin.chen.orangecloud.data.model.WafRule
 import jiamin.chen.orangecloud.data.model.WafRuleCreate
@@ -65,4 +69,42 @@ class SecurityRepository @Inject constructor(
      */
     suspend fun getTunnel(accountId: String, tunnelId: String): Tunnel =
         api.get("accounts/$accountId/cfd_tunnel/$tunnelId")
+
+    // MARK: - 隧道生命周期（argotunnel.write）
+
+    /** 新建远程托管隧道（config_src=cloudflare）。 */
+    suspend fun createTunnel(accountId: String, name: String): Tunnel =
+        api.post("accounts/$accountId/cfd_tunnel", CreateTunnelRequest(name))
+
+    /** 隧道连接令牌（result 是裸 base64 字符串），用于 `cloudflared tunnel run --token`。 */
+    suspend fun tunnelToken(accountId: String, tunnelId: String): String =
+        api.get("accounts/$accountId/cfd_tunnel/$tunnelId/token")
+
+    /** 清理失活连接（删除隧道前先调用；活跃的 cloudflared 仍会重连）。 */
+    suspend fun deleteConnections(accountId: String, tunnelId: String) =
+        api.delete("accounts/$accountId/cfd_tunnel/$tunnelId/connections")
+
+    /** 删除隧道：先清理连接再删；若仍有活跃连接，CF 业务错误原样透出。 */
+    suspend fun deleteTunnel(accountId: String, tunnelId: String) {
+        runCatching { deleteConnections(accountId, tunnelId) }
+        api.delete("accounts/$accountId/cfd_tunnel/$tunnelId")
+    }
+
+    // MARK: - 配置（公共主机名 / ingress，仅远程托管）
+
+    /** 读隧道配置。新建后尚无配置时返回 null（404 或 config 为空均按「无配置」处理）。 */
+    suspend fun configuration(accountId: String, tunnelId: String): TunnelConfig? = try {
+        api.get<TunnelConfigResult>("accounts/$accountId/cfd_tunnel/$tunnelId/configurations").config
+    } catch (e: ApiError.Http) {
+        if (e.status == 404) null else throw e
+    }
+
+    /** 整组回写配置（catch-all 守在末尾由调用方保证），返回更新后的配置。 */
+    suspend fun updateConfiguration(accountId: String, tunnelId: String, config: TunnelConfig): TunnelConfig {
+        val result = api.put<TunnelConfigResult, TunnelConfigUpdate>(
+            "accounts/$accountId/cfd_tunnel/$tunnelId/configurations",
+            TunnelConfigUpdate(config),
+        )
+        return result.config ?: config
+    }
 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/StorageRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/StorageRepository.kt
@@ -1,6 +1,7 @@
 package jiamin.chen.orangecloud.data.repository
 
 import jiamin.chen.orangecloud.core.network.CfApiClient
+import jiamin.chen.orangecloud.data.model.D1CreateRequest
 import jiamin.chen.orangecloud.data.model.D1Database
 import jiamin.chen.orangecloud.data.model.D1QueryRequest
 import jiamin.chen.orangecloud.data.model.D1QueryResult
@@ -70,6 +71,14 @@ class StorageRepository @Inject constructor(
      */
     suspend fun getDatabase(accountId: String, databaseId: String): D1Database =
         api.get("accounts/$accountId/d1/database/$databaseId")
+
+    /** 创建数据库。locationHint 为空走自动放置。 */
+    suspend fun createDatabase(accountId: String, name: String, locationHint: String?): D1Database =
+        api.post("accounts/$accountId/d1/database", D1CreateRequest(name, locationHint))
+
+    /** 删除数据库（连同全部表与数据，不可恢复）。 */
+    suspend fun deleteDatabase(accountId: String, databaseId: String) =
+        api.delete("accounts/$accountId/d1/database/$databaseId")
 
     /** 执行 SQL（每条语句一个结果）。 */
     suspend fun query(accountId: String, databaseId: String, sql: String, params: List<String>? = null): List<D1QueryResult> =

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/WorkerRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/WorkerRepository.kt
@@ -4,20 +4,36 @@ import jiamin.chen.orangecloud.core.network.CfApiClient
 import jiamin.chen.orangecloud.data.local.WorkerDao
 import jiamin.chen.orangecloud.data.local.toEntity
 import jiamin.chen.orangecloud.data.local.toWorker
+import jiamin.chen.orangecloud.data.model.WorkerBindingInput
+import jiamin.chen.orangecloud.data.model.WorkerCustomDomain
+import jiamin.chen.orangecloud.data.model.WorkerCustomDomainInput
+import jiamin.chen.orangecloud.data.model.WorkerRoute
+import jiamin.chen.orangecloud.data.model.WorkerRouteInput
+import jiamin.chen.orangecloud.data.model.WorkerSchedule
+import jiamin.chen.orangecloud.data.model.WorkerSchedulesResult
+import jiamin.chen.orangecloud.data.model.WorkerScheduleInput
 import jiamin.chen.orangecloud.data.model.WorkerScript
+import jiamin.chen.orangecloud.data.model.WorkerSecret
+import jiamin.chen.orangecloud.data.model.WorkerSecretInput
+import jiamin.chen.orangecloud.data.model.WorkerSettings
+import jiamin.chen.orangecloud.data.model.WorkerSettingsPatch
+import jiamin.chen.orangecloud.data.model.WorkerSubdomain
+import jiamin.chen.orangecloud.data.model.WorkerSubdomainInput
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Workers 仓库：Room 为单一可信源，网络刷新后整账号替换缓存（对应 iOS WorkerService + CacheSync）。
- * 该端点不分页。
+ * Workers 仓库：Room 为单一可信源，列表刷新后整账号替换缓存（对应 iOS WorkerService + CacheSync）。
+ * 脚本配置（变量/密钥/触发器/域名）为会话级即时数据，不入 Room。该列表端点不分页。
  */
 @Singleton
 class WorkerRepository @Inject constructor(
     private val api: CfApiClient,
     private val workerDao: WorkerDao,
+    private val json: Json,
 ) {
     fun observeWorkers(accountId: String): Flow<List<WorkerScript>> =
         workerDao.observeByAccount(accountId).map { rows -> rows.map { it.toWorker() } }
@@ -26,4 +42,85 @@ class WorkerRepository @Inject constructor(
         val scripts = api.getList<WorkerScript>("accounts/$accountId/workers/scripts").items
         workerDao.replaceForAccount(accountId, scripts.map { it.toEntity(accountId) })
     }
+
+    // MARK: - 设置（绑定 / 变量）
+
+    /** 脚本设置（绑定 + 兼容性日期/标志）。 */
+    suspend fun settings(accountId: String, scriptName: String): WorkerSettings =
+        api.get("accounts/$accountId/workers/scripts/$scriptName/settings")
+
+    /**
+     * 改绑定（变量）：传入完整新 bindings（变更项为实体，其余 inherit），PATCH settings 不动代码。
+     * CF 要求 settings 作为 multipart form part。
+     */
+    suspend fun patchSettings(accountId: String, scriptName: String, bindings: List<WorkerBindingInput>, settings: WorkerSettings) {
+        val patch = WorkerSettingsPatch(
+            bindings = bindings,
+            compatibilityDate = settings.compatibilityDate,
+            compatibilityFlags = settings.compatibilityFlags,
+        )
+        api.requestMultipartJsonChecked(
+            method = "PATCH",
+            path = "accounts/$accountId/workers/scripts/$scriptName/settings",
+            partName = "settings",
+            bodyJson = json.encodeToString(WorkerSettingsPatch.serializer(), patch),
+        )
+    }
+
+    // MARK: - 密钥
+
+    /** 密钥列表（仅名 + 类型，永不含值）。 */
+    suspend fun listSecrets(accountId: String, scriptName: String): List<WorkerSecret> =
+        api.getList<WorkerSecret>("accounts/$accountId/workers/scripts/$scriptName/secrets").items
+
+    /** 新建 / 更新密钥。 */
+    suspend fun putSecret(accountId: String, scriptName: String, name: String, text: String) =
+        api.putChecked("accounts/$accountId/workers/scripts/$scriptName/secrets", WorkerSecretInput(name, text))
+
+    /** 删除密钥。 */
+    suspend fun deleteSecret(accountId: String, scriptName: String, name: String) =
+        api.delete("accounts/$accountId/workers/scripts/$scriptName/secrets/$name")
+
+    // MARK: - Cron 触发器
+
+    suspend fun schedules(accountId: String, scriptName: String): List<WorkerSchedule> =
+        api.get<WorkerSchedulesResult>("accounts/$accountId/workers/scripts/$scriptName/schedules").schedules
+
+    /** 整组替换 Cron（请求体是裸数组 [{cron}]；漏传即删）。 */
+    suspend fun putSchedules(accountId: String, scriptName: String, crons: List<String>) =
+        api.putChecked("accounts/$accountId/workers/scripts/$scriptName/schedules", crons.map { WorkerScheduleInput(it) })
+
+    // MARK: - 域名 / 路由
+
+    /** workers.dev 子域状态。 */
+    suspend fun subdomain(accountId: String, scriptName: String): WorkerSubdomain =
+        api.get("accounts/$accountId/workers/scripts/$scriptName/subdomain")
+
+    /** 切换 workers.dev 子域。 */
+    suspend fun setSubdomain(accountId: String, scriptName: String, enabled: Boolean) =
+        api.postChecked("accounts/$accountId/workers/scripts/$scriptName/subdomain", WorkerSubdomainInput(enabled))
+
+    /** 该脚本的自定义域（按 service 过滤）。 */
+    suspend fun customDomains(accountId: String, scriptName: String): List<WorkerCustomDomain> =
+        api.getList<WorkerCustomDomain>("accounts/$accountId/workers/domains", listOf("service" to scriptName)).items
+
+    /** 挂载自定义域到该脚本。 */
+    suspend fun attachDomain(accountId: String, scriptName: String, hostname: String, zoneId: String) =
+        api.putChecked("accounts/$accountId/workers/domains", WorkerCustomDomainInput(hostname, scriptName, zoneId))
+
+    /** 卸载自定义域。 */
+    suspend fun deleteDomain(accountId: String, domainId: String) =
+        api.delete("accounts/$accountId/workers/domains/$domainId")
+
+    /** zone 下全部 Worker 路由（调用方按 script 过滤到本脚本）。 */
+    suspend fun routes(zoneId: String): List<WorkerRoute> =
+        api.getList<WorkerRoute>("zones/$zoneId/workers/routes").items
+
+    /** 新建路由（pattern → script）。 */
+    suspend fun createRoute(zoneId: String, pattern: String, scriptName: String) =
+        api.postChecked("zones/$zoneId/workers/routes", WorkerRouteInput(pattern, scriptName))
+
+    /** 删除路由。 */
+    suspend fun deleteRoute(zoneId: String, routeId: String) =
+        api.delete("zones/$zoneId/workers/routes/$routeId")
 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/ZoneRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/ZoneRepository.kt
@@ -4,6 +4,7 @@ import jiamin.chen.orangecloud.core.network.CfApiClient
 import jiamin.chen.orangecloud.data.local.ZoneDao
 import jiamin.chen.orangecloud.data.local.toEntity
 import jiamin.chen.orangecloud.data.local.toZone
+import jiamin.chen.orangecloud.data.model.CreateZoneRequest
 import jiamin.chen.orangecloud.data.model.Zone
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -29,11 +30,27 @@ class ZoneRepository @Inject constructor(
     fun observeZone(zoneId: String): Flow<Zone?> =
         zoneDao.observeById(zoneId).map { it?.toZone(json) }
 
+    /**
+     * 新建 Zone（添加域名，full setup）。成功后把新 Zone 单条 upsert 进缓存
+     * （insertAll 的 REPLACE 只换同主键，不动其它域名），列表 Flow 即时可见。
+     */
+    suspend fun createZone(accountId: String, name: String): Zone {
+        val zone = api.post<Zone, CreateZoneRequest>(
+            "zones",
+            CreateZoneRequest(name = name, account = CreateZoneRequest.AccountRef(accountId)),
+        )
+        zoneDao.insertAll(listOf(zone.toEntity(accountId, json)))
+        return zone
+    }
+
     /** 从网络拉全量（自动翻页）并整账号替换缓存。 */
     suspend fun refreshZones(accountId: String) {
         val zones = fetchAllZones(accountId)
         zoneDao.replaceForAccount(accountId, zones.map { it.toEntity(accountId, json) })
     }
+
+    /** 一次性拉取账号下全部域名（不写缓存），供需要 zone 列表的功能（如 Worker 路由）使用。 */
+    suspend fun listZones(accountId: String): List<Zone> = fetchAllZones(accountId)
 
     private suspend fun fetchAllZones(accountId: String): List<Zone> {
         val all = mutableListOf<Zone>()

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelDetailScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelDetailScreen.kt
@@ -2,6 +2,7 @@ package jiamin.chen.orangecloud.ui.network
 
 import android.text.format.DateUtils
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,6 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -18,19 +21,42 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Hub
 import androidx.compose.material.icons.outlined.SettingsEthernet
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -45,13 +71,17 @@ import jiamin.chen.orangecloud.core.design.SkyHeader
 import jiamin.chen.orangecloud.core.design.onSky
 import jiamin.chen.orangecloud.core.design.rememberSkyPhase
 import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.core.util.copyToClipboard
+import jiamin.chen.orangecloud.data.model.IngressRule
+import jiamin.chen.orangecloud.data.model.IngressServiceKind
 import jiamin.chen.orangecloud.data.model.TunnelConnection
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
-/** 隧道详情：信息段 + 活跃连接列表（对齐 iOS TunnelDetailView，只读）。 */
+/** 隧道详情：信息 + 连接令牌 + 公共主机名管理 + 活跃连接 + 危险操作（对齐 iOS TunnelDetailView）。 */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TunnelDetailScreen(
     onBack: () -> Unit,
@@ -60,77 +90,387 @@ fun TunnelDetailScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val snackbarHostState = remember { SnackbarHostState() }
+    val errMsg = stringResource(R.string.error_generic)
+
+    var hostnameEdit by remember { mutableStateOf<HostnameEdit?>(null) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var showCleanupConfirm by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.canWrite) { if (state.canWrite) viewModel.loadToken() }
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                TunnelDetailEvent.Deleted -> onBack()
+                is TunnelDetailEvent.Notice -> snackbarHostState.showSnackbar(event.message)
+                is TunnelDetailEvent.Error -> snackbarHostState.showSnackbar(event.message ?: errMsg)
+            }
+        }
+    }
 
     SkyBackground(phase = phase) {
-        Column(Modifier.fillMaxSize().systemBarsPadding()) {
-            SkyHeader(
-                title = state.tunnel?.name?.ifBlank { viewModel.tunnelName } ?: viewModel.tunnelName.ifBlank { stringResource(R.string.tunnel_title) },
-                onSky = onSky,
-                isLoading = state.isLoading,
-                onRefresh = { viewModel.load() },
-                onBack = onBack,
-                titleSize = 22,
-                backDescription = stringResource(R.string.common_back),
-                refreshDescription = stringResource(R.string.common_refresh),
-            )
-            when {
-                state.missingScope ->
-                    SkyEmptyState(Icons.Outlined.Hub, stringResource(R.string.scope_missing), onSky, stringResource(R.string.common_refresh)) { viewModel.load() }
+        Box(Modifier.fillMaxSize().systemBarsPadding()) {
+            Column(Modifier.fillMaxSize()) {
+                SkyHeader(
+                    title = state.tunnel?.name?.ifBlank { viewModel.tunnelName } ?: viewModel.tunnelName.ifBlank { stringResource(R.string.tunnel_title) },
+                    onSky = onSky,
+                    isLoading = state.isLoading,
+                    onRefresh = { viewModel.load() },
+                    onBack = onBack,
+                    titleSize = 22,
+                    backDescription = stringResource(R.string.common_back),
+                    refreshDescription = stringResource(R.string.common_refresh),
+                )
+                when {
+                    state.missingScope ->
+                        SkyEmptyState(Icons.Outlined.Hub, stringResource(R.string.scope_missing), onSky, stringResource(R.string.common_refresh)) { viewModel.load() }
 
-                state.tunnel == null && state.isLoading ->
-                    Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator(color = onSky) }
+                    state.tunnel == null && state.isLoading ->
+                        Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator(color = onSky) }
 
-                state.tunnel == null ->
-                    SkyEmptyState(Icons.Outlined.Hub, stringResource(R.string.error_generic), onSky, stringResource(R.string.common_refresh)) { viewModel.load() }
+                    state.tunnel == null ->
+                        SkyEmptyState(Icons.Outlined.Hub, stringResource(R.string.error_generic), onSky, stringResource(R.string.common_refresh)) { viewModel.load() }
 
-                else -> {
-                    val tunnel = state.tunnel!!
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
-                            .padding(horizontal = 16.dp)
-                            .padding(bottom = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        // 信息段
-                        SectionCard(stringResource(R.string.tunnel_section_info)) {
-                            StatusRow(tunnel.status)
-                            tunnel.tunType?.let { InfoRow(stringResource(R.string.tunnel_field_type), it) }
-                            tunnel.remoteConfig?.let {
-                                InfoRow(
-                                    stringResource(R.string.tunnel_field_config),
-                                    stringResource(if (it) R.string.tunnel_config_remote else R.string.tunnel_config_local),
-                                )
+                    else -> {
+                        val tunnel = state.tunnel!!
+                        val isRemote = tunnel.remoteConfig == true
+                        Column(
+                            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())
+                                .padding(horizontal = 16.dp).padding(bottom = 24.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            SectionCard(stringResource(R.string.tunnel_section_info)) {
+                                StatusRow(tunnel.status)
+                                tunnel.tunType?.let { InfoRow(stringResource(R.string.tunnel_field_type), it) }
+                                tunnel.remoteConfig?.let {
+                                    InfoRow(
+                                        stringResource(R.string.tunnel_field_config),
+                                        stringResource(if (it) R.string.tunnel_config_remote else R.string.tunnel_config_local),
+                                    )
+                                }
+                                formatDate(tunnel.createdAt)?.let { InfoRow(stringResource(R.string.tunnel_field_created), it) }
+                                InfoRow(stringResource(R.string.tunnel_field_id), tunnel.id, mono = true)
                             }
-                            formatDate(tunnel.createdAt)?.let { InfoRow(stringResource(R.string.tunnel_field_created), it) }
-                            InfoRow(stringResource(R.string.tunnel_field_id), tunnel.id, mono = true)
-                        }
 
-                        // 活跃连接
-                        SectionCard(stringResource(R.string.tunnel_section_connections)) {
-                            val connections = tunnel.connections.orEmpty()
-                            if (connections.isEmpty()) {
-                                Text(
-                                    stringResource(R.string.tunnel_no_connections),
-                                    fontSize = 14.sp,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            if (state.canWrite) ConnectCard(state)
+
+                            if (isRemote) {
+                                PublicHostnamesCard(
+                                    state = state,
+                                    onAdd = { hostnameEdit = HostnameEdit.New },
+                                    onEdit = { index, rule -> hostnameEdit = HostnameEdit.Edit(index, rule) },
+                                    onDelete = { viewModel.deleteHostname(it) },
                                 )
                             } else {
-                                connections.forEachIndexed { index, conn ->
-                                    ConnectionRow(conn)
-                                    if (index < connections.lastIndex) {
-                                        Spacer(Modifier.size(10.dp))
+                                SectionCard(stringResource(R.string.tunnel_hostnames_section)) {
+                                    Text(stringResource(R.string.tunnel_local_note), fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                            }
+
+                            SectionCard(stringResource(R.string.tunnel_section_connections)) {
+                                val connections = tunnel.connections.orEmpty()
+                                if (connections.isEmpty()) {
+                                    Text(stringResource(R.string.tunnel_no_connections), fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                } else {
+                                    connections.forEachIndexed { index, conn ->
+                                        ConnectionRow(conn)
+                                        if (index < connections.lastIndex) Spacer(Modifier.size(10.dp))
                                     }
+                                }
+                            }
+
+                            if (state.canWrite) {
+                                SectionCard(stringResource(R.string.tunnel_danger_section)) {
+                                    DangerButton(stringResource(R.string.tunnel_cleanup)) { showCleanupConfirm = true }
+                                    DangerButton(stringResource(R.string.tunnel_delete)) { showDeleteConfirm = true }
                                 }
                             }
                         }
                     }
                 }
             }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    hostnameEdit?.let { edit ->
+        val initial = (edit as? HostnameEdit.Edit)?.rule
+        val index = (edit as? HostnameEdit.Edit)?.index
+        HostnameFormSheet(
+            initial = initial,
+            isSaving = state.isSaving,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onSubmit = { rule -> viewModel.saveHostname(rule, index); hostnameEdit = null },
+            onDismiss = { hostnameEdit = null },
+        )
+    }
+
+    if (showCleanupConfirm) {
+        ConfirmDialog(
+            title = stringResource(R.string.tunnel_cleanup_confirm_title),
+            message = stringResource(R.string.tunnel_cleanup_confirm_msg),
+            confirmLabel = stringResource(R.string.tunnel_cleanup),
+            onConfirm = { showCleanupConfirm = false; viewModel.cleanupConnections() },
+            onDismiss = { showCleanupConfirm = false },
+        )
+    }
+    if (showDeleteConfirm) {
+        ConfirmDialog(
+            title = stringResource(R.string.tunnel_delete_confirm_title),
+            message = stringResource(R.string.tunnel_delete_confirm_msg),
+            confirmLabel = stringResource(R.string.tunnel_delete),
+            onConfirm = { showDeleteConfirm = false; viewModel.deleteTunnel() },
+            onDismiss = { showDeleteConfirm = false },
+        )
+    }
+}
+
+private sealed interface HostnameEdit {
+    data object New : HostnameEdit
+    data class Edit(val index: Int, val rule: IngressRule) : HostnameEdit
+}
+
+// MARK: - 连接令牌
+
+@Composable
+private fun ConnectCard(state: TunnelDetailUiState) {
+    val context = LocalContext.current
+    var revealed by remember { mutableStateOf(false) }
+    var copied by remember { mutableStateOf(false) }
+    val token = state.token
+    val command = "cloudflared service install ${token ?: ""}"
+
+    SectionCard(stringResource(R.string.tunnel_connect_section)) {
+        Text(stringResource(R.string.tunnel_connect_intro), fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        when {
+            token != null -> {
+                Text(
+                    if (revealed) command else "cloudflared service install ${token.take(8)}…••••",
+                    fontSize = 12.sp,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = { revealed = !revealed }, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(if (revealed) R.string.tunnel_connect_hide else R.string.tunnel_connect_reveal))
+                    }
+                    Button(
+                        onClick = { copyToClipboard(context, command); copied = true },
+                        colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(stringResource(if (copied) R.string.tunnel_connect_copied else R.string.tunnel_connect_copy))
+                    }
+                }
+                Text(stringResource(R.string.tunnel_connect_token_warn), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            state.isLoadingToken -> Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = OcOrange)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.tunnel_connect_loading), fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            else -> Text(stringResource(R.string.tunnel_connect_failed), fontSize = 13.sp, color = Color(0xFFE5484D))
         }
     }
 }
+
+// MARK: - 公共主机名
+
+@Composable
+private fun PublicHostnamesCard(
+    state: TunnelDetailUiState,
+    onAdd: () -> Unit,
+    onEdit: (Int, IngressRule) -> Unit,
+    onDelete: (Int) -> Unit,
+) {
+    SectionCard(stringResource(R.string.tunnel_hostnames_section)) {
+        when {
+            state.isLoadingConfig && !state.configLoaded -> Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = OcOrange)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.tunnel_hostnames_loading), fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            state.publicHostnames.isEmpty() -> Text(
+                stringResource(if (state.canWrite) R.string.tunnel_hostnames_empty else R.string.tunnel_hostnames_empty_ro),
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            else -> state.publicHostnames.forEachIndexed { index, rule ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().let { if (state.canWrite) it.clickable { onEdit(index, rule) } else it },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(rule.hostname ?: "—", fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+                        Text("→ ${rule.service}", fontSize = 12.sp, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                        rule.path?.takeIf { it.isNotEmpty() }?.let {
+                            Text(it, fontSize = 11.sp, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                    if (state.canWrite) {
+                        IconButton(onClick = { onDelete(index) }) {
+                            Icon(Icons.Outlined.Delete, contentDescription = stringResource(R.string.dns_delete), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                }
+            }
+        }
+        if (state.canWrite) {
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable(onClick = onAdd).padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.Outlined.Add, contentDescription = null, tint = OcOrange, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.tunnel_hostnames_add), color = OcOrange, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+            }
+            Text(stringResource(R.string.tunnel_hostnames_footer), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HostnameFormSheet(
+    initial: IngressRule?,
+    isSaving: Boolean,
+    sheetState: androidx.compose.material3.SheetState,
+    onSubmit: (IngressRule) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var hostname by remember { mutableStateOf(initial?.hostname ?: "") }
+    var kind by remember { mutableStateOf(initial?.serviceKind ?: IngressServiceKind.HTTP) }
+    var target by remember { mutableStateOf(if (initial?.serviceKind == IngressServiceKind.OTHER) "" else initial?.serviceTarget ?: "localhost:8000") }
+    var rawService by remember { mutableStateOf(if (initial?.serviceKind == IngressServiceKind.OTHER) initial.service else "") }
+    var path by remember { mutableStateOf(initial?.path ?: "") }
+    var protoExpanded by remember { mutableStateOf(false) }
+
+    val isOther = kind == IngressServiceKind.OTHER
+    val canSave = hostname.trim().isNotEmpty() &&
+        (if (isOther) rawService.trim().isNotEmpty() else target.trim().isNotEmpty()) && !isSaving
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().navigationBarsPadding().imePadding().padding(horizontal = 24.dp).padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(
+                stringResource(if (initial == null) R.string.tunnel_host_form_add else R.string.tunnel_host_form_edit),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            OutlinedTextField(
+                value = hostname,
+                onValueChange = { hostname = it },
+                label = { Text(stringResource(R.string.tunnel_host_hostname)) },
+                placeholder = { Text("app.example.com") },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            ExposedDropdownMenuBox(expanded = protoExpanded, onExpandedChange = { protoExpanded = !protoExpanded }) {
+                OutlinedTextField(
+                    value = protoLabel(kind),
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.tunnel_host_protocol)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = protoExpanded) },
+                    modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                )
+                ExposedDropdownMenu(expanded = protoExpanded, onDismissRequest = { protoExpanded = false }) {
+                    IngressServiceKind.entries.forEach { option ->
+                        DropdownMenuItem(text = { Text(protoLabel(option)) }, onClick = { kind = option; protoExpanded = false })
+                    }
+                }
+            }
+            if (isOther) {
+                OutlinedTextField(
+                    value = rawService,
+                    onValueChange = { rawService = it },
+                    label = { Text(stringResource(R.string.tunnel_host_service)) },
+                    placeholder = { Text(stringResource(R.string.tunnel_host_service_other)) },
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                OutlinedTextField(
+                    value = target,
+                    onValueChange = { target = it },
+                    label = { Text(stringResource(R.string.tunnel_host_service)) },
+                    placeholder = { Text(kind.targetPlaceholder) },
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Text(stringResource(R.string.tunnel_host_service_footer), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            OutlinedTextField(
+                value = path,
+                onValueChange = { path = it },
+                label = { Text(stringResource(R.string.tunnel_host_path)) },
+                placeholder = { Text(stringResource(R.string.tunnel_host_path_hint)) },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Button(
+                onClick = {
+                    val service = if (isOther) rawService.trim() else kind.scheme + target.trim()
+                    onSubmit(
+                        IngressRule(
+                            hostname = hostname.trim(),
+                            service = service,
+                            path = path.trim().ifEmpty { null },
+                            originRequest = initial?.originRequest,
+                        ),
+                    )
+                },
+                enabled = canSave,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.dns_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun protoLabel(kind: IngressServiceKind): String =
+    if (kind == IngressServiceKind.OTHER) stringResource(R.string.tunnel_proto_other) else kind.label
+
+@Composable
+private fun ConfirmDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = { TextButton(onClick = onConfirm) { Text(confirmLabel, color = Color(0xFFE5484D)) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.common_cancel)) } },
+    )
+}
+
+@Composable
+private fun DangerButton(label: String, onClick: () -> Unit) {
+    OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+        Icon(Icons.Outlined.Delete, contentDescription = null, tint = Color(0xFFE5484D), modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(label, color = Color(0xFFE5484D))
+    }
+}
+
+// MARK: - 复用小组件
 
 @Composable
 private fun SectionCard(title: String, content: @Composable () -> Unit) {
@@ -147,9 +487,7 @@ private fun SectionCard(title: String, content: @Composable () -> Unit) {
             shape = RoundedCornerShape(16.dp),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                content()
-            }
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) { content() }
         }
     }
 }
@@ -161,12 +499,7 @@ private fun StatusRow(status: String?) {
         Spacer(Modifier.weight(1f))
         Box(Modifier.size(8.dp).clip(CircleShape).background(tunnelStatusColor(status)))
         Spacer(Modifier.width(6.dp))
-        Text(
-            stringResource(tunnelStatusLabel(status)),
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        Text(stringResource(tunnelStatusLabel(status)), fontSize = 14.sp, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
     }
 }
 
@@ -189,12 +522,7 @@ private fun InfoRow(label: String, value: String, mono: Boolean = false) {
 @Composable
 private fun ConnectionRow(conn: TunnelConnection) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            Icons.Outlined.SettingsEthernet,
-            contentDescription = null,
-            tint = Color(0xFF2FBF71),
-            modifier = Modifier.size(22.dp),
-        )
+        Icon(Icons.Outlined.SettingsEthernet, contentDescription = null, tint = Color(0xFF2FBF71), modifier = Modifier.size(22.dp))
         Spacer(Modifier.width(12.dp))
         Column(Modifier.weight(1f)) {
             Text(

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelDetailViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelDetailViewModel.kt
@@ -6,12 +6,21 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jiamin.chen.orangecloud.core.auth.AuthRepository
 import jiamin.chen.orangecloud.core.auth.Scopes
+import jiamin.chen.orangecloud.data.model.CreateDnsRecord
+import jiamin.chen.orangecloud.data.model.IngressRule
 import jiamin.chen.orangecloud.data.model.Tunnel
+import jiamin.chen.orangecloud.data.model.TunnelConfig
+import jiamin.chen.orangecloud.data.model.Zone
 import jiamin.chen.orangecloud.data.repository.AccountStore
+import jiamin.chen.orangecloud.data.repository.DnsRepository
 import jiamin.chen.orangecloud.data.repository.SecurityRepository
+import jiamin.chen.orangecloud.data.repository.ZoneRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,25 +30,56 @@ data class TunnelDetailUiState(
     val isLoading: Boolean = false,
     val hasError: Boolean = false,
     val missingScope: Boolean = false,
-)
+    // 连接令牌
+    val token: String? = null,
+    val isLoadingToken: Boolean = false,
+    // 配置（公共主机名 / ingress）
+    val config: TunnelConfig? = null,
+    val isLoadingConfig: Boolean = false,
+    val configLoaded: Boolean = false,
+    val isSaving: Boolean = false,
+    val canWrite: Boolean = false,
+    val error: String? = null,
+) {
+    /** 非 catch-all 的公共主机名规则（供 UI 列表）。 */
+    val publicHostnames: List<IngressRule>
+        get() = (config?.ingress ?: emptyList()).filter { !it.isCatchAll }
+}
 
-/** 单条隧道详情：信息 + 内嵌活跃连接（对齐 iOS TunnelDetailView）。 */
+sealed interface TunnelDetailEvent {
+    data object Deleted : TunnelDetailEvent
+    data class Notice(val message: String) : TunnelDetailEvent
+    data class Error(val message: String?) : TunnelDetailEvent
+}
+
+/** 单条隧道详情：信息 + 连接令牌 + 公共主机名管理 + 危险操作（对齐 iOS TunnelDetailView）。 */
 @HiltViewModel
 class TunnelDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val accountStore: AccountStore,
     private val securityRepository: SecurityRepository,
+    private val dnsRepository: DnsRepository,
+    private val zoneRepository: ZoneRepository,
     authRepository: AuthRepository,
 ) : ViewModel() {
 
     val tunnelId: String = checkNotNull(savedStateHandle["tunnelId"])
     val tunnelName: String = savedStateHandle.get<String>("tunnelName").orEmpty()
     private val hasScope = authRepository.hasScope(Scopes.TUNNEL_READ)
+    private val canWrite = authRepository.hasScope(Scopes.TUNNEL_WRITE)
+    private val canWriteDNS = authRepository.hasScope(Scopes.DNS_WRITE)
+    private var zonesCache: List<Zone>? = null
 
     private val _uiState = MutableStateFlow(
-        TunnelDetailUiState(isLoading = hasScope, missingScope = !hasScope),
+        TunnelDetailUiState(isLoading = hasScope, missingScope = !hasScope, canWrite = canWrite),
     )
     val uiState: StateFlow<TunnelDetailUiState> = _uiState.asStateFlow()
+
+    private val eventChannel = Channel<TunnelDetailEvent>(Channel.BUFFERED)
+    val events: Flow<TunnelDetailEvent> = eventChannel.receiveAsFlow()
+
+    /** CNAME 目标：<隧道ID>.cfargotunnel.com */
+    val cnameTarget: String get() = "$tunnelId.cfargotunnel.com"
 
     init {
         if (hasScope) load()
@@ -54,6 +94,7 @@ class TunnelDetailViewModel @Inject constructor(
                 val accountId = accountStore.selectedAccountId.value ?: error("no account")
                 val tunnel = securityRepository.getTunnel(accountId, tunnelId)
                 _uiState.update { it.copy(tunnel = tunnel) }
+                if (tunnel.remoteConfig == true) loadConfiguration(accountId)
             } catch (e: Exception) {
                 _uiState.update { it.copy(hasError = true) }
             } finally {
@@ -61,4 +102,153 @@ class TunnelDetailViewModel @Inject constructor(
             }
         }
     }
+
+    /** 连接令牌（argotunnel.write 才可读）。按需加载一次。 */
+    fun loadToken() {
+        if (!canWrite || _uiState.value.token != null || _uiState.value.isLoadingToken) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingToken = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val token = securityRepository.tunnelToken(accountId, tunnelId)
+                _uiState.update { it.copy(token = token) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isLoadingToken = false) }
+            }
+        }
+    }
+
+    private suspend fun loadConfiguration(accountId: String) {
+        _uiState.update { it.copy(isLoadingConfig = true) }
+        try {
+            val config = securityRepository.configuration(accountId, tunnelId)
+            _uiState.update { it.copy(config = config, configLoaded = true) }
+        } catch (e: Exception) {
+            _uiState.update { it.copy(error = e.message) }
+        } finally {
+            _uiState.update { it.copy(isLoadingConfig = false) }
+        }
+    }
+
+    /** 清理失活连接（活跃的 cloudflared 会自动重连）。 */
+    fun cleanupConnections() {
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                securityRepository.deleteConnections(accountId, tunnelId)
+                load()
+            } catch (e: Exception) {
+                eventChannel.send(TunnelDetailEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    /** 删除隧道：成功后发出 Deleted（界面退出）。 */
+    fun deleteTunnel() {
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                securityRepository.deleteTunnel(accountId, tunnelId)
+                eventChannel.send(TunnelDetailEvent.Deleted)
+            } catch (e: Exception) {
+                eventChannel.send(TunnelDetailEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    /** 新增或更新一条公共主机名。index 为 null 时新增（并尝试自动建 CNAME）。 */
+    fun saveHostname(rule: IngressRule, index: Int?) {
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+            try {
+                val rules = _uiState.value.publicHostnames.toMutableList()
+                if (index != null && index in rules.indices) rules[index] = rule else rules.add(rule)
+                if (saveIngress(rules)) {
+                    if (index == null && !rule.hostname.isNullOrEmpty()) ensureCname(rule.hostname)
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun deleteHostname(index: Int) {
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                val rules = _uiState.value.publicHostnames.toMutableList()
+                if (index in rules.indices) {
+                    rules.removeAt(index)
+                    saveIngress(rules) // 不自动删 DNS，避免误删用户其它记录
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    /** 拼装整份 ingress（编辑后的规则 + 原 catch-all）并回写。 */
+    private suspend fun saveIngress(rules: List<IngressRule>): Boolean {
+        val accountId = accountStore.selectedAccountId.value ?: return false
+        val current = _uiState.value.config
+        val catchAll = current?.ingress?.firstOrNull { it.isCatchAll } ?: IngressRule.catchAll
+        val newConfig = (current ?: TunnelConfig()).copy(ingress = rules + catchAll)
+        return try {
+            val saved = securityRepository.updateConfiguration(accountId, tunnelId, newConfig)
+            _uiState.update { it.copy(config = saved) }
+            true
+        } catch (e: Exception) {
+            _uiState.update { it.copy(error = e.message) }
+            false
+        }
+    }
+
+    /** 为公共主机名自动建代理 CNAME；无 dns.write 或找不到域名时给出手动提示。 */
+    private suspend fun ensureCname(hostname: String) {
+        if (!canWriteDNS) {
+            eventChannel.send(TunnelDetailEvent.Notice(manualCnameMessage(hostname)))
+            return
+        }
+        try {
+            val zone = bestZone(hostname, zones()) ?: run {
+                eventChannel.send(TunnelDetailEvent.Notice(manualCnameMessage(hostname)))
+                return
+            }
+            dnsRepository.createRecord(
+                zone.id,
+                CreateDnsRecord(type = "CNAME", name = hostname, content = cnameTarget, proxied = true, ttl = 1, comment = "Cloudflare Tunnel"),
+            )
+            eventChannel.send(TunnelDetailEvent.Notice("$hostname → $cnameTarget"))
+        } catch (e: Exception) {
+            eventChannel.send(TunnelDetailEvent.Notice(manualCnameMessage(hostname)))
+        }
+    }
+
+    private fun manualCnameMessage(hostname: String): String = "$hostname CNAME → $cnameTarget"
+
+    private suspend fun zones(): List<Zone> {
+        zonesCache?.let { return it }
+        val accountId = accountStore.selectedAccountId.value ?: return emptyList()
+        return zoneRepository.listZones(accountId).also { zonesCache = it }
+    }
+
+    /** hostname 所属 zone：取名字最长的后缀匹配项（处理多级子域名/多 zone）。 */
+    private fun bestZone(hostname: String, zones: List<Zone>): Zone? =
+        zones.filter { hostname == it.name || hostname.endsWith("." + it.name) }.maxByOrNull { it.name.length }
 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelListScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelListScreen.kt
@@ -1,13 +1,17 @@
 package jiamin.chen.orangecloud.ui.network
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -16,18 +20,36 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Hub
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -39,9 +61,11 @@ import jiamin.chen.orangecloud.core.design.SkyBackground
 import jiamin.chen.orangecloud.core.design.SkyHeader
 import jiamin.chen.orangecloud.core.design.onSky
 import jiamin.chen.orangecloud.core.design.rememberSkyPhase
+import jiamin.chen.orangecloud.core.design.theme.OcOrange
 import jiamin.chen.orangecloud.data.model.Tunnel
 import jiamin.chen.orangecloud.ui.storage.StorageListBody
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TunnelListScreen(
     onBack: () -> Unit,
@@ -49,34 +73,93 @@ fun TunnelListScreen(
     viewModel: TunnelListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val isSaving by viewModel.isSaving.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showCreate by remember { mutableStateOf(false) }
+    var toDelete by remember { mutableStateOf<Tunnel?>(null) }
+    val deletedMsg = stringResource(R.string.dns_deleted)
+    val errMsg = stringResource(R.string.error_generic)
 
-    SkyBackground(phase = phase) {
-        Column(Modifier.fillMaxSize().systemBarsPadding()) {
-            SkyHeader(
-                title = stringResource(R.string.tunnel_title),
-                onSky = onSky,
-                isLoading = state.isLoading,
-                onRefresh = { viewModel.load() },
-                onBack = onBack,
-                titleSize = 22,
-                backDescription = stringResource(R.string.common_back),
-                refreshDescription = stringResource(R.string.common_refresh),
-            )
-            StorageListBody(state, onSky, Icons.Outlined.Hub, stringResource(R.string.tunnel_empty), { viewModel.load() }) { tunnel ->
-                TunnelRow(tunnel, onClick = { onOpenTunnel(tunnel.id, tunnel.name) })
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is TunnelListEvent.Created -> { showCreate = false; onOpenTunnel(event.tunnel.id, event.tunnel.name) }
+                TunnelListEvent.Deleted -> { toDelete = null; snackbarHostState.showSnackbar(deletedMsg) }
+                is TunnelListEvent.Error -> snackbarHostState.showSnackbar(event.message ?: errMsg)
             }
         }
     }
+
+    SkyBackground(phase = phase) {
+        Box(Modifier.fillMaxSize().systemBarsPadding()) {
+            Column(Modifier.fillMaxSize()) {
+                SkyHeader(
+                    title = stringResource(R.string.tunnel_title),
+                    onSky = onSky,
+                    isLoading = state.isLoading,
+                    onRefresh = { viewModel.load() },
+                    onBack = onBack,
+                    titleSize = 22,
+                    backDescription = stringResource(R.string.common_back),
+                    refreshDescription = stringResource(R.string.common_refresh),
+                )
+                StorageListBody(state, onSky, Icons.Outlined.Hub, stringResource(R.string.tunnel_empty), { viewModel.load() }) { tunnel ->
+                    TunnelRow(
+                        tunnel = tunnel,
+                        onClick = { onOpenTunnel(tunnel.id, tunnel.name) },
+                        onLongClick = if (viewModel.canWrite) ({ toDelete = tunnel }) else null,
+                    )
+                }
+            }
+            if (viewModel.canWrite) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    containerColor = OcOrange,
+                    contentColor = Color.White,
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = stringResource(R.string.tunnel_new))
+                }
+            }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    if (showCreate) {
+        TunnelCreateSheet(
+            isSaving = isSaving,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onCreate = { viewModel.createTunnel(it) },
+            onDismiss = { showCreate = false },
+        )
+    }
+    toDelete?.let { tunnel ->
+        AlertDialog(
+            onDismissRequest = { toDelete = null },
+            title = { Text(stringResource(R.string.tunnel_delete_confirm_title)) },
+            text = { Text(stringResource(R.string.tunnel_delete_confirm_msg)) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteTunnel(tunnel) }) {
+                    Text(stringResource(R.string.tunnel_delete), color = Color(0xFFE5484D))
+                }
+            },
+            dismissButton = { TextButton(onClick = { toDelete = null }) { Text(stringResource(R.string.common_cancel)) } },
+        )
+    }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun TunnelRow(tunnel: Tunnel, onClick: () -> Unit) {
+private fun TunnelRow(tunnel: Tunnel, onClick: () -> Unit, onLongClick: (() -> Unit)? = null) {
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         shape = RoundedCornerShape(16.dp),
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().let {
+            if (onLongClick != null) it.combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            else it.combinedClickable(onClick = onClick)
+        },
     ) {
         Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
             Box(Modifier.size(10.dp).clip(CircleShape).background(tunnelStatusColor(tunnel.status)))
@@ -101,6 +184,48 @@ private fun TunnelRow(tunnel: Tunnel, onClick: () -> Unit) {
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TunnelCreateSheet(
+    isSaving: Boolean,
+    sheetState: androidx.compose.material3.SheetState,
+    onCreate: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    val canSave = name.trim().isNotEmpty() && !isSaving
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().navigationBarsPadding().imePadding().padding(horizontal = 24.dp).padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(stringResource(R.string.tunnel_new), fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text(stringResource(R.string.tunnel_new_name)) },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(stringResource(R.string.tunnel_new_footer), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Button(
+                onClick = { onCreate(name.trim()) },
+                enabled = canSave,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.tunnel_create))
+            }
         }
     }
 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelListViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/network/TunnelListViewModel.kt
@@ -1,5 +1,6 @@
 package jiamin.chen.orangecloud.ui.network
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jiamin.chen.orangecloud.core.auth.AuthRepository
 import jiamin.chen.orangecloud.core.auth.Scopes
@@ -7,14 +8,71 @@ import jiamin.chen.orangecloud.data.model.Tunnel
 import jiamin.chen.orangecloud.data.repository.AccountStore
 import jiamin.chen.orangecloud.data.repository.SecurityRepository
 import jiamin.chen.orangecloud.ui.storage.StorageListViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+sealed interface TunnelListEvent {
+    data class Created(val tunnel: Tunnel) : TunnelListEvent
+    data object Deleted : TunnelListEvent
+    data class Error(val message: String?) : TunnelListEvent
+}
 
 @HiltViewModel
 class TunnelListViewModel @Inject constructor(
-    accountStore: AccountStore,
+    private val accountStore: AccountStore,
     private val securityRepository: SecurityRepository,
     authRepository: AuthRepository,
 ) : StorageListViewModel<Tunnel>(accountStore, authRepository.hasScope(Scopes.TUNNEL_READ)) {
+
+    /** argotunnel.write 才可新建 / 删除隧道。 */
+    val canWrite: Boolean = authRepository.hasScope(Scopes.TUNNEL_WRITE)
+
+    private val _isSaving = MutableStateFlow(false)
+    val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
+
+    private val eventChannel = Channel<TunnelListEvent>(Channel.BUFFERED)
+    val events: Flow<TunnelListEvent> = eventChannel.receiveAsFlow()
+
     override suspend fun fetch(accountId: String) = securityRepository.listTunnels(accountId)
     init { load() }
+
+    /** 新建远程托管隧道，成功后插到列表顶端并发出 Created（供随后展示连接令牌）。 */
+    fun createTunnel(name: String) {
+        if (!canWrite || _isSaving.value) return
+        viewModelScope.launch {
+            _isSaving.value = true
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val tunnel = securityRepository.createTunnel(accountId, name)
+                state.update { it.copy(items = listOf(tunnel) + it.items) }
+                eventChannel.send(TunnelListEvent.Created(tunnel))
+            } catch (e: Exception) {
+                eventChannel.send(TunnelListEvent.Error(e.message))
+            } finally {
+                _isSaving.value = false
+            }
+        }
+    }
+
+    /** 删除隧道（先清理连接）。 */
+    fun deleteTunnel(tunnel: Tunnel) {
+        if (!canWrite) return
+        viewModelScope.launch {
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                securityRepository.deleteTunnel(accountId, tunnel.id)
+                state.update { it.copy(items = it.items.filterNot { t -> t.id == tunnel.id }) }
+                eventChannel.send(TunnelListEvent.Deleted)
+            } catch (e: Exception) {
+                eventChannel.send(TunnelListEvent.Error(e.message))
+            }
+        }
+    }
 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/root/OrangeCloudRoot.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/root/OrangeCloudRoot.kt
@@ -68,7 +68,10 @@ import jiamin.chen.orangecloud.ui.storage.R2ObjectListScreen
 import jiamin.chen.orangecloud.ui.storage.StorageHubScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerDetailScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerListScreen
+import jiamin.chen.orangecloud.ui.workers.WorkerRoutesScreen
+import jiamin.chen.orangecloud.ui.workers.WorkerSecretsScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerTailScreen
+import jiamin.chen.orangecloud.ui.workers.WorkerTriggersScreen
 import jiamin.chen.orangecloud.ui.zones.ZoneDetailScreen
 import jiamin.chen.orangecloud.ui.zones.ZonesPaneScreen
 import java.time.LocalTime
@@ -119,6 +122,9 @@ private object Dest {
     const val SNIPPET_EDIT_ROUTE = "snippetEdit/{zoneId}?zoneName={zoneName}&name={name}"
     const val ZONE_SETTINGS_ROUTE = "zonesettings/{zoneId}?zoneName={zoneName}"
     const val WORKER_ROUTE = "worker/{scriptName}"
+    const val WORKER_SECRETS_ROUTE = "worker/{scriptName}/secrets"
+    const val WORKER_TRIGGERS_ROUTE = "worker/{scriptName}/triggers"
+    const val WORKER_DOMAINS_ROUTE = "worker/{scriptName}/domains"
     const val TAIL_ROUTE = "tail/{scriptName}"
     private fun zoneScoped(prefix: String, zoneId: String, zoneName: String) =
         "$prefix/$zoneId?zoneName=${Uri.encode(zoneName)}"
@@ -133,6 +139,9 @@ private object Dest {
     fun identity(sessionId: String): String = "identity/${Uri.encode(sessionId)}"
     fun tunnelDetail(id: String, name: String): String = "tunnel/$id?tunnelName=${Uri.encode(name)}"
     fun worker(scriptName: String): String = "worker/${Uri.encode(scriptName)}"
+    fun workerSecrets(scriptName: String): String = "worker/${Uri.encode(scriptName)}/secrets"
+    fun workerTriggers(scriptName: String): String = "worker/${Uri.encode(scriptName)}/triggers"
+    fun workerDomains(scriptName: String): String = "worker/${Uri.encode(scriptName)}/domains"
     fun tail(scriptName: String): String = "tail/${Uri.encode(scriptName)}"
     fun r2Objects(bucket: String): String = "r2/objects/${Uri.encode(bucket)}"
     fun d1Query(dbId: String, dbName: String): String = "d1/query/$dbId?dbName=${Uri.encode(dbName)}"
@@ -284,11 +293,13 @@ private fun MainScaffold() {
             ) { entry ->
                 val zoneId = entry.arguments?.getString("zoneId").orEmpty()
                 val zoneName = entry.arguments?.getString("zoneName").orEmpty()
-                SnippetsListScreen(
-                    onBack = { navController.popBackStack() },
-                    onOpenSnippet = { name -> navController.navigate(Dest.snippetEdit(zoneId, zoneName, name)) },
-                    onCreate = { navController.navigate(Dest.snippetEdit(zoneId, zoneName, "")) },
-                )
+                ProGate {
+                    SnippetsListScreen(
+                        onBack = { navController.popBackStack() },
+                        onOpenSnippet = { name -> navController.navigate(Dest.snippetEdit(zoneId, zoneName, name)) },
+                        onCreate = { navController.navigate(Dest.snippetEdit(zoneId, zoneName, "")) },
+                    )
+                }
             }
             composable(
                 route = Dest.SNIPPET_EDIT_ROUTE,
@@ -298,10 +309,12 @@ private fun MainScaffold() {
                     navArgument("name") { type = NavType.StringType; defaultValue = "" },
                 ),
             ) {
-                SnippetEditorScreen(
-                    onBack = { navController.popBackStack() },
-                    onClosed = { navController.popBackStack() },
-                )
+                ProGate {
+                    SnippetEditorScreen(
+                        onBack = { navController.popBackStack() },
+                        onClosed = { navController.popBackStack() },
+                    )
+                }
             }
             composable(
                 route = Dest.ZONE_SETTINGS_ROUTE,
@@ -346,7 +359,28 @@ private fun MainScaffold() {
                 WorkerDetailScreen(
                     onBack = { navController.popBackStack() },
                     onOpenTail = { navController.navigate(Dest.tail(scriptName)) },
+                    onOpenSecrets = { navController.navigate(Dest.workerSecrets(scriptName)) },
+                    onOpenTriggers = { navController.navigate(Dest.workerTriggers(scriptName)) },
+                    onOpenDomains = { navController.navigate(Dest.workerDomains(scriptName)) },
                 )
+            }
+            composable(
+                route = Dest.WORKER_SECRETS_ROUTE,
+                arguments = listOf(navArgument("scriptName") { type = NavType.StringType }),
+            ) {
+                ProGate { WorkerSecretsScreen(onBack = { navController.popBackStack() }) }
+            }
+            composable(
+                route = Dest.WORKER_TRIGGERS_ROUTE,
+                arguments = listOf(navArgument("scriptName") { type = NavType.StringType }),
+            ) {
+                ProGate { WorkerTriggersScreen(onBack = { navController.popBackStack() }) }
+            }
+            composable(
+                route = Dest.WORKER_DOMAINS_ROUTE,
+                arguments = listOf(navArgument("scriptName") { type = NavType.StringType }),
+            ) {
+                ProGate { WorkerRoutesScreen(onBack = { navController.popBackStack() }) }
             }
             composable(
                 route = Dest.TAIL_ROUTE,

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/settings/SettingsScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -28,6 +29,7 @@ import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.MonitorHeart
 import androidx.compose.material.icons.outlined.Notifications
@@ -96,6 +98,27 @@ fun SettingsScreen(
         }
     }
     fun openUrl(url: String) = context.launchCustomTab(Uri.parse(url))
+
+    // 帮助与反馈：邮件 intent，正文预填诊断头（版本/系统/设备/账号数），不含任何令牌或密钥。
+    val feedbackSubject = stringResource(R.string.feedback_subject)
+    val noMailMsg = stringResource(R.string.feedback_no_mail)
+    fun sendFeedback() {
+        val diag = buildString {
+            append("\n\n---\n")
+            append("App ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})\n")
+            append("Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})\n")
+            append("${Build.MANUFACTURER} ${Build.MODEL}\n")
+            append("Accounts: ${state.sessions.size}")
+        }
+        val intent = Intent(Intent.ACTION_SENDTO).apply {
+            data = Uri.parse("mailto:")
+            putExtra(Intent.EXTRA_EMAIL, arrayOf("orange-cloud@hz.do"))
+            putExtra(Intent.EXTRA_SUBJECT, feedbackSubject)
+            putExtra(Intent.EXTRA_TEXT, diag)
+        }
+        runCatching { context.startActivity(intent) }
+            .onFailure { Toast.makeText(context, noMailMsg, Toast.LENGTH_SHORT).show() }
+    }
 
     SkyBackground(phase = phase) {
         Column(
@@ -196,6 +219,11 @@ fun SettingsScreen(
             // ── 服务状态 ──
             SettingsSection(stringResource(R.string.settings_service), stringResource(R.string.settings_service_footer)) {
                 NavRow(Icons.Outlined.MonitorHeart, OcSuccess, stringResource(R.string.status_title), onOpenStatus)
+            }
+
+            // ── 帮助与反馈 ──
+            SettingsSection(stringResource(R.string.settings_help), stringResource(R.string.settings_help_footer)) {
+                NavRow(Icons.Outlined.Email, Color(0xFF3D86E0), stringResource(R.string.settings_feedback)) { sendFeedback() }
             }
 
             // ── 关于 ──

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/D1ManageUi.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/D1ManageUi.kt
@@ -1,0 +1,166 @@
+package jiamin.chen.orangecloud.ui.storage
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jiamin.chen.orangecloud.R
+import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.data.model.D1Database
+
+/** D1 主副本放置提示（primary_location_hint）。AUTOMATIC 不传 hint，由 Cloudflare 就近分配。 */
+private enum class D1Loc(val hint: String?, val labelRes: Int) {
+    AUTOMATIC(null, R.string.d1_loc_auto),
+    WNAM("wnam", R.string.d1_loc_wnam),
+    ENAM("enam", R.string.d1_loc_enam),
+    WEUR("weur", R.string.d1_loc_weur),
+    EEUR("eeur", R.string.d1_loc_eeur),
+    APAC("apac", R.string.d1_loc_apac),
+    OC("oc", R.string.d1_loc_oc),
+}
+
+/** 创建数据库底部表单：名称 + 可选主要位置。 */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun D1CreateSheet(
+    isCreating: Boolean,
+    sheetState: SheetState,
+    onCreate: (name: String, locationHint: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var location by remember { mutableStateOf(D1Loc.AUTOMATIC) }
+    var expanded by remember { mutableStateOf(false) }
+    val canCreate = name.trim().isNotEmpty() && !isCreating
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .imePadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(stringResource(R.string.d1_create_title), fontSize = 20.sp, fontWeight = FontWeight.Bold)
+
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text(stringResource(R.string.d1_name)) },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+                OutlinedTextField(
+                    value = stringResource(location.labelRes),
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.d1_location)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    D1Loc.entries.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(stringResource(option.labelRes)) },
+                            onClick = { location = option; expanded = false },
+                        )
+                    }
+                }
+            }
+            Text(
+                stringResource(R.string.d1_location_hint),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Button(
+                onClick = { onCreate(name.trim(), location.hint) },
+                enabled = canCreate,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isCreating) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.d1_create))
+            }
+        }
+    }
+}
+
+/** 删除数据库二次确认：必须原样输入库名才启用删除（对齐 iOS / Dashboard）。 */
+@Composable
+fun D1DeleteDialog(
+    database: D1Database,
+    isDeleting: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var typed by remember { mutableStateOf("") }
+    val matches = typed.trim() == database.name
+
+    AlertDialog(
+        onDismissRequest = { if (!isDeleting) onDismiss() },
+        title = { Text(stringResource(R.string.d1_delete_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(stringResource(R.string.d1_delete_warn, database.name), fontSize = 14.sp)
+                OutlinedTextField(
+                    value = typed,
+                    onValueChange = { typed = it },
+                    label = { Text(stringResource(R.string.d1_delete_confirm_label)) },
+                    placeholder = { Text(database.name) },
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = matches && !isDeleting) {
+                Text(stringResource(R.string.d1_delete_button), color = if (matches && !isDeleting) Color(0xFFE5484D) else MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isDeleting) { Text(stringResource(R.string.common_cancel)) }
+        },
+    )
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/D1Screens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/D1Screens.kt
@@ -2,6 +2,7 @@ package jiamin.chen.orangecloud.ui.storage
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,21 +15,30 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.outlined.TableRows
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -44,8 +54,10 @@ import jiamin.chen.orangecloud.core.design.SkyHeader
 import jiamin.chen.orangecloud.core.design.onSky
 import jiamin.chen.orangecloud.core.design.rememberSkyPhase
 import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.data.model.D1Database
 import jiamin.chen.orangecloud.data.model.tailDisplayText
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun D1DatabaseListScreen(
     onBack: () -> Unit,
@@ -53,34 +65,83 @@ fun D1DatabaseListScreen(
     viewModel: D1DatabaseListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val opState by viewModel.opState.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showCreate by remember { mutableStateOf(false) }
+    var toDelete by remember { mutableStateOf<D1Database?>(null) }
+    val createSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val createdMsg = stringResource(R.string.d1_created)
+    val deletedMsg = stringResource(R.string.dns_deleted)
+    val errMsg = stringResource(R.string.error_generic)
 
-    SkyBackground(phase = phase) {
-        Column(Modifier.fillMaxSize().systemBarsPadding()) {
-            SkyHeader(
-                title = stringResource(R.string.storage_d1),
-                onSky = onSky,
-                isLoading = state.isLoading,
-                onRefresh = { viewModel.load() },
-                onBack = onBack,
-                titleSize = 22,
-                backDescription = stringResource(R.string.common_back),
-                refreshDescription = stringResource(R.string.common_refresh),
-            )
-            StorageListBody(state, onSky, Icons.Outlined.Storage, stringResource(R.string.d1_empty), { viewModel.load() }) { db ->
-                val subtitle = listOfNotNull(
-                    db.fileSize?.let { formatBytes(it) },
-                    db.numTables?.let { stringResource(R.string.d1_tables, it) },
-                ).joinToString(" · ").ifEmpty { null }
-                StorageRow(
-                    Icons.Outlined.Storage,
-                    db.name,
-                    subtitle,
-                    onClick = { onOpenDatabase(db.uuid, db.name) },
-                )
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                D1DbEvent.Created -> { showCreate = false; snackbarHostState.showSnackbar(createdMsg) }
+                D1DbEvent.Deleted -> { toDelete = null; snackbarHostState.showSnackbar(deletedMsg) }
+                is D1DbEvent.Error -> snackbarHostState.showSnackbar(event.message ?: errMsg)
             }
         }
+    }
+
+    SkyBackground(phase = phase) {
+        Box(Modifier.fillMaxSize().systemBarsPadding()) {
+            Column(Modifier.fillMaxSize()) {
+                SkyHeader(
+                    title = stringResource(R.string.storage_d1),
+                    onSky = onSky,
+                    isLoading = state.isLoading,
+                    onRefresh = { viewModel.load() },
+                    onBack = onBack,
+                    titleSize = 22,
+                    backDescription = stringResource(R.string.common_back),
+                    refreshDescription = stringResource(R.string.common_refresh),
+                )
+                StorageListBody(state, onSky, Icons.Outlined.Storage, stringResource(R.string.d1_empty), { viewModel.load() }) { db ->
+                    val subtitle = listOfNotNull(
+                        db.fileSize?.let { formatBytes(it) },
+                        db.numTables?.let { stringResource(R.string.d1_tables, it) },
+                    ).joinToString(" · ").ifEmpty { null }
+                    StorageRow(
+                        Icons.Outlined.Storage,
+                        db.name,
+                        subtitle,
+                        onClick = { onOpenDatabase(db.uuid, db.name) },
+                        onLongClick = if (viewModel.canWrite) ({ toDelete = db }) else null,
+                    )
+                }
+            }
+            if (viewModel.canWrite) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    containerColor = OcOrange,
+                    contentColor = Color.White,
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = stringResource(R.string.d1_create_title))
+                }
+            }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    if (showCreate) {
+        D1CreateSheet(
+            isCreating = opState.isCreating,
+            sheetState = createSheetState,
+            onCreate = { name, hint -> viewModel.create(name, hint) },
+            onDismiss = { showCreate = false },
+        )
+    }
+    toDelete?.let { db ->
+        D1DeleteDialog(
+            database = db,
+            isDeleting = opState.isDeleting,
+            onConfirm = { viewModel.delete(db) },
+            onDismiss = { toDelete = null },
+        )
     }
 }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageCommon.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageCommon.kt
@@ -1,6 +1,8 @@
 package jiamin.chen.orangecloud.ui.storage
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -81,7 +83,8 @@ fun formatBytes(bytes: Long): String {
     return "%.1f %s".format(v, units[i])
 }
 
-/** 存储通用列表行：图标 + 标题 + 可选副标题 + 右箭头。 */
+/** 存储通用列表行：图标 + 标题 + 可选副标题 + 右箭头。onLongClick 提供长按操作（如删除）。 */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun StorageRow(
     icon: ImageVector,
@@ -89,13 +92,20 @@ fun StorageRow(
     subtitle: String? = null,
     showChevron: Boolean = true,
     onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         shape = RoundedCornerShape(16.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .let { if (onClick != null) it.clickable(onClick = onClick) else it },
+            .let {
+                when {
+                    onLongClick != null -> it.combinedClickable(onClick = onClick ?: {}, onLongClick = onLongClick)
+                    onClick != null -> it.clickable(onClick = onClick)
+                    else -> it
+                }
+            },
     ) {
         Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
             Icon(icon, contentDescription = null, tint = OcOrange, modifier = Modifier.size(24.dp))

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageViewModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageViewModels.kt
@@ -42,12 +42,34 @@ class R2BucketListViewModel @Inject constructor(
     init { load() }
 }
 
+sealed interface D1DbEvent {
+    data object Created : D1DbEvent
+    data object Deleted : D1DbEvent
+    data class Error(val message: String?) : D1DbEvent
+}
+
+/** 创建/删除数据库的进行态（列表读取态仍走基类 uiState）。 */
+data class D1DbOpState(
+    val isCreating: Boolean = false,
+    val isDeleting: Boolean = false,
+)
+
 @HiltViewModel
 class D1DatabaseListViewModel @Inject constructor(
-    accountStore: AccountStore,
+    private val accountStore: AccountStore,
     private val storageRepository: StorageRepository,
     authRepository: AuthRepository,
 ) : StorageListViewModel<D1Database>(accountStore, authRepository.hasScope(Scopes.D1_READ)) {
+
+    /** 创建 / 删除数据库都需要 d1.write（读权限已是进入 D1 段的前置条件）。 */
+    val canWrite: Boolean = authRepository.hasScope(Scopes.D1_WRITE)
+
+    private val _opState = MutableStateFlow(D1DbOpState())
+    val opState: StateFlow<D1DbOpState> = _opState.asStateFlow()
+
+    private val eventChannel = Channel<D1DbEvent>(Channel.BUFFERED)
+    val events: Flow<D1DbEvent> = eventChannel.receiveAsFlow()
+
     // 列表端点的 num_tables / file_size 常年为 0，并发拉详情回填真实值（对齐 iOS）。
     // 某个库详情失败时回退到列表条目本身，不阻塞其余库。
     override suspend fun fetch(accountId: String): List<D1Database> = coroutineScope {
@@ -56,6 +78,42 @@ class D1DatabaseListViewModel @Inject constructor(
             .awaitAll()
     }
     init { load() }
+
+    /** 创建数据库：成功后把新库插到列表顶端。 */
+    fun create(name: String, locationHint: String?) {
+        if (!canWrite || _opState.value.isCreating) return
+        viewModelScope.launch {
+            _opState.update { it.copy(isCreating = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val created = storageRepository.createDatabase(accountId, name, locationHint)
+                state.update { it.copy(items = listOf(created) + it.items) }
+                eventChannel.send(D1DbEvent.Created)
+            } catch (e: Exception) {
+                eventChannel.send(D1DbEvent.Error(e.message))
+            } finally {
+                _opState.update { it.copy(isCreating = false) }
+            }
+        }
+    }
+
+    /** 删除数据库：成功后从列表移除。不可恢复，调用前须经二次确认。 */
+    fun delete(database: D1Database) {
+        if (!canWrite || _opState.value.isDeleting) return
+        viewModelScope.launch {
+            _opState.update { it.copy(isDeleting = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                storageRepository.deleteDatabase(accountId, database.uuid)
+                state.update { it.copy(items = it.items.filterNot { db -> db.uuid == database.uuid }) }
+                eventChannel.send(D1DbEvent.Deleted)
+            } catch (e: Exception) {
+                eventChannel.send(D1DbEvent.Error(e.message))
+            } finally {
+                _opState.update { it.copy(isDeleting = false) }
+            }
+        }
+    }
 }
 
 @HiltViewModel

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerConfigScreens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerConfigScreens.kt
@@ -1,0 +1,668 @@
+package jiamin.chen.orangecloud.ui.workers
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import jiamin.chen.orangecloud.R
+import jiamin.chen.orangecloud.core.design.SkyBackground
+import jiamin.chen.orangecloud.core.design.SkyHeader
+import jiamin.chen.orangecloud.core.design.onSky
+import jiamin.chen.orangecloud.core.design.rememberSkyPhase
+import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.data.model.WorkerBinding
+import jiamin.chen.orangecloud.data.model.WorkerSchedule
+import jiamin.chen.orangecloud.data.model.Zone
+
+// ============================================================
+//  共享小组件
+// ============================================================
+
+@Composable
+private fun WorkerSection(title: String, footer: String? = null, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            title,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) { content() }
+        }
+        if (footer != null) {
+            Text(footer, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(start = 4.dp))
+        }
+    }
+}
+
+@Composable
+private fun AddInlineButton(text: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(Icons.Outlined.Add, contentDescription = null, tint = OcOrange, modifier = Modifier.size(20.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(text, color = OcOrange, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun EmptyHint(text: String) {
+    Text(text, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+}
+
+// ============================================================
+//  变量与密钥
+// ============================================================
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkerSecretsScreen(
+    onBack: () -> Unit,
+    viewModel: WorkerBindingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val phase = rememberSkyPhase()
+    val onSky = phase.onSky
+    // sheet: null = closed; "secret" = new secret; "var:" + name = edit/new variable
+    var sheet by remember { mutableStateOf<EditorTarget?>(null) }
+
+    SkyBackground(phase = phase) {
+        Column(Modifier.fillMaxSize().systemBarsPadding()) {
+            SkyHeader(
+                title = stringResource(R.string.worker_secrets_title),
+                onSky = onSky,
+                isLoading = state.isLoading,
+                onRefresh = { viewModel.load() },
+                onBack = onBack,
+                titleSize = 22,
+                backDescription = stringResource(R.string.common_back),
+                refreshDescription = stringResource(R.string.common_refresh),
+            )
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // 密钥
+                WorkerSection(
+                    stringResource(R.string.worker_secrets_section),
+                    footer = if (state.canWrite) stringResource(R.string.worker_secrets_footer) else stringResource(R.string.worker_secrets_readonly),
+                ) {
+                    if (state.secrets.isEmpty()) EmptyHint(stringResource(R.string.worker_secrets_empty))
+                    state.secrets.forEach { secret ->
+                        ItemRow(
+                            title = secret.name,
+                            mono = false,
+                            onDelete = if (state.canWrite) ({ viewModel.deleteSecret(secret) }) else null,
+                        )
+                    }
+                    if (state.canWrite) AddInlineButton(stringResource(R.string.worker_secrets_add)) { sheet = EditorTarget.NewSecret }
+                }
+
+                // 环境变量
+                WorkerSection(
+                    stringResource(R.string.worker_vars_section),
+                    footer = stringResource(R.string.worker_vars_footer),
+                ) {
+                    if (state.variables.isEmpty()) EmptyHint(stringResource(R.string.worker_vars_empty))
+                    state.variables.forEach { binding ->
+                        ItemRow(
+                            title = binding.name,
+                            subtitle = binding.text,
+                            mono = true,
+                            onClick = if (state.canWrite) ({ sheet = EditorTarget.EditVar(binding.name, binding.text ?: "") }) else null,
+                            onDelete = if (state.canWrite) ({ viewModel.deleteVariable(binding) }) else null,
+                        )
+                    }
+                    if (state.canWrite) AddInlineButton(stringResource(R.string.worker_vars_add)) { sheet = EditorTarget.NewVar }
+                }
+
+                // 只读绑定
+                if (state.otherBindings.isNotEmpty()) {
+                    WorkerSection(
+                        stringResource(R.string.worker_other_section),
+                        footer = stringResource(R.string.worker_other_footer),
+                    ) {
+                        state.otherBindings.forEach { binding ->
+                            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                                Text(binding.name, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+                                Text(bindingTypeLabel(binding), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                        }
+                    }
+                }
+
+                state.error?.let { Text(it, color = Color(0xFFE5484D), fontSize = 13.sp) }
+            }
+        }
+    }
+
+    sheet?.let { target ->
+        WorkerValueSheet(
+            target = target,
+            isSaving = state.isSaving,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onSubmit = { name, value ->
+                when (target) {
+                    EditorTarget.NewSecret -> viewModel.addSecret(name, value)
+                    EditorTarget.NewVar -> viewModel.setVariable(name, value)
+                    is EditorTarget.EditVar -> viewModel.setVariable(target.name, value)
+                }
+                sheet = null
+            },
+            onDismiss = { sheet = null },
+        )
+    }
+}
+
+private sealed interface EditorTarget {
+    data object NewSecret : EditorTarget
+    data object NewVar : EditorTarget
+    data class EditVar(val name: String, val value: String) : EditorTarget
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WorkerValueSheet(
+    target: EditorTarget,
+    isSaving: Boolean,
+    sheetState: androidx.compose.material3.SheetState,
+    onSubmit: (name: String, value: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isSecret = target is EditorTarget.NewSecret
+    val lockedName = (target as? EditorTarget.EditVar)?.name
+    var name by remember { mutableStateOf(lockedName ?: "") }
+    var value by remember { mutableStateOf((target as? EditorTarget.EditVar)?.value ?: "") }
+
+    val nameValid = (lockedName ?: name).matches(Regex("^[A-Za-z_][A-Za-z0-9_]*$"))
+    val canSave = nameValid && value.isNotEmpty() && !isSaving
+    val title = when {
+        isSecret -> stringResource(R.string.worker_secret_add_title)
+        lockedName == null -> stringResource(R.string.worker_var_add_title)
+        else -> stringResource(R.string.worker_var_edit_title)
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().navigationBarsPadding().imePadding().padding(horizontal = 24.dp).padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(title, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            if (lockedName != null) {
+                Text(lockedName, fontSize = 14.sp, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.worker_binding_name)) },
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(stringResource(R.string.worker_binding_name_hint), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            OutlinedTextField(
+                value = value,
+                onValueChange = { value = it },
+                label = { Text(stringResource(if (isSecret) R.string.worker_secret_value else R.string.worker_binding_value)) },
+                singleLine = !isSecret,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Button(
+                onClick = { onSubmit((lockedName ?: name).trim(), value) },
+                enabled = canSave,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.dns_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun bindingTypeLabel(binding: WorkerBinding): String = when (binding.type) {
+    "plain_text" -> stringResource(R.string.worker_bind_var)
+    "secret_text", "secrets_store_secret" -> stringResource(R.string.worker_bind_secret)
+    "kv_namespace" -> "KV"
+    "d1" -> "D1"
+    "r2_bucket" -> "R2"
+    "queue" -> stringResource(R.string.worker_bind_queue)
+    "durable_object_namespace" -> "Durable Object"
+    "service" -> stringResource(R.string.worker_bind_service)
+    "ai" -> "Workers AI"
+    "vectorize" -> "Vectorize"
+    "analytics_engine" -> "Analytics Engine"
+    "browser" -> stringResource(R.string.worker_bind_browser)
+    else -> binding.type
+}
+
+/** 通用行：标题 + 可选副标题 + 可选点击/删除。 */
+@Composable
+private fun ItemRow(
+    title: String,
+    subtitle: String? = null,
+    mono: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    onDelete: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().let { if (onClick != null) it.clickable(onClick = onClick) else it },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                fontFamily = if (mono) FontFamily.Monospace else FontFamily.Default,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (subtitle != null) {
+                Text(subtitle, fontSize = 12.sp, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+            }
+        }
+        if (onDelete != null) {
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Outlined.Delete, contentDescription = stringResource(R.string.dns_delete), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+// ============================================================
+//  触发器（Cron）
+// ============================================================
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkerTriggersScreen(
+    onBack: () -> Unit,
+    viewModel: WorkerTriggersViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val phase = rememberSkyPhase()
+    val onSky = phase.onSky
+    var showAdd by remember { mutableStateOf(false) }
+
+    SkyBackground(phase = phase) {
+        Column(Modifier.fillMaxSize().systemBarsPadding()) {
+            SkyHeader(
+                title = stringResource(R.string.worker_triggers_title),
+                onSky = onSky,
+                isLoading = state.isLoading,
+                onRefresh = { viewModel.load() },
+                onBack = onBack,
+                titleSize = 22,
+                backDescription = stringResource(R.string.common_back),
+                refreshDescription = stringResource(R.string.common_refresh),
+            )
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                WorkerSection(
+                    stringResource(R.string.worker_triggers_title),
+                    footer = if (state.canWrite) stringResource(R.string.worker_triggers_footer) else stringResource(R.string.worker_secrets_readonly),
+                ) {
+                    if (state.schedules.isEmpty()) {
+                        EmptyHint(stringResource(R.string.worker_triggers_empty_desc))
+                    }
+                    state.schedules.forEach { schedule ->
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Column(Modifier.weight(1f)) {
+                                Text(schedule.cron, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurface)
+                                Text(cronDescribe(schedule.cron), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            if (state.canWrite) {
+                                IconButton(onClick = { viewModel.deleteCron(schedule) }) {
+                                    Icon(Icons.Outlined.Delete, contentDescription = stringResource(R.string.dns_delete), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                            }
+                        }
+                    }
+                    if (state.canWrite) AddInlineButton(stringResource(R.string.worker_triggers_add)) { showAdd = true }
+                }
+                state.error?.let { Text(it, color = Color(0xFFE5484D), fontSize = 13.sp) }
+            }
+        }
+    }
+
+    if (showAdd) {
+        CronSheet(
+            isSaving = state.isSaving,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onSubmit = { viewModel.addCron(it); showAdd = false },
+            onDismiss = { showAdd = false },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CronSheet(
+    isSaving: Boolean,
+    sheetState: androidx.compose.material3.SheetState,
+    onSubmit: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var cron by remember { mutableStateOf("") }
+    val valid = cron.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }.size == 5
+    val presets = listOf(
+        "*/5 * * * *" to stringResource(R.string.worker_cron_5m),
+        "0 * * * *" to stringResource(R.string.worker_cron_hourly),
+        "0 0 * * *" to stringResource(R.string.worker_cron_daily),
+        "0 0 * * 1" to stringResource(R.string.worker_cron_weekly),
+    )
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().navigationBarsPadding().imePadding().padding(horizontal = 24.dp).padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(stringResource(R.string.worker_triggers_add), fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            OutlinedTextField(
+                value = cron,
+                onValueChange = { cron = it },
+                label = { Text(stringResource(R.string.worker_cron_expr)) },
+                placeholder = { Text("*/5 * * * *") },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                if (valid) cronDescribe(cron) else stringResource(R.string.worker_cron_hint),
+                fontSize = 12.sp,
+                color = if (valid) MaterialTheme.colorScheme.onSurfaceVariant else Color(0xFFC77C00),
+            )
+            Text(stringResource(R.string.worker_cron_presets), fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            presets.forEach { (expr, label) ->
+                Row(
+                    Modifier.fillMaxWidth().clickable { cron = expr }.padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(expr, fontSize = 14.sp, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+                    Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Button(
+                onClick = { onSubmit(cron.trim()) },
+                enabled = valid && !isSaving,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.dns_save))
+            }
+        }
+    }
+}
+
+/** Cron 人类可读释义（覆盖常见样式，其余回退）。 */
+@Composable
+private fun cronDescribe(cron: String): String {
+    val f = cron.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
+    if (f.size != 5) return stringResource(R.string.worker_cron_custom)
+    val (minute, hour, dom, month, dow) = f
+    if (minute.startsWith("*/") && hour == "*" && dom == "*" && month == "*" && dow == "*") {
+        minute.removePrefix("*/").toIntOrNull()?.let { return stringResource(R.string.worker_cron_every_n, it) }
+    }
+    if (minute == "0" && hour == "*" && dom == "*" && month == "*" && dow == "*") {
+        return stringResource(R.string.worker_cron_desc_hourly)
+    }
+    val m = minute.toIntOrNull()
+    val h = hour.toIntOrNull()
+    if (m != null && h != null && dom == "*" && month == "*" && dow == "*") {
+        return stringResource(R.string.worker_cron_desc_daily, "%02d:%02d".format(h, m))
+    }
+    return stringResource(R.string.worker_cron_custom)
+}
+
+// ============================================================
+//  域名 / 路由
+// ============================================================
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkerRoutesScreen(
+    onBack: () -> Unit,
+    viewModel: WorkerRoutesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val phase = rememberSkyPhase()
+    val onSky = phase.onSky
+    var routeSheet by remember { mutableStateOf<RouteSheetKind?>(null) }
+
+    SkyBackground(phase = phase) {
+        Column(Modifier.fillMaxSize().systemBarsPadding()) {
+            SkyHeader(
+                title = stringResource(R.string.worker_domains_title),
+                onSky = onSky,
+                isLoading = state.isLoading,
+                onRefresh = { viewModel.load() },
+                onBack = onBack,
+                titleSize = 22,
+                backDescription = stringResource(R.string.common_back),
+                refreshDescription = stringResource(R.string.common_refresh),
+            )
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // workers.dev 子域
+                WorkerSection(
+                    stringResource(R.string.worker_subdomain_section),
+                    footer = stringResource(R.string.worker_subdomain_footer),
+                ) {
+                    val sub = state.subdomain
+                    if (sub == null) {
+                        EmptyHint(stringResource(R.string.worker_subdomain_none))
+                    } else {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Text(stringResource(R.string.worker_subdomain_label), fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+                            if (state.togglingSubdomain) {
+                                CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp, color = OcOrange)
+                            } else {
+                                Switch(
+                                    checked = sub.enabled,
+                                    onCheckedChange = { viewModel.toggleSubdomain(it) },
+                                    enabled = state.canWrite,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // 自定义域
+                WorkerSection(
+                    stringResource(R.string.worker_customdomains_section),
+                    footer = stringResource(R.string.worker_customdomains_footer),
+                ) {
+                    if (state.customDomains.isEmpty()) EmptyHint(stringResource(R.string.worker_customdomains_empty))
+                    state.customDomains.forEach { domain ->
+                        ItemRow(
+                            title = domain.hostname,
+                            subtitle = domain.zoneName,
+                            onDelete = if (state.canWrite) ({ viewModel.detachDomain(domain) }) else null,
+                        )
+                    }
+                    if (state.canWrite && state.zones.isNotEmpty()) {
+                        AddInlineButton(stringResource(R.string.worker_customdomains_add)) { routeSheet = RouteSheetKind.Domain }
+                    }
+                }
+
+                // Zone 路由
+                WorkerSection(
+                    stringResource(R.string.worker_routes_section),
+                    footer = stringResource(R.string.worker_routes_footer),
+                ) {
+                    if (state.routes.isEmpty()) EmptyHint(stringResource(R.string.worker_routes_empty))
+                    state.routes.forEach { scoped ->
+                        ItemRow(
+                            title = scoped.route.pattern,
+                            subtitle = scoped.zoneName,
+                            mono = true,
+                            onDelete = if (state.canWrite) ({ viewModel.deleteRoute(scoped) }) else null,
+                        )
+                    }
+                    if (state.canWrite && state.zones.isNotEmpty()) {
+                        AddInlineButton(stringResource(R.string.worker_routes_add)) { routeSheet = RouteSheetKind.Route }
+                    }
+                }
+
+                state.error?.let { Text(it, color = Color(0xFFE5484D), fontSize = 13.sp) }
+            }
+        }
+    }
+
+    routeSheet?.let { kind ->
+        RouteEditorSheet(
+            kind = kind,
+            zones = state.zones,
+            isSaving = state.isSaving,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onSubmit = { zoneId, text ->
+                if (kind == RouteSheetKind.Domain) viewModel.attachDomain(text, zoneId) else viewModel.addRoute(zoneId, text)
+                routeSheet = null
+            },
+            onDismiss = { routeSheet = null },
+        )
+    }
+}
+
+private enum class RouteSheetKind { Domain, Route }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RouteEditorSheet(
+    kind: RouteSheetKind,
+    zones: List<Zone>,
+    isSaving: Boolean,
+    sheetState: androidx.compose.material3.SheetState,
+    onSubmit: (zoneId: String, text: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isDomain = kind == RouteSheetKind.Domain
+    var zoneId by remember { mutableStateOf("") }
+    var text by remember { mutableStateOf("") }
+    var expanded by remember { mutableStateOf(false) }
+    val selectedZoneName = zones.firstOrNull { it.id == zoneId }?.name ?: stringResource(R.string.worker_route_zone_pick)
+    val canSave = zoneId.isNotEmpty() && text.trim().isNotEmpty() && !isSaving
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().navigationBarsPadding().imePadding().padding(horizontal = 24.dp).padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(
+                stringResource(if (isDomain) R.string.worker_attach_domain_title else R.string.worker_add_route_title),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+                OutlinedTextField(
+                    value = selectedZoneName,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.worker_route_zone)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    zones.forEach { zone ->
+                        DropdownMenuItem(text = { Text(zone.name) }, onClick = { zoneId = zone.id; expanded = false })
+                    }
+                }
+            }
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text(stringResource(if (isDomain) R.string.worker_domain_hostname else R.string.worker_route_pattern)) },
+                placeholder = { Text(if (isDomain) "api.example.com" else "example.com/api/*") },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                stringResource(if (isDomain) R.string.worker_domain_hostname_hint else R.string.worker_route_pattern_hint),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(
+                onClick = { onSubmit(zoneId, text.trim()) },
+                enabled = canSave,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.dns_save))
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerConfigViewModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerConfigViewModels.kt
@@ -1,0 +1,387 @@
+package jiamin.chen.orangecloud.ui.workers
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jiamin.chen.orangecloud.core.auth.AuthRepository
+import jiamin.chen.orangecloud.core.auth.Scopes
+import jiamin.chen.orangecloud.data.model.ScopedWorkerRoute
+import jiamin.chen.orangecloud.data.model.WorkerBinding
+import jiamin.chen.orangecloud.data.model.WorkerBindingInput
+import jiamin.chen.orangecloud.data.model.WorkerCustomDomain
+import jiamin.chen.orangecloud.data.model.WorkerSchedule
+import jiamin.chen.orangecloud.data.model.WorkerSecret
+import jiamin.chen.orangecloud.data.model.WorkerSettings
+import jiamin.chen.orangecloud.data.model.WorkerSubdomain
+import jiamin.chen.orangecloud.data.repository.AccountStore
+import jiamin.chen.orangecloud.data.repository.WorkerRepository
+import jiamin.chen.orangecloud.data.repository.ZoneRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// MARK: - 变量与密钥（密钥专用端点 + 变量 PATCH settings）
+
+data class WorkerBindingsUiState(
+    val secrets: List<WorkerSecret> = emptyList(),
+    val variables: List<WorkerBinding> = emptyList(),
+    val otherBindings: List<WorkerBinding> = emptyList(),
+    val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
+    val loaded: Boolean = false,
+    val canWrite: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * Worker 密钥（secret_text，专用端点）+ 环境变量（plain_text，PATCH settings）+ 只读绑定清单。
+ * 改变量一律 read-modify-write：变更项为实体、其余绑定 inherit，绝不丢失既有绑定/密钥。
+ */
+@HiltViewModel
+class WorkerBindingsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val accountStore: AccountStore,
+    private val workerRepository: WorkerRepository,
+    authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val scriptName: String = checkNotNull(savedStateHandle["scriptName"])
+    private val canWrite = authRepository.hasScope(Scopes.WORKERS_WRITE)
+    private var settings: WorkerSettings? = null
+
+    private val _uiState = MutableStateFlow(WorkerBindingsUiState(canWrite = canWrite))
+    val uiState: StateFlow<WorkerBindingsUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val accountId = accountId()
+                val secrets = workerRepository.listSecrets(accountId, scriptName)
+                val s = workerRepository.settings(accountId, scriptName)
+                settings = s
+                _uiState.update {
+                    it.copy(
+                        secrets = secrets,
+                        variables = s.validBindings.filter { b -> b.isPlainText }.sortedBy { b -> b.name },
+                        otherBindings = s.validBindings.filter { b -> !b.isPlainText && !b.isSecret }.sortedBy { b -> b.name },
+                        loaded = true,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    fun addSecret(name: String, text: String) {
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+            try {
+                val accountId = accountId()
+                workerRepository.putSecret(accountId, scriptName, name, text)
+                _uiState.update { it.copy(secrets = workerRepository.listSecrets(accountId, scriptName)) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun deleteSecret(secret: WorkerSecret) {
+        if (!canWrite) return
+        viewModelScope.launch {
+            try {
+                val accountId = accountId()
+                workerRepository.deleteSecret(accountId, scriptName, secret.name)
+                _uiState.update { it.copy(secrets = it.secrets.filterNot { s -> s.name == secret.name }) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    fun setVariable(name: String, value: String) {
+        val s = settings ?: return
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+            try {
+                val bindings = s.inheritedBindings(excludingName = name) + WorkerBindingInput("plain_text", name, value)
+                patchAndReload(bindings)
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun deleteVariable(binding: WorkerBinding) {
+        val s = settings ?: return
+        if (!canWrite) return
+        viewModelScope.launch {
+            try {
+                patchAndReload(s.inheritedBindings(excludingName = binding.name))
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    private suspend fun patchAndReload(bindings: List<WorkerBindingInput>) {
+        val s = settings ?: return
+        val accountId = accountId()
+        workerRepository.patchSettings(accountId, scriptName, bindings, s)
+        val fresh = workerRepository.settings(accountId, scriptName)
+        settings = fresh
+        _uiState.update {
+            it.copy(
+                variables = fresh.validBindings.filter { b -> b.isPlainText }.sortedBy { b -> b.name },
+                otherBindings = fresh.validBindings.filter { b -> !b.isPlainText && !b.isSecret }.sortedBy { b -> b.name },
+            )
+        }
+    }
+
+    private suspend fun accountId(): String {
+        accountStore.ensureLoaded()
+        return accountStore.selectedAccountId.value ?: error("no account")
+    }
+}
+
+// MARK: - Cron 触发器（整组 read-modify-write）
+
+data class WorkerTriggersUiState(
+    val schedules: List<WorkerSchedule> = emptyList(),
+    val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
+    val loaded: Boolean = false,
+    val canWrite: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class WorkerTriggersViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val accountStore: AccountStore,
+    private val workerRepository: WorkerRepository,
+    authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val scriptName: String = checkNotNull(savedStateHandle["scriptName"])
+    private val canWrite = authRepository.hasScope(Scopes.WORKERS_WRITE)
+
+    private val _uiState = MutableStateFlow(WorkerTriggersUiState(canWrite = canWrite))
+    val uiState: StateFlow<WorkerTriggersUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val schedules = workerRepository.schedules(accountId(), scriptName)
+                _uiState.update { it.copy(schedules = schedules, loaded = true) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    fun addCron(cron: String) {
+        val trimmed = cron.trim()
+        if (!canWrite || _uiState.value.isSaving || trimmed.isEmpty()) return
+        if (_uiState.value.schedules.any { it.cron == trimmed }) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+            try {
+                val crons = _uiState.value.schedules.map { it.cron } + trimmed
+                workerRepository.putSchedules(accountId(), scriptName, crons)
+                reload()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun deleteCron(schedule: WorkerSchedule) {
+        if (!canWrite) return
+        viewModelScope.launch {
+            try {
+                val crons = _uiState.value.schedules.filter { it.cron != schedule.cron }.map { it.cron }
+                workerRepository.putSchedules(accountId(), scriptName, crons)
+                reload()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    private suspend fun reload() {
+        runCatching { workerRepository.schedules(accountId(), scriptName) }
+            .onSuccess { list -> _uiState.update { it.copy(schedules = list) } }
+    }
+
+    private suspend fun accountId(): String {
+        accountStore.ensureLoaded()
+        return accountStore.selectedAccountId.value ?: error("no account")
+    }
+}
+
+// MARK: - 域名 / 路由（workers.dev 子域 + 自定义域 + Zone 路由）
+
+data class WorkerRoutesUiState(
+    val subdomain: WorkerSubdomain? = null,
+    val customDomains: List<WorkerCustomDomain> = emptyList(),
+    val routes: List<ScopedWorkerRoute> = emptyList(),
+    val zones: List<jiamin.chen.orangecloud.data.model.Zone> = emptyList(),
+    val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
+    val togglingSubdomain: Boolean = false,
+    val loaded: Boolean = false,
+    val canWrite: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class WorkerRoutesViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val accountStore: AccountStore,
+    private val workerRepository: WorkerRepository,
+    private val zoneRepository: ZoneRepository,
+    authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val scriptName: String = checkNotNull(savedStateHandle["scriptName"])
+    private val canWrite = authRepository.hasScope(Scopes.WORKERS_WRITE)
+
+    private val _uiState = MutableStateFlow(WorkerRoutesUiState(canWrite = canWrite))
+    val uiState: StateFlow<WorkerRoutesUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val accountId = accountId()
+                val zones = zoneRepository.listZones(accountId)
+                val customDomains = workerRepository.customDomains(accountId, scriptName)
+                // 子域可能未在账号开通，单独容错，不阻断整页
+                val subdomain = runCatching { workerRepository.subdomain(accountId, scriptName) }.getOrNull()
+                _uiState.update {
+                    it.copy(zones = zones, customDomains = customDomains, subdomain = subdomain, loaded = true)
+                }
+                loadRoutes(zones)
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    /** 逐 zone 查路由并过滤本脚本（routes 端点是 zone 级）。 */
+    private suspend fun loadRoutes(zones: List<jiamin.chen.orangecloud.data.model.Zone>) {
+        val collected = mutableListOf<ScopedWorkerRoute>()
+        for (zone in zones) {
+            val zoneRoutes = runCatching { workerRepository.routes(zone.id) }.getOrDefault(emptyList())
+            for (route in zoneRoutes) {
+                if (route.script == scriptName) collected += ScopedWorkerRoute(zone.id, zone.name, route)
+            }
+        }
+        _uiState.update { it.copy(routes = collected.sortedBy { r -> r.route.pattern }) }
+    }
+
+    fun toggleSubdomain(enabled: Boolean) {
+        if (!canWrite || _uiState.value.togglingSubdomain) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(togglingSubdomain = true, error = null) }
+            try {
+                val accountId = accountId()
+                workerRepository.setSubdomain(accountId, scriptName, enabled)
+                val fresh = runCatching { workerRepository.subdomain(accountId, scriptName) }.getOrNull()
+                _uiState.update { it.copy(subdomain = fresh) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(togglingSubdomain = false) }
+            }
+        }
+    }
+
+    fun attachDomain(hostname: String, zoneId: String) {
+        if (!canWrite || _uiState.value.isSaving) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+            try {
+                val accountId = accountId()
+                workerRepository.attachDomain(accountId, scriptName, hostname, zoneId)
+                _uiState.update { it.copy(customDomains = workerRepository.customDomains(accountId, scriptName)) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun detachDomain(domain: WorkerCustomDomain) {
+        if (!canWrite) return
+        viewModelScope.launch {
+            try {
+                workerRepository.deleteDomain(accountId(), domain.id)
+                _uiState.update { it.copy(customDomains = it.customDomains.filterNot { d -> d.id == domain.id }) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    fun addRoute(zoneId: String, pattern: String) {
+        val trimmed = pattern.trim()
+        if (!canWrite || _uiState.value.isSaving || trimmed.isEmpty()) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+            try {
+                workerRepository.createRoute(zoneId, trimmed, scriptName)
+                loadRoutes(_uiState.value.zones)
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun deleteRoute(scoped: ScopedWorkerRoute) {
+        if (!canWrite) return
+        viewModelScope.launch {
+            try {
+                workerRepository.deleteRoute(scoped.zoneId, scoped.route.id)
+                _uiState.update { it.copy(routes = it.routes.filterNot { r -> r.route.id == scoped.route.id && r.zoneId == scoped.zoneId }) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    private suspend fun accountId(): String {
+        accountStore.ensureLoaded()
+        return accountStore.selectedAccountId.value ?: error("no account")
+    }
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDetailScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDetailScreen.kt
@@ -18,7 +18,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Key
+import androidx.compose.material.icons.outlined.Public
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -40,6 +45,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -66,6 +72,9 @@ import java.time.format.FormatStyle
 fun WorkerDetailScreen(
     onBack: () -> Unit,
     onOpenTail: () -> Unit,
+    onOpenSecrets: () -> Unit = {},
+    onOpenTriggers: () -> Unit = {},
+    onOpenDomains: () -> Unit = {},
     viewModel: WorkerDetailViewModel = hiltViewModel(),
 ) {
     val worker by viewModel.worker.collectAsStateWithLifecycle()
@@ -100,6 +109,19 @@ fun WorkerDetailScreen(
                     Icon(Icons.Outlined.Terminal, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
                     Text(stringResource(R.string.tail_title))
+                }
+
+                // 管理：变量与密钥 / 触发器 / 域名（各页 Pro 闸门）
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    shape = RoundedCornerShape(16.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(Modifier.padding(vertical = 4.dp)) {
+                        ManageRow(Icons.Outlined.Key, stringResource(R.string.worker_manage_secrets), onOpenSecrets)
+                        ManageRow(Icons.Outlined.Schedule, stringResource(R.string.worker_manage_triggers), onOpenTriggers)
+                        ManageRow(Icons.Outlined.Public, stringResource(R.string.worker_manage_domains), onOpenDomains)
+                    }
                 }
 
                 if (viewModel.canViewMetrics) {
@@ -184,6 +206,23 @@ fun WorkerDetailScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ManageRow(icon: ImageVector, label: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(icon, contentDescription = null, tint = OcOrange, modifier = Modifier.size(22.dp))
+        Spacer(Modifier.width(14.dp))
+        Text(label, fontSize = 15.sp, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+        Icon(
+            Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zones/AddZoneSheet.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zones/AddZoneSheet.kt
@@ -1,0 +1,272 @@
+package jiamin.chen.orangecloud.ui.zones
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jiamin.chen.orangecloud.R
+import jiamin.chen.orangecloud.core.design.ZoneAvatar
+import jiamin.chen.orangecloud.core.util.copyToClipboard
+import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.data.model.Zone
+
+/**
+ * 添加域名底部表单：填根域名 → POST /zones（full setup）→ 切到名称服务器结果页。
+ * 对应 iOS AddZoneView（表单 + 结果两段）。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddZoneSheet(
+    state: AddZoneUiState,
+    accountName: String?,
+    sheetState: SheetState,
+    onCreate: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        val zone = state.createdZone
+        if (zone == null) {
+            AddZoneForm(state, accountName, onCreate)
+        } else {
+            AddZoneResult(zone, onDismiss)
+        }
+    }
+}
+
+/** 去掉协议头/路径/首尾点与空白，统一小写——用户常整段粘贴 URL。 */
+private fun normalizeDomain(input: String): String {
+    var s = input.trim().lowercase()
+    s.indexOf("://").takeIf { it >= 0 }?.let { s = s.substring(it + 3) }
+    s.indexOf('/').takeIf { it >= 0 }?.let { s = s.substring(0, it) }
+    return s.trim('.')
+}
+
+/** 宽松校验：至少两段、无空段、无空格、TLD ≥ 2 字符（最终以服务端为准，不限 ASCII 以容国际化域名）。 */
+private fun isValidDomain(input: String): Boolean {
+    val s = normalizeDomain(input)
+    if (s.length < 3 || s.contains(' ')) return false
+    val labels = s.split('.')
+    if (labels.size < 2 || labels.any { it.isEmpty() }) return false
+    return (labels.lastOrNull()?.length ?: 0) >= 2
+}
+
+@Composable
+private fun AddZoneForm(
+    state: AddZoneUiState,
+    accountName: String?,
+    onCreate: (String) -> Unit,
+) {
+    var domain by remember { mutableStateOf("") }
+    val canSubmit = isValidDomain(domain) && !state.isSaving
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Text(stringResource(R.string.addzone_title), fontSize = 20.sp, fontWeight = FontWeight.Bold)
+
+        OutlinedTextField(
+            value = domain,
+            onValueChange = { domain = it },
+            label = { Text(stringResource(R.string.addzone_domain_label)) },
+            placeholder = { Text("example.com") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            stringResource(R.string.addzone_domain_hint),
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        if (!accountName.isNullOrBlank()) {
+            Text(
+                stringResource(R.string.addzone_account, accountName),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Text(
+            stringResource(R.string.addzone_ns_note),
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        state.error?.let {
+            Text(it, color = Color(0xFFE5484D), fontSize = 13.sp)
+        }
+
+        Button(
+            onClick = { onCreate(normalizeDomain(domain)) },
+            enabled = canSubmit,
+            colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (state.isSaving) {
+                CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                Spacer(Modifier.width(8.dp))
+            }
+            Text(stringResource(R.string.addzone_add))
+        }
+    }
+}
+
+@Composable
+private fun AddZoneResult(zone: Zone, onDone: () -> Unit) {
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+    val nameServers = zone.nameServers.orEmpty()
+    val steps = listOf(
+        stringResource(R.string.addzone_step1),
+        stringResource(R.string.addzone_step2),
+        stringResource(R.string.addzone_step3),
+        stringResource(R.string.addzone_step4),
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            ZoneAvatar(zone.name, size = 52.dp)
+            Text(zone.name, fontSize = 20.sp, fontWeight = FontWeight.Bold, maxLines = 1)
+            Text(
+                stringResource(R.string.addzone_pending),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (nameServers.isEmpty()) {
+            Text(
+                stringResource(R.string.addzone_ns_missing),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            ResultCard(stringResource(R.string.addzone_ns_title)) {
+                nameServers.forEach { server ->
+                    Text(
+                        server,
+                        fontSize = 14.sp,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+                Spacer(Modifier.size(2.dp))
+                OutlinedButton(
+                    onClick = {
+                        copyToClipboard(context, nameServers.joinToString("\n"))
+                        copied = true
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(if (copied) R.string.addzone_copied else R.string.addzone_copy))
+                }
+            }
+
+            ResultCard(stringResource(R.string.addzone_steps_title)) {
+                steps.forEachIndexed { index, step ->
+                    Row(verticalAlignment = Alignment.Top) {
+                        Box(
+                            Modifier.size(22.dp).clip(CircleShape)
+                                .background(OcOrange),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text("${index + 1}", color = Color.White, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                        }
+                        Spacer(Modifier.width(12.dp))
+                        Text(step, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface)
+                    }
+                }
+            }
+        }
+
+        Button(
+            onClick = onDone,
+            colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.addzone_done))
+        }
+    }
+}
+
+@Composable
+private fun ResultCard(title: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            title,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                content()
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zones/ZoneListScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zones/ZoneListScreen.kt
@@ -19,18 +19,23 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Dns
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,16 +56,20 @@ import jiamin.chen.orangecloud.core.design.theme.OcSuccess
 import jiamin.chen.orangecloud.data.model.Zone
 import java.time.LocalTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ZoneListScreen(
     onZoneClick: (Zone) -> Unit = {},
     viewModel: ZoneListViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val addState by viewModel.addState.collectAsStateWithLifecycle()
     val isDark = jiamin.chen.orangecloud.core.design.theme.LocalIsDark.current
     val phase = remember(isDark) { SkyPhase.current(isDark, LocalTime.now().hour) }
     val onSky = if (phase.isDark) Color(0xFFF3ECE4) else Color(0xFF24190F)
     val activeCount = uiState.zones.count { it.isActive }
+    var showAdd by remember { mutableStateOf(false) }
+    val addSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     SkyBackground(phase = phase) {
         Column(Modifier.fillMaxSize().systemBarsPadding()) {
@@ -83,6 +92,11 @@ fun ZoneListScreen(
                         )
                     }
                 }
+                if (viewModel.canWrite) {
+                    IconButton(onClick = { showAdd = true }) {
+                        Icon(Icons.Outlined.Add, stringResource(R.string.addzone_title), tint = onSky)
+                    }
+                }
                 if (uiState.isLoading) {
                     CircularProgressIndicator(modifier = Modifier.size(22.dp), color = onSky, strokeWidth = 2.dp)
                     Spacer(Modifier.width(12.dp))
@@ -98,7 +112,7 @@ fun ZoneListScreen(
                     Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator(color = onSky) }
 
                 uiState.zones.isEmpty() ->
-                    EmptyZones(onSky) { viewModel.refresh() }
+                    EmptyZones(onSky, viewModel.canWrite, onAdd = { showAdd = true }) { viewModel.refresh() }
 
                 else -> LazyColumn(
                     contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 96.dp),
@@ -109,6 +123,19 @@ fun ZoneListScreen(
                     }
                 }
             }
+        }
+
+        if (showAdd) {
+            AddZoneSheet(
+                state = addState,
+                accountName = viewModel.currentAccountName(),
+                sheetState = addSheetState,
+                onCreate = { viewModel.createZone(it) },
+                onDismiss = {
+                    showAdd = false
+                    viewModel.resetAddState()
+                },
+            )
         }
     }
 }
@@ -150,13 +177,16 @@ private fun ZoneRow(zone: Zone, onClick: () -> Unit) {
 }
 
 @Composable
-private fun EmptyZones(onSky: Color, onRetry: () -> Unit) {
+private fun EmptyZones(onSky: Color, canWrite: Boolean, onAdd: () -> Unit, onRetry: () -> Unit) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(Icons.Outlined.Dns, contentDescription = null, tint = onSky.copy(alpha = 0.6f), modifier = Modifier.size(48.dp))
             Spacer(Modifier.height(12.dp))
             Text(stringResource(R.string.zones_empty), color = onSky.copy(alpha = 0.85f), fontSize = 16.sp)
             Spacer(Modifier.height(8.dp))
+            if (canWrite) {
+                TextButton(onClick = onAdd) { Text(stringResource(R.string.addzone_title)) }
+            }
             TextButton(onClick = onRetry) { Text(stringResource(R.string.common_refresh)) }
         }
     }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zones/ZoneListViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zones/ZoneListViewModel.kt
@@ -3,6 +3,8 @@ package jiamin.chen.orangecloud.ui.zones
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jiamin.chen.orangecloud.core.auth.AuthRepository
+import jiamin.chen.orangecloud.core.auth.Scopes
 import jiamin.chen.orangecloud.data.model.Zone
 import jiamin.chen.orangecloud.data.repository.AccountStore
 import jiamin.chen.orangecloud.data.repository.ZoneRepository
@@ -11,10 +13,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,15 +28,29 @@ data class ZoneListUiState(
     val hasError: Boolean = false,
 )
 
+/** 添加域名（新建 Zone）状态：createdZone 非空时表单切到「名称服务器」结果页。 */
+data class AddZoneUiState(
+    val isSaving: Boolean = false,
+    val error: String? = null,
+    val createdZone: Zone? = null,
+)
+
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class ZoneListViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val zoneRepository: ZoneRepository,
+    authRepository: AuthRepository,
 ) : ViewModel() {
+
+    /** 有 zone.write 才展示「添加域名」入口。 */
+    val canWrite: Boolean = authRepository.hasScope(Scopes.ZONE_WRITE)
 
     private val loading = MutableStateFlow(false)
     private val error = MutableStateFlow(false)
+
+    private val _addState = MutableStateFlow(AddZoneUiState())
+    val addState: StateFlow<AddZoneUiState> = _addState.asStateFlow()
 
     // 切账号自动重查当前账号的域名缓存
     private val zones: Flow<List<Zone>> = accountStore.selectedAccountId.flatMapLatest { id ->
@@ -46,6 +64,30 @@ class ZoneListViewModel @Inject constructor(
 
     init {
         refresh()
+    }
+
+    /** 当前选中账号名（添加域名表单展示用）。 */
+    fun currentAccountName(): String? = accountStore.selectedAccount?.name
+
+    /** 新建域名。成功后 createdZone 非空，表单切到名称服务器结果页。 */
+    fun createZone(name: String) {
+        if (_addState.value.isSaving) return
+        viewModelScope.launch {
+            _addState.update { it.copy(isSaving = true, error = null) }
+            try {
+                accountStore.ensureLoaded()
+                val id = accountStore.selectedAccountId.value ?: error("no account")
+                val zone = zoneRepository.createZone(id, name)
+                _addState.update { it.copy(createdZone = zone, isSaving = false) }
+            } catch (e: Exception) {
+                _addState.update { it.copy(error = e.message ?: "error", isSaving = false) }
+            }
+        }
+    }
+
+    /** 关闭/重置添加域名表单。 */
+    fun resetAddState() {
+        _addState.value = AddZoneUiState()
     }
 
     fun refresh() {

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -43,7 +43,7 @@
     <string name="perm_kv">KV storage</string>
     <string name="perm_kv_desc">Read and write key-values</string>
     <string name="perm_tunnels">Tunnels</string>
-    <string name="perm_tunnels_desc">View Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">View tunnels; with write access, create tunnels and configure public hostname routes</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">View and toggle firewall rules</string>
     <string name="perm_zone_settings">Domain settings</string>
@@ -394,10 +394,6 @@
     <!-- What\'s New -->
     <string name="whatsnew_title">What\'s New</string>
     <string name="whatsnew_ok">Got it</string>
-    <string name="whatsnew_1_0_oauth_title">One-tap OAuth sign-in</string>
-    <string name="whatsnew_1_0_oauth_detail">Sign in with Cloudflare\'s official authorization — no API tokens to paste.</string>
-    <string name="whatsnew_1_0_modules_title">Domains · Workers · Storage</string>
-    <string name="whatsnew_1_0_modules_detail">DNS, analytics, WAF, Snippets, Workers live logs, and R2/D1/KV storage — all in one place.</string>
 
     <!-- Paywall -->
     <string name="paywall_title">Orange Cloud Pro</string>
@@ -412,4 +408,154 @@
     <string name="paywall_monthly">Monthly</string>
     <string name="paywall_lifetime">Lifetime</string>
     <string name="paywall_note">Billed via Google Play, cancel anytime.</string>
+
+
+    <!-- Add domain -->
+    <string name="addzone_title">Add domain</string>
+    <string name="addzone_domain_label">Domain</string>
+    <string name="addzone_domain_hint">Enter a root domain you already own (e.g. example.com), without www or https://.</string>
+    <string name="addzone_account">Add to account: %1$s</string>
+    <string name="addzone_ns_note">After adding, Cloudflare assigns two nameservers. Sign in to your registrar and switch the NS to them to activate the domain.</string>
+    <string name="addzone_add">Add</string>
+    <string name="addzone_pending">Pending activation</string>
+    <string name="addzone_ns_title">Nameservers</string>
+    <string name="addzone_copy">Copy nameservers</string>
+    <string name="addzone_copied">Copied</string>
+    <string name="addzone_steps_title">Next steps</string>
+    <string name="addzone_step1">Sign in to the registrar where you bought this domain.</string>
+    <string name="addzone_step2">Find the “Nameservers” setting.</string>
+    <string name="addzone_step3">Remove the existing nameservers and replace them with the two Cloudflare addresses above.</string>
+    <string name="addzone_step4">Save changes. Activation usually takes minutes to hours, up to 24 hours.</string>
+    <string name="addzone_done">Done</string>
+    <string name="addzone_ns_missing">Cloudflare hasn’t returned nameservers yet. Check the domain details or the Cloudflare dashboard later.</string>
+
+    <!-- D1 create / delete -->
+    <string name="d1_create_title">Create database</string>
+    <string name="d1_create">Create</string>
+    <string name="d1_created">Created</string>
+    <string name="d1_name">Database name</string>
+    <string name="d1_location">Primary location</string>
+    <string name="d1_location_hint">The primary location sets where the primary replica lives. Choose “Automatic” to let Cloudflare place it nearby.</string>
+    <string name="d1_loc_auto">Automatic</string>
+    <string name="d1_loc_wnam">Western North America</string>
+    <string name="d1_loc_enam">Eastern North America</string>
+    <string name="d1_loc_weur">Western Europe</string>
+    <string name="d1_loc_eeur">Eastern Europe</string>
+    <string name="d1_loc_apac">Asia-Pacific</string>
+    <string name="d1_loc_oc">Oceania</string>
+    <string name="d1_delete_title">Delete database</string>
+    <string name="d1_delete_warn">This permanently deletes the database %1$s and all its tables and data. This cannot be undone or recovered.</string>
+    <string name="d1_delete_confirm_label">Type the database name to confirm</string>
+    <string name="d1_delete_button">Delete permanently</string>
+
+    <!-- Worker management -->
+    <string name="worker_manage_secrets">Variables &amp; secrets</string>
+    <string name="worker_manage_triggers">Triggers</string>
+    <string name="worker_manage_domains">Domains</string>
+    <string name="worker_secrets_title">Variables &amp; secrets</string>
+    <string name="worker_secrets_section">Secrets</string>
+    <string name="worker_secrets_empty">No secrets</string>
+    <string name="worker_secrets_add">Add secret</string>
+    <string name="worker_secrets_footer">Secret values can’t be read for security; the list shows names only. Adding the same name overwrites it.</string>
+    <string name="worker_secrets_readonly">Read-only with the current authorization (missing workers-scripts.write).</string>
+    <string name="worker_vars_section">Environment variables</string>
+    <string name="worker_vars_empty">No variables</string>
+    <string name="worker_vars_add">Add variable</string>
+    <string name="worker_vars_footer">Plain-text variables, readable and editable. Editing one doesn’t affect other bindings.</string>
+    <string name="worker_var_add_title">Add variable</string>
+    <string name="worker_var_edit_title">Edit variable</string>
+    <string name="worker_secret_add_title">Add secret</string>
+    <string name="worker_binding_name">Name</string>
+    <string name="worker_binding_name_hint">Letters, digits, underscore; must not start with a digit.</string>
+    <string name="worker_binding_value">Value</string>
+    <string name="worker_secret_value">Value (cannot be read after saving)</string>
+    <string name="worker_other_section">Other bindings (read-only)</string>
+    <string name="worker_other_footer">KV / D1 / R2 and other resource bindings are shown here; edit them with Wrangler or the dashboard.</string>
+    <string name="worker_bind_var">Variable</string>
+    <string name="worker_bind_secret">Secret</string>
+    <string name="worker_bind_queue">Queue</string>
+    <string name="worker_bind_service">Service binding</string>
+    <string name="worker_bind_browser">Browser Rendering</string>
+    <string name="worker_triggers_title">Triggers</string>
+    <string name="worker_triggers_empty_desc">Add a cron expression to run this Worker on a schedule.</string>
+    <string name="worker_triggers_add">Add trigger</string>
+    <string name="worker_triggers_footer">Cron runs in UTC.</string>
+    <string name="worker_cron_expr">Cron expression</string>
+    <string name="worker_cron_hint">Standard 5 fields: minute hour day month weekday (UTC).</string>
+    <string name="worker_cron_presets">Common</string>
+    <string name="worker_cron_5m">Every 5 minutes</string>
+    <string name="worker_cron_hourly">Every hour</string>
+    <string name="worker_cron_daily">Daily at 00:00 (UTC)</string>
+    <string name="worker_cron_weekly">Mondays at 00:00 (UTC)</string>
+    <string name="worker_cron_every_n">Every %1$d minutes</string>
+    <string name="worker_cron_desc_hourly">Every hour</string>
+    <string name="worker_cron_desc_daily">Daily at %1$s (UTC)</string>
+    <string name="worker_cron_custom">Custom cron (UTC)</string>
+    <string name="worker_domains_title">Domains</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">workers.dev subdomain</string>
+    <string name="worker_subdomain_footer">When enabled, the Worker is reachable at script.subdomain.workers.dev.</string>
+    <string name="worker_subdomain_none">workers.dev subdomain isn’t enabled for this account</string>
+    <string name="worker_customdomains_section">Custom domains</string>
+    <string name="worker_customdomains_empty">No custom domains</string>
+    <string name="worker_customdomains_add">Attach custom domain</string>
+    <string name="worker_customdomains_footer">Point a domain/subdomain straight at this Worker, no DNS or certificate setup needed.</string>
+    <string name="worker_routes_section">Routes</string>
+    <string name="worker_routes_empty">No routes</string>
+    <string name="worker_routes_add">Add route</string>
+    <string name="worker_routes_footer">Use a URL pattern (e.g. example.com/api/*) to send matching requests to this Worker.</string>
+    <string name="worker_route_zone">Domain</string>
+    <string name="worker_route_zone_pick">Select</string>
+    <string name="worker_domain_hostname">Hostname</string>
+    <string name="worker_domain_hostname_hint">Full hostname; must belong to the selected domain.</string>
+    <string name="worker_route_pattern">Route pattern</string>
+    <string name="worker_route_pattern_hint">URL pattern, wildcards allowed, e.g. example.com/*.</string>
+    <string name="worker_attach_domain_title">Attach custom domain</string>
+    <string name="worker_add_route_title">Add route</string>
+
+    <!-- Tunnel management -->
+    <string name="tunnel_new">New tunnel</string>
+    <string name="tunnel_new_name">Tunnel name</string>
+    <string name="tunnel_new_footer">Creates a remotely-managed tunnel (configured via the dashboard / this app).</string>
+    <string name="tunnel_create">Create</string>
+    <string name="tunnel_connect_section">Run command</string>
+    <string name="tunnel_connect_intro">Install cloudflared on the target machine and run the command below as an administrator to connect the tunnel.</string>
+    <string name="tunnel_connect_reveal">Show token</string>
+    <string name="tunnel_connect_hide">Hide token</string>
+    <string name="tunnel_connect_copy">Copy command</string>
+    <string name="tunnel_connect_copied">Command copied</string>
+    <string name="tunnel_connect_token_warn">The token is equivalent to tunnel credentials. Keep it safe and don’t share it publicly.</string>
+    <string name="tunnel_connect_loading">Fetching token…</string>
+    <string name="tunnel_connect_failed">Couldn’t fetch token</string>
+    <string name="tunnel_hostnames_section">Public hostnames</string>
+    <string name="tunnel_hostnames_empty">No public hostnames yet. Add one below.</string>
+    <string name="tunnel_hostnames_empty_ro">No public hostnames yet.</string>
+    <string name="tunnel_hostnames_add">Add public hostname</string>
+    <string name="tunnel_hostnames_footer">Map a public domain to a local service. A proxied CNAME is created automatically when you add one.</string>
+    <string name="tunnel_hostnames_loading">Loading configuration…</string>
+    <string name="tunnel_local_note">This tunnel is locally managed (config.yml); manage public hostnames in the cloudflared config file.</string>
+    <string name="tunnel_danger_section">Danger zone</string>
+    <string name="tunnel_cleanup">Clean up stale connections</string>
+    <string name="tunnel_cleanup_confirm_title">Clean up connections</string>
+    <string name="tunnel_cleanup_confirm_msg">Removes disconnected connection records; active cloudflared instances reconnect automatically.</string>
+    <string name="tunnel_delete">Delete tunnel</string>
+    <string name="tunnel_delete_confirm_title">Delete tunnel</string>
+    <string name="tunnel_delete_confirm_msg">This deletes the tunnel and drops its connections. This cannot be undone.</string>
+    <string name="tunnel_host_form_add">Add public hostname</string>
+    <string name="tunnel_host_form_edit">Edit public hostname</string>
+    <string name="tunnel_host_hostname">Public hostname</string>
+    <string name="tunnel_host_protocol">Protocol</string>
+    <string name="tunnel_host_service">Local service</string>
+    <string name="tunnel_host_service_footer">cloudflared forwards requests for this hostname to this local address.</string>
+    <string name="tunnel_host_service_other">Full service address, e.g. unix:/path.sock</string>
+    <string name="tunnel_host_path">Path</string>
+    <string name="tunnel_host_path_hint">Path regex (optional), e.g. /api/.*</string>
+    <string name="tunnel_proto_other">Other</string>
+
+    <!-- Help &amp; feedback -->
+    <string name="settings_help">Help &amp; feedback</string>
+    <string name="settings_help_footer">Feedback and suggestions are sent to our email with version and device info (no tokens or secrets).</string>
+    <string name="settings_feedback">Send feedback</string>
+    <string name="feedback_subject">Orange Cloud feedback</string>
+    <string name="feedback_no_mail">No email app found</string>
 </resources>

--- a/apps/android/app/src/main/res/values-en/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-en/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">From viewing to managing</string>
+    <string name="whatsnew_1_1_0_detail">You can now add domains, create and delete D1 databases and tunnels, manage Worker variables/secrets/triggers/domains, and a tunnel’s public hostname routes.</string>
+    <string name="whatsnew_1_0_0_title">One-tap OAuth sign-in</string>
+    <string name="whatsnew_1_0_0_detail">Sign in with Cloudflare\'s official authorization — no API tokens to paste.</string>
+    <string name="whatsnew_1_0_1_title">Domains · Workers · Storage</string>
+    <string name="whatsnew_1_0_1_detail">DNS, analytics, WAF, Snippets, Workers live logs, and R2/D1/KV storage — all in one place.</string>
+</resources>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -42,7 +42,7 @@
     <string name="perm_kv">Almacenamiento KV</string>
     <string name="perm_kv_desc">Leer y escribir claves-valor</string>
     <string name="perm_tunnels">Túneles</string>
-    <string name="perm_tunnels_desc">Ver Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">Ver túneles; con permiso de escritura, crear túneles y configurar rutas de nombre de host público</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">Ver y activar reglas de firewall</string>
     <string name="perm_zone_settings">Configuración del dominio</string>
@@ -372,10 +372,6 @@
 
     <string name="whatsnew_title">Novedades</string>
     <string name="whatsnew_ok">Entendido</string>
-    <string name="whatsnew_1_0_oauth_title">Inicio de sesión OAuth con un toque</string>
-    <string name="whatsnew_1_0_oauth_detail">Inicia sesión con la autorización oficial de Cloudflare, sin pegar tokens de API.</string>
-    <string name="whatsnew_1_0_modules_title">Dominios · Workers · Almacenamiento</string>
-    <string name="whatsnew_1_0_modules_detail">DNS, analíticas, WAF, Snippets, registros en vivo de Workers y almacenamiento R2/D1/KV, todo en un solo lugar.</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">Desbloquea todas las funciones premium</string>
@@ -389,4 +385,154 @@
     <string name="paywall_monthly">Mensual</string>
     <string name="paywall_lifetime">Pago único</string>
     <string name="paywall_note">Se cobra mediante Google Play; cancela cuando quieras.</string>
+
+
+    <!-- Añadir dominio -->
+    <string name="addzone_title">Añadir dominio</string>
+    <string name="addzone_domain_label">Dominio</string>
+    <string name="addzone_domain_hint">Introduce un dominio raíz que ya tengas (p. ej. example.com), sin www ni https://.</string>
+    <string name="addzone_account">Añadir a la cuenta: %1$s</string>
+    <string name="addzone_ns_note">Tras añadirlo, Cloudflare asigna dos servidores de nombres. Inicia sesión en tu registrador y cambia los NS por ellos para activar el dominio.</string>
+    <string name="addzone_add">Añadir</string>
+    <string name="addzone_pending">Pendiente de activación</string>
+    <string name="addzone_ns_title">Servidores de nombres</string>
+    <string name="addzone_copy">Copiar servidores de nombres</string>
+    <string name="addzone_copied">Copiado</string>
+    <string name="addzone_steps_title">Próximos pasos</string>
+    <string name="addzone_step1">Inicia sesión en el registrador donde compraste este dominio.</string>
+    <string name="addzone_step2">Busca la opción «Servidores de nombres».</string>
+    <string name="addzone_step3">Elimina los servidores de nombres actuales y reemplázalos por las dos direcciones de Cloudflare de arriba.</string>
+    <string name="addzone_step4">Guarda los cambios. La activación suele tardar de minutos a horas, hasta 24 horas.</string>
+    <string name="addzone_done">Listo</string>
+    <string name="addzone_ns_missing">Cloudflare aún no ha devuelto los servidores de nombres. Revisa los detalles del dominio o el panel de Cloudflare más tarde.</string>
+
+    <!-- D1 crear / eliminar -->
+    <string name="d1_create_title">Crear base de datos</string>
+    <string name="d1_create">Crear</string>
+    <string name="d1_created">Creada</string>
+    <string name="d1_name">Nombre de la base de datos</string>
+    <string name="d1_location">Ubicación principal</string>
+    <string name="d1_location_hint">La ubicación principal define dónde reside la réplica principal. Elige «Automática» para que Cloudflare la coloque cerca.</string>
+    <string name="d1_loc_auto">Automática</string>
+    <string name="d1_loc_wnam">Norteamérica occidental</string>
+    <string name="d1_loc_enam">Norteamérica oriental</string>
+    <string name="d1_loc_weur">Europa occidental</string>
+    <string name="d1_loc_eeur">Europa oriental</string>
+    <string name="d1_loc_apac">Asia-Pacífico</string>
+    <string name="d1_loc_oc">Oceanía</string>
+    <string name="d1_delete_title">Eliminar base de datos</string>
+    <string name="d1_delete_warn">Esto elimina permanentemente la base de datos %1$s y todas sus tablas y datos. No se puede deshacer ni recuperar.</string>
+    <string name="d1_delete_confirm_label">Escribe el nombre de la base de datos para confirmar</string>
+    <string name="d1_delete_button">Eliminar definitivamente</string>
+
+    <!-- Gestión de Workers -->
+    <string name="worker_manage_secrets">Variables y secretos</string>
+    <string name="worker_manage_triggers">Activadores</string>
+    <string name="worker_manage_domains">Dominios</string>
+    <string name="worker_secrets_title">Variables y secretos</string>
+    <string name="worker_secrets_section">Secretos</string>
+    <string name="worker_secrets_empty">Sin secretos</string>
+    <string name="worker_secrets_add">Añadir secreto</string>
+    <string name="worker_secrets_footer">Los valores de los secretos no se pueden leer por seguridad; la lista solo muestra nombres. Añadir el mismo nombre lo sobrescribe.</string>
+    <string name="worker_secrets_readonly">Solo lectura con la autorización actual (falta workers-scripts.write).</string>
+    <string name="worker_vars_section">Variables de entorno</string>
+    <string name="worker_vars_empty">Sin variables</string>
+    <string name="worker_vars_add">Añadir variable</string>
+    <string name="worker_vars_footer">Variables de texto plano, legibles y editables. Editar una no afecta a otros enlaces.</string>
+    <string name="worker_var_add_title">Añadir variable</string>
+    <string name="worker_var_edit_title">Editar variable</string>
+    <string name="worker_secret_add_title">Añadir secreto</string>
+    <string name="worker_binding_name">Nombre</string>
+    <string name="worker_binding_name_hint">Letras, dígitos y guion bajo; no puede empezar por dígito.</string>
+    <string name="worker_binding_value">Valor</string>
+    <string name="worker_secret_value">Valor (no se puede leer tras guardar)</string>
+    <string name="worker_other_section">Otros enlaces (solo lectura)</string>
+    <string name="worker_other_footer">Los enlaces de KV / D1 / R2 y otros recursos se muestran aquí; edítalos con Wrangler o el panel.</string>
+    <string name="worker_bind_var">Variable</string>
+    <string name="worker_bind_secret">Secreto</string>
+    <string name="worker_bind_queue">Cola</string>
+    <string name="worker_bind_service">Enlace de servicio</string>
+    <string name="worker_bind_browser">Renderizado del navegador</string>
+    <string name="worker_triggers_title">Activadores</string>
+    <string name="worker_triggers_empty_desc">Añade una expresión cron para ejecutar este Worker de forma programada.</string>
+    <string name="worker_triggers_add">Añadir activador</string>
+    <string name="worker_triggers_footer">Cron se ejecuta en UTC.</string>
+    <string name="worker_cron_expr">Expresión cron</string>
+    <string name="worker_cron_hint">5 campos estándar: minuto hora día mes día de la semana (UTC).</string>
+    <string name="worker_cron_presets">Comunes</string>
+    <string name="worker_cron_5m">Cada 5 minutos</string>
+    <string name="worker_cron_hourly">Cada hora</string>
+    <string name="worker_cron_daily">Cada día a las 00:00 (UTC)</string>
+    <string name="worker_cron_weekly">Los lunes a las 00:00 (UTC)</string>
+    <string name="worker_cron_every_n">Cada %1$d minutos</string>
+    <string name="worker_cron_desc_hourly">Cada hora</string>
+    <string name="worker_cron_desc_daily">Cada día a las %1$s (UTC)</string>
+    <string name="worker_cron_custom">Cron personalizado (UTC)</string>
+    <string name="worker_domains_title">Dominios</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">Subdominio workers.dev</string>
+    <string name="worker_subdomain_footer">Si se activa, el Worker es accesible en script.subdominio.workers.dev.</string>
+    <string name="worker_subdomain_none">El subdominio workers.dev no está activado para esta cuenta</string>
+    <string name="worker_customdomains_section">Dominios personalizados</string>
+    <string name="worker_customdomains_empty">Sin dominios personalizados</string>
+    <string name="worker_customdomains_add">Vincular dominio personalizado</string>
+    <string name="worker_customdomains_footer">Apunta un dominio/subdominio directamente a este Worker, sin configurar DNS ni certificados.</string>
+    <string name="worker_routes_section">Rutas</string>
+    <string name="worker_routes_empty">Sin rutas</string>
+    <string name="worker_routes_add">Añadir ruta</string>
+    <string name="worker_routes_footer">Usa un patrón de URL (p. ej. example.com/api/*) para enviar las solicitudes coincidentes a este Worker.</string>
+    <string name="worker_route_zone">Dominio</string>
+    <string name="worker_route_zone_pick">Selecciona</string>
+    <string name="worker_domain_hostname">Nombre de host</string>
+    <string name="worker_domain_hostname_hint">Nombre de host completo; debe pertenecer al dominio seleccionado.</string>
+    <string name="worker_route_pattern">Patrón de ruta</string>
+    <string name="worker_route_pattern_hint">Patrón de URL, se permiten comodines, p. ej. example.com/*.</string>
+    <string name="worker_attach_domain_title">Vincular dominio personalizado</string>
+    <string name="worker_add_route_title">Añadir ruta</string>
+
+    <!-- Gestión de túneles -->
+    <string name="tunnel_new">Nuevo túnel</string>
+    <string name="tunnel_new_name">Nombre del túnel</string>
+    <string name="tunnel_new_footer">Crea un túnel gestionado de forma remota (configurado desde el panel / esta app).</string>
+    <string name="tunnel_create">Crear</string>
+    <string name="tunnel_connect_section">Ejecutar comando</string>
+    <string name="tunnel_connect_intro">Instala cloudflared en la máquina de destino y ejecuta el siguiente comando como administrador para conectar el túnel.</string>
+    <string name="tunnel_connect_reveal">Mostrar token</string>
+    <string name="tunnel_connect_hide">Ocultar token</string>
+    <string name="tunnel_connect_copy">Copiar comando</string>
+    <string name="tunnel_connect_copied">Comando copiado</string>
+    <string name="tunnel_connect_token_warn">El token equivale a las credenciales del túnel. Guárdalo bien y no lo compartas públicamente.</string>
+    <string name="tunnel_connect_loading">Obteniendo token…</string>
+    <string name="tunnel_connect_failed">No se pudo obtener el token</string>
+    <string name="tunnel_hostnames_section">Nombres de host públicos</string>
+    <string name="tunnel_hostnames_empty">Aún no hay nombres de host públicos. Añade uno abajo.</string>
+    <string name="tunnel_hostnames_empty_ro">Aún no hay nombres de host públicos.</string>
+    <string name="tunnel_hostnames_add">Añadir nombre de host público</string>
+    <string name="tunnel_hostnames_footer">Asigna un dominio público a un servicio local. Al añadir uno se crea automáticamente un CNAME con proxy.</string>
+    <string name="tunnel_hostnames_loading">Cargando configuración…</string>
+    <string name="tunnel_local_note">Este túnel se gestiona localmente (config.yml); administra los nombres de host públicos en el archivo de configuración de cloudflared.</string>
+    <string name="tunnel_danger_section">Zona de peligro</string>
+    <string name="tunnel_cleanup">Limpiar conexiones inactivas</string>
+    <string name="tunnel_cleanup_confirm_title">Limpiar conexiones</string>
+    <string name="tunnel_cleanup_confirm_msg">Elimina los registros de conexiones desconectadas; las instancias activas de cloudflared se reconectan automáticamente.</string>
+    <string name="tunnel_delete">Eliminar túnel</string>
+    <string name="tunnel_delete_confirm_title">Eliminar túnel</string>
+    <string name="tunnel_delete_confirm_msg">Esto elimina el túnel y corta sus conexiones. No se puede deshacer.</string>
+    <string name="tunnel_host_form_add">Añadir nombre de host público</string>
+    <string name="tunnel_host_form_edit">Editar nombre de host público</string>
+    <string name="tunnel_host_hostname">Nombre de host público</string>
+    <string name="tunnel_host_protocol">Protocolo</string>
+    <string name="tunnel_host_service">Servicio local</string>
+    <string name="tunnel_host_service_footer">cloudflared reenvía las solicitudes de este nombre de host a esta dirección local.</string>
+    <string name="tunnel_host_service_other">Dirección de servicio completa, p. ej. unix:/path.sock</string>
+    <string name="tunnel_host_path">Ruta</string>
+    <string name="tunnel_host_path_hint">Regex de ruta (opcional), p. ej. /api/.*</string>
+    <string name="tunnel_proto_other">Otro</string>
+
+    <!-- Ayuda y comentarios -->
+    <string name="settings_help">Ayuda y comentarios</string>
+    <string name="settings_help_footer">Los comentarios y sugerencias se envían a nuestro correo con la versión y datos del dispositivo (sin tokens ni secretos).</string>
+    <string name="settings_feedback">Enviar comentarios</string>
+    <string name="feedback_subject">Comentarios de Orange Cloud</string>
+    <string name="feedback_no_mail">No se encontró ninguna app de correo</string>
 </resources>

--- a/apps/android/app/src/main/res/values-es/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-es/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">De ver a gestionar</string>
+    <string name="whatsnew_1_1_0_detail">Ahora puedes añadir dominios, crear y eliminar bases de datos D1 y túneles, gestionar variables/secretos/activadores/dominios de Workers y las rutas de nombre de host público de un túnel.</string>
+    <string name="whatsnew_1_0_0_title">Inicio de sesión OAuth con un toque</string>
+    <string name="whatsnew_1_0_0_detail">Inicia sesión con la autorización oficial de Cloudflare, sin pegar tokens de API.</string>
+    <string name="whatsnew_1_0_1_title">Dominios · Workers · Almacenamiento</string>
+    <string name="whatsnew_1_0_1_detail">DNS, analíticas, WAF, Snippets, registros en vivo de Workers y almacenamiento R2/D1/KV, todo en un solo lugar.</string>
+</resources>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -41,7 +41,7 @@
     <string name="perm_kv">KV ストレージ</string>
     <string name="perm_kv_desc">キー値の読み書き</string>
     <string name="perm_tunnels">トンネル</string>
-    <string name="perm_tunnels_desc">Cloudflare Tunnel を表示</string>
+    <string name="perm_tunnels_desc">トンネルの表示。読み書き権限で作成や公開ホスト名ルートの設定が可能</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">ファイアウォールルールの表示と切替</string>
     <string name="perm_zone_settings">ドメイン設定</string>
@@ -371,10 +371,6 @@
 
     <string name="whatsnew_title">新機能</string>
     <string name="whatsnew_ok">OK</string>
-    <string name="whatsnew_1_0_oauth_title">OAuth ワンタップログイン</string>
-    <string name="whatsnew_1_0_oauth_detail">Cloudflare 公式の認証でログイン。API トークンの貼り付けは不要です。</string>
-    <string name="whatsnew_1_0_modules_title">ドメイン · Workers · ストレージ</string>
-    <string name="whatsnew_1_0_modules_detail">DNS、トラフィック分析、WAF、Snippets、Workers リアルタイムログ、R2/D1/KV ストレージをすべて網羅。</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">すべてのプレミアム機能をアンロック</string>
@@ -388,4 +384,154 @@
     <string name="paywall_monthly">月額</string>
     <string name="paywall_lifetime">買い切り</string>
     <string name="paywall_note">Google Play で課金。いつでもキャンセルできます。</string>
+
+
+    <!-- ドメインを追加 -->
+    <string name="addzone_title">ドメインを追加</string>
+    <string name="addzone_domain_label">ドメイン</string>
+    <string name="addzone_domain_hint">所有しているルートドメイン（例: example.com）を入力します。www や https:// は不要です。</string>
+    <string name="addzone_account">追加先アカウント: %1$s</string>
+    <string name="addzone_ns_note">追加すると Cloudflare が 2 つのネームサーバーを割り当てます。レジストラにログインし、NS をそれらに変更するとドメインが有効になります。</string>
+    <string name="addzone_add">追加</string>
+    <string name="addzone_pending">有効化待ち</string>
+    <string name="addzone_ns_title">ネームサーバー</string>
+    <string name="addzone_copy">ネームサーバーをコピー</string>
+    <string name="addzone_copied">コピーしました</string>
+    <string name="addzone_steps_title">次のステップ</string>
+    <string name="addzone_step1">このドメインを購入したレジストラにログインします。</string>
+    <string name="addzone_step2">「ネームサーバー」設定を見つけます。</string>
+    <string name="addzone_step3">既存のネームサーバーを削除し、上記 2 つの Cloudflare アドレスに置き換えます。</string>
+    <string name="addzone_step4">変更を保存します。有効化には通常数分〜数時間、最大 24 時間かかります。</string>
+    <string name="addzone_done">完了</string>
+    <string name="addzone_ns_missing">Cloudflare がまだネームサーバーを返していません。後でドメイン詳細または Cloudflare ダッシュボードでご確認ください。</string>
+
+    <!-- D1 作成 / 削除 -->
+    <string name="d1_create_title">データベースを作成</string>
+    <string name="d1_create">作成</string>
+    <string name="d1_created">作成しました</string>
+    <string name="d1_name">データベース名</string>
+    <string name="d1_location">プライマリの場所</string>
+    <string name="d1_location_hint">プライマリの場所は主レプリカが置かれるリージョンを決めます。「自動」を選ぶと Cloudflare が近くに配置します。</string>
+    <string name="d1_loc_auto">自動</string>
+    <string name="d1_loc_wnam">北米西部</string>
+    <string name="d1_loc_enam">北米東部</string>
+    <string name="d1_loc_weur">ヨーロッパ西部</string>
+    <string name="d1_loc_eeur">ヨーロッパ東部</string>
+    <string name="d1_loc_apac">アジア太平洋</string>
+    <string name="d1_loc_oc">オセアニア</string>
+    <string name="d1_delete_title">データベースを削除</string>
+    <string name="d1_delete_warn">データベース %1$s とそのすべてのテーブル・データを完全に削除します。取り消しや復元はできません。</string>
+    <string name="d1_delete_confirm_label">確認のためデータベース名を入力</string>
+    <string name="d1_delete_button">完全に削除</string>
+
+    <!-- Worker 管理 -->
+    <string name="worker_manage_secrets">変数とシークレット</string>
+    <string name="worker_manage_triggers">トリガー</string>
+    <string name="worker_manage_domains">ドメイン</string>
+    <string name="worker_secrets_title">変数とシークレット</string>
+    <string name="worker_secrets_section">シークレット</string>
+    <string name="worker_secrets_empty">シークレットはありません</string>
+    <string name="worker_secrets_add">シークレットを追加</string>
+    <string name="worker_secrets_footer">シークレットの値はセキュリティのため読み取れません。一覧は名前のみ表示します。同名で追加すると上書きされます。</string>
+    <string name="worker_secrets_readonly">現在の認可では表示のみ可能です（workers-scripts.write がありません）。</string>
+    <string name="worker_vars_section">環境変数</string>
+    <string name="worker_vars_empty">変数はありません</string>
+    <string name="worker_vars_add">変数を追加</string>
+    <string name="worker_vars_footer">プレーンテキスト変数で、閲覧・編集できます。1 つを変更しても他のバインディングには影響しません。</string>
+    <string name="worker_var_add_title">変数を追加</string>
+    <string name="worker_var_edit_title">変数を編集</string>
+    <string name="worker_secret_add_title">シークレットを追加</string>
+    <string name="worker_binding_name">名前</string>
+    <string name="worker_binding_name_hint">英字・数字・アンダースコア。数字で始められません。</string>
+    <string name="worker_binding_value">値</string>
+    <string name="worker_secret_value">値（保存後は読み取り不可）</string>
+    <string name="worker_other_section">その他のバインディング（読み取り専用）</string>
+    <string name="worker_other_footer">KV / D1 / R2 などのリソースバインディングはここで確認できます。編集は Wrangler またはダッシュボードで行ってください。</string>
+    <string name="worker_bind_var">変数</string>
+    <string name="worker_bind_secret">シークレット</string>
+    <string name="worker_bind_queue">キュー</string>
+    <string name="worker_bind_service">Service バインディング</string>
+    <string name="worker_bind_browser">ブラウザレンダリング</string>
+    <string name="worker_triggers_title">トリガー</string>
+    <string name="worker_triggers_empty_desc">cron 式を追加して、この Worker をスケジュール実行します。</string>
+    <string name="worker_triggers_add">トリガーを追加</string>
+    <string name="worker_triggers_footer">cron は UTC で実行されます。</string>
+    <string name="worker_cron_expr">cron 式</string>
+    <string name="worker_cron_hint">標準 5 フィールド: 分 時 日 月 曜日（UTC）。</string>
+    <string name="worker_cron_presets">よく使う設定</string>
+    <string name="worker_cron_5m">5 分ごと</string>
+    <string name="worker_cron_hourly">毎時</string>
+    <string name="worker_cron_daily">毎日 0:00（UTC）</string>
+    <string name="worker_cron_weekly">毎週月曜 0:00（UTC）</string>
+    <string name="worker_cron_every_n">%1$d 分ごと</string>
+    <string name="worker_cron_desc_hourly">毎時</string>
+    <string name="worker_cron_desc_daily">毎日 %1$s（UTC）</string>
+    <string name="worker_cron_custom">カスタム cron（UTC）</string>
+    <string name="worker_domains_title">ドメイン</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">workers.dev サブドメイン</string>
+    <string name="worker_subdomain_footer">有効にすると、この Worker は スクリプト名.サブドメイン.workers.dev でアクセスできます。</string>
+    <string name="worker_subdomain_none">このアカウントでは workers.dev サブドメインが有効になっていません</string>
+    <string name="worker_customdomains_section">カスタムドメイン</string>
+    <string name="worker_customdomains_empty">カスタムドメインはありません</string>
+    <string name="worker_customdomains_add">カスタムドメインを接続</string>
+    <string name="worker_customdomains_footer">ドメイン/サブドメインを直接この Worker に向けます。DNS や証明書の設定は不要です。</string>
+    <string name="worker_routes_section">ルート</string>
+    <string name="worker_routes_empty">ルートはありません</string>
+    <string name="worker_routes_add">ルートを追加</string>
+    <string name="worker_routes_footer">URL パターン（例: example.com/api/*）で一致するリクエストをこの Worker に渡します。</string>
+    <string name="worker_route_zone">ドメイン</string>
+    <string name="worker_route_zone_pick">選択してください</string>
+    <string name="worker_domain_hostname">ホスト名</string>
+    <string name="worker_domain_hostname_hint">完全なホスト名。選択したドメインに属している必要があります。</string>
+    <string name="worker_route_pattern">ルートパターン</string>
+    <string name="worker_route_pattern_hint">URL パターン。ワイルドカード可（例: example.com/*）。</string>
+    <string name="worker_attach_domain_title">カスタムドメインを接続</string>
+    <string name="worker_add_route_title">ルートを追加</string>
+
+    <!-- トンネル管理 -->
+    <string name="tunnel_new">新しいトンネル</string>
+    <string name="tunnel_new_name">トンネル名</string>
+    <string name="tunnel_new_footer">リモート管理トンネルを作成します（ダッシュボード／本アプリで構成）。</string>
+    <string name="tunnel_create">作成</string>
+    <string name="tunnel_connect_section">実行コマンド</string>
+    <string name="tunnel_connect_intro">対象マシンに cloudflared をインストールし、以下のコマンドを管理者として実行するとトンネルが接続されます。</string>
+    <string name="tunnel_connect_reveal">トークンを表示</string>
+    <string name="tunnel_connect_hide">トークンを隠す</string>
+    <string name="tunnel_connect_copy">コマンドをコピー</string>
+    <string name="tunnel_connect_copied">コマンドをコピーしました</string>
+    <string name="tunnel_connect_token_warn">トークンはトンネルの認証情報に相当します。大切に保管し、公開しないでください。</string>
+    <string name="tunnel_connect_loading">トークンを取得中…</string>
+    <string name="tunnel_connect_failed">トークンを取得できませんでした</string>
+    <string name="tunnel_hostnames_section">公開ホスト名</string>
+    <string name="tunnel_hostnames_empty">公開ホスト名はまだありません。下から追加してください。</string>
+    <string name="tunnel_hostnames_empty_ro">公開ホスト名はまだありません。</string>
+    <string name="tunnel_hostnames_add">公開ホスト名を追加</string>
+    <string name="tunnel_hostnames_footer">外部ドメインをローカルサービスにマッピングします。追加時にプロキシ済み CNAME が自動作成されます。</string>
+    <string name="tunnel_hostnames_loading">構成を読み込み中…</string>
+    <string name="tunnel_local_note">このトンネルはローカル管理（config.yml）です。公開ホスト名は cloudflared 設定ファイルで管理してください。</string>
+    <string name="tunnel_danger_section">危険な操作</string>
+    <string name="tunnel_cleanup">停止した接続を整理</string>
+    <string name="tunnel_cleanup_confirm_title">接続を整理</string>
+    <string name="tunnel_cleanup_confirm_msg">切断された接続記録を削除します。稼働中の cloudflared は自動的に再接続します。</string>
+    <string name="tunnel_delete">トンネルを削除</string>
+    <string name="tunnel_delete_confirm_title">トンネルを削除</string>
+    <string name="tunnel_delete_confirm_msg">このトンネルを削除し、接続を切断します。取り消せません。</string>
+    <string name="tunnel_host_form_add">公開ホスト名を追加</string>
+    <string name="tunnel_host_form_edit">公開ホスト名を編集</string>
+    <string name="tunnel_host_hostname">公開ホスト名</string>
+    <string name="tunnel_host_protocol">プロトコル</string>
+    <string name="tunnel_host_service">ローカルサービス</string>
+    <string name="tunnel_host_service_footer">cloudflared はこのホスト名宛てのリクエストをこのローカルアドレスへ転送します。</string>
+    <string name="tunnel_host_service_other">完全なサービスアドレス（例: unix:/path.sock）</string>
+    <string name="tunnel_host_path">パス</string>
+    <string name="tunnel_host_path_hint">パスの正規表現（任意）。例: /api/.*</string>
+    <string name="tunnel_proto_other">その他</string>
+
+    <!-- ヘルプとフィードバック -->
+    <string name="settings_help">ヘルプとフィードバック</string>
+    <string name="settings_help_footer">フィードバックや提案はバージョン・端末情報（トークンやシークレットは含みません）とともにメールで送信されます。</string>
+    <string name="settings_feedback">フィードバックを送信</string>
+    <string name="feedback_subject">Orange Cloud フィードバック</string>
+    <string name="feedback_no_mail">メールアプリが見つかりません</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ja/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ja/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">表示から管理へ</string>
+    <string name="whatsnew_1_1_0_detail">ドメインの追加、D1 データベースとトンネルの作成・削除、Worker の変数/シークレット/トリガー/ドメイン、トンネルの公開ホスト名ルートを管理できるようになりました。</string>
+    <string name="whatsnew_1_0_0_title">OAuth ワンタップログイン</string>
+    <string name="whatsnew_1_0_0_detail">Cloudflare 公式の認証でログイン。API トークンの貼り付けは不要です。</string>
+    <string name="whatsnew_1_0_1_title">ドメイン · Workers · ストレージ</string>
+    <string name="whatsnew_1_0_1_detail">DNS、トラフィック分析、WAF、Snippets、Workers リアルタイムログ、R2/D1/KV ストレージをすべて網羅。</string>
+</resources>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -41,7 +41,7 @@
     <string name="perm_kv">KV 스토리지</string>
     <string name="perm_kv_desc">키-값 읽기/쓰기</string>
     <string name="perm_tunnels">터널</string>
-    <string name="perm_tunnels_desc">Cloudflare Tunnel 보기</string>
+    <string name="perm_tunnels_desc">터널 보기. 읽기/쓰기 권한으로 터널 생성 및 공개 호스트 이름 경로 구성 가능</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">방화벽 규칙 보기 및 켜기/끄기</string>
     <string name="perm_zone_settings">도메인 설정</string>
@@ -371,10 +371,6 @@
 
     <string name="whatsnew_title">새로운 기능</string>
     <string name="whatsnew_ok">확인</string>
-    <string name="whatsnew_1_0_oauth_title">OAuth 원탭 로그인</string>
-    <string name="whatsnew_1_0_oauth_detail">Cloudflare 공식 인증으로 로그인하며 API 토큰을 붙여넣을 필요가 없습니다.</string>
-    <string name="whatsnew_1_0_modules_title">도메인 · Workers · 스토리지</string>
-    <string name="whatsnew_1_0_modules_detail">DNS, 트래픽 분석, WAF, Snippets, Workers 실시간 로그, R2/D1/KV 스토리지까지 한곳에서.</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">모든 프리미엄 기능 잠금 해제</string>
@@ -388,4 +384,154 @@
     <string name="paywall_monthly">월간</string>
     <string name="paywall_lifetime">평생 이용권</string>
     <string name="paywall_note">Google Play를 통해 청구되며 언제든 취소할 수 있습니다.</string>
+
+
+    <!-- 도메인 추가 -->
+    <string name="addzone_title">도메인 추가</string>
+    <string name="addzone_domain_label">도메인</string>
+    <string name="addzone_domain_hint">이미 보유한 루트 도메인(예: example.com)을 입력하세요. www나 https://는 필요 없습니다.</string>
+    <string name="addzone_account">추가할 계정: %1$s</string>
+    <string name="addzone_ns_note">추가하면 Cloudflare가 네임서버 2개를 할당합니다. 등록기관에 로그인해 NS를 해당 값으로 변경하면 도메인이 활성화됩니다.</string>
+    <string name="addzone_add">추가</string>
+    <string name="addzone_pending">활성화 대기 중</string>
+    <string name="addzone_ns_title">네임서버</string>
+    <string name="addzone_copy">네임서버 복사</string>
+    <string name="addzone_copied">복사됨</string>
+    <string name="addzone_steps_title">다음 단계</string>
+    <string name="addzone_step1">이 도메인을 구매한 등록기관에 로그인합니다.</string>
+    <string name="addzone_step2">"네임서버" 설정을 찾습니다.</string>
+    <string name="addzone_step3">기존 네임서버를 삭제하고 위의 Cloudflare 주소 2개로 교체합니다.</string>
+    <string name="addzone_step4">변경 사항을 저장합니다. 활성화는 보통 몇 분에서 몇 시간, 최대 24시간이 걸립니다.</string>
+    <string name="addzone_done">완료</string>
+    <string name="addzone_ns_missing">Cloudflare가 아직 네임서버를 반환하지 않았습니다. 나중에 도메인 세부 정보나 Cloudflare 대시보드에서 확인하세요.</string>
+
+    <!-- D1 생성 / 삭제 -->
+    <string name="d1_create_title">데이터베이스 만들기</string>
+    <string name="d1_create">만들기</string>
+    <string name="d1_created">생성됨</string>
+    <string name="d1_name">데이터베이스 이름</string>
+    <string name="d1_location">기본 위치</string>
+    <string name="d1_location_hint">기본 위치는 기본 복제본이 위치할 지역을 결정합니다. "자동"을 선택하면 Cloudflare가 가까운 곳에 배치합니다.</string>
+    <string name="d1_loc_auto">자동</string>
+    <string name="d1_loc_wnam">북미 서부</string>
+    <string name="d1_loc_enam">북미 동부</string>
+    <string name="d1_loc_weur">유럽 서부</string>
+    <string name="d1_loc_eeur">유럽 동부</string>
+    <string name="d1_loc_apac">아시아 태평양</string>
+    <string name="d1_loc_oc">오세아니아</string>
+    <string name="d1_delete_title">데이터베이스 삭제</string>
+    <string name="d1_delete_warn">데이터베이스 %1$s와 모든 테이블 및 데이터를 영구적으로 삭제합니다. 취소하거나 복구할 수 없습니다.</string>
+    <string name="d1_delete_confirm_label">확인을 위해 데이터베이스 이름 입력</string>
+    <string name="d1_delete_button">영구 삭제</string>
+
+    <!-- Worker 관리 -->
+    <string name="worker_manage_secrets">변수 및 시크릿</string>
+    <string name="worker_manage_triggers">트리거</string>
+    <string name="worker_manage_domains">도메인</string>
+    <string name="worker_secrets_title">변수 및 시크릿</string>
+    <string name="worker_secrets_section">시크릿</string>
+    <string name="worker_secrets_empty">시크릿 없음</string>
+    <string name="worker_secrets_add">시크릿 추가</string>
+    <string name="worker_secrets_footer">시크릿 값은 보안을 위해 읽을 수 없으며 목록에는 이름만 표시됩니다. 같은 이름으로 추가하면 덮어씁니다.</string>
+    <string name="worker_secrets_readonly">현재 권한으로는 보기만 가능합니다(workers-scripts.write 없음).</string>
+    <string name="worker_vars_section">환경 변수</string>
+    <string name="worker_vars_empty">변수 없음</string>
+    <string name="worker_vars_add">변수 추가</string>
+    <string name="worker_vars_footer">평문 변수로 읽고 편집할 수 있습니다. 하나를 변경해도 다른 바인딩에는 영향을 주지 않습니다.</string>
+    <string name="worker_var_add_title">변수 추가</string>
+    <string name="worker_var_edit_title">변수 편집</string>
+    <string name="worker_secret_add_title">시크릿 추가</string>
+    <string name="worker_binding_name">이름</string>
+    <string name="worker_binding_name_hint">영문자, 숫자, 밑줄. 숫자로 시작할 수 없습니다.</string>
+    <string name="worker_binding_value">값</string>
+    <string name="worker_secret_value">값(저장 후 읽을 수 없음)</string>
+    <string name="worker_other_section">기타 바인딩(읽기 전용)</string>
+    <string name="worker_other_footer">KV / D1 / R2 등 리소스 바인딩은 여기에서 확인합니다. 편집은 Wrangler나 대시보드를 사용하세요.</string>
+    <string name="worker_bind_var">변수</string>
+    <string name="worker_bind_secret">시크릿</string>
+    <string name="worker_bind_queue">큐</string>
+    <string name="worker_bind_service">서비스 바인딩</string>
+    <string name="worker_bind_browser">브라우저 렌더링</string>
+    <string name="worker_triggers_title">트리거</string>
+    <string name="worker_triggers_empty_desc">cron 식을 추가해 이 Worker를 예약 실행하세요.</string>
+    <string name="worker_triggers_add">트리거 추가</string>
+    <string name="worker_triggers_footer">cron은 UTC로 실행됩니다.</string>
+    <string name="worker_cron_expr">cron 식</string>
+    <string name="worker_cron_hint">표준 5개 필드: 분 시 일 월 요일(UTC).</string>
+    <string name="worker_cron_presets">자주 쓰는 설정</string>
+    <string name="worker_cron_5m">5분마다</string>
+    <string name="worker_cron_hourly">매시간</string>
+    <string name="worker_cron_daily">매일 00:00(UTC)</string>
+    <string name="worker_cron_weekly">매주 월요일 00:00(UTC)</string>
+    <string name="worker_cron_every_n">%1$d분마다</string>
+    <string name="worker_cron_desc_hourly">매시간</string>
+    <string name="worker_cron_desc_daily">매일 %1$s(UTC)</string>
+    <string name="worker_cron_custom">사용자 지정 cron(UTC)</string>
+    <string name="worker_domains_title">도메인</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">workers.dev 서브도메인</string>
+    <string name="worker_subdomain_footer">활성화하면 이 Worker에 스크립트.서브도메인.workers.dev로 접근할 수 있습니다.</string>
+    <string name="worker_subdomain_none">이 계정에는 workers.dev 서브도메인이 활성화되어 있지 않습니다</string>
+    <string name="worker_customdomains_section">사용자 지정 도메인</string>
+    <string name="worker_customdomains_empty">사용자 지정 도메인 없음</string>
+    <string name="worker_customdomains_add">사용자 지정 도메인 연결</string>
+    <string name="worker_customdomains_footer">도메인/서브도메인을 이 Worker로 바로 연결합니다. DNS나 인증서 설정이 필요 없습니다.</string>
+    <string name="worker_routes_section">경로</string>
+    <string name="worker_routes_empty">경로 없음</string>
+    <string name="worker_routes_add">경로 추가</string>
+    <string name="worker_routes_footer">URL 패턴(예: example.com/api/*)으로 일치하는 요청을 이 Worker로 보냅니다.</string>
+    <string name="worker_route_zone">도메인</string>
+    <string name="worker_route_zone_pick">선택하세요</string>
+    <string name="worker_domain_hostname">호스트 이름</string>
+    <string name="worker_domain_hostname_hint">전체 호스트 이름이며 선택한 도메인에 속해야 합니다.</string>
+    <string name="worker_route_pattern">경로 패턴</string>
+    <string name="worker_route_pattern_hint">URL 패턴, 와일드카드 허용, 예: example.com/*.</string>
+    <string name="worker_attach_domain_title">사용자 지정 도메인 연결</string>
+    <string name="worker_add_route_title">경로 추가</string>
+
+    <!-- 터널 관리 -->
+    <string name="tunnel_new">새 터널</string>
+    <string name="tunnel_new_name">터널 이름</string>
+    <string name="tunnel_new_footer">원격 관리 터널을 만듭니다(대시보드/이 앱에서 구성).</string>
+    <string name="tunnel_create">만들기</string>
+    <string name="tunnel_connect_section">실행 명령</string>
+    <string name="tunnel_connect_intro">대상 컴퓨터에 cloudflared를 설치하고 아래 명령을 관리자 권한으로 실행하면 터널이 연결됩니다.</string>
+    <string name="tunnel_connect_reveal">토큰 표시</string>
+    <string name="tunnel_connect_hide">토큰 숨기기</string>
+    <string name="tunnel_connect_copy">명령 복사</string>
+    <string name="tunnel_connect_copied">명령 복사됨</string>
+    <string name="tunnel_connect_token_warn">토큰은 터널 자격 증명과 같습니다. 안전하게 보관하고 공개하지 마세요.</string>
+    <string name="tunnel_connect_loading">토큰 가져오는 중…</string>
+    <string name="tunnel_connect_failed">토큰을 가져올 수 없습니다</string>
+    <string name="tunnel_hostnames_section">공개 호스트 이름</string>
+    <string name="tunnel_hostnames_empty">아직 공개 호스트 이름이 없습니다. 아래에서 추가하세요.</string>
+    <string name="tunnel_hostnames_empty_ro">아직 공개 호스트 이름이 없습니다.</string>
+    <string name="tunnel_hostnames_add">공개 호스트 이름 추가</string>
+    <string name="tunnel_hostnames_footer">외부 도메인을 로컬 서비스에 매핑합니다. 추가 시 프록시된 CNAME이 자동으로 생성됩니다.</string>
+    <string name="tunnel_hostnames_loading">구성 불러오는 중…</string>
+    <string name="tunnel_local_note">이 터널은 로컬 관리(config.yml)입니다. 공개 호스트 이름은 cloudflared 구성 파일에서 관리하세요.</string>
+    <string name="tunnel_danger_section">위험 영역</string>
+    <string name="tunnel_cleanup">비활성 연결 정리</string>
+    <string name="tunnel_cleanup_confirm_title">연결 정리</string>
+    <string name="tunnel_cleanup_confirm_msg">끊긴 연결 기록을 제거합니다. 실행 중인 cloudflared는 자동으로 다시 연결됩니다.</string>
+    <string name="tunnel_delete">터널 삭제</string>
+    <string name="tunnel_delete_confirm_title">터널 삭제</string>
+    <string name="tunnel_delete_confirm_msg">이 터널을 삭제하고 연결을 끊습니다. 취소할 수 없습니다.</string>
+    <string name="tunnel_host_form_add">공개 호스트 이름 추가</string>
+    <string name="tunnel_host_form_edit">공개 호스트 이름 편집</string>
+    <string name="tunnel_host_hostname">공개 호스트 이름</string>
+    <string name="tunnel_host_protocol">프로토콜</string>
+    <string name="tunnel_host_service">로컬 서비스</string>
+    <string name="tunnel_host_service_footer">cloudflared는 이 호스트 이름에 대한 요청을 이 로컬 주소로 전달합니다.</string>
+    <string name="tunnel_host_service_other">전체 서비스 주소, 예: unix:/path.sock</string>
+    <string name="tunnel_host_path">경로</string>
+    <string name="tunnel_host_path_hint">경로 정규식(선택), 예: /api/.*</string>
+    <string name="tunnel_proto_other">기타</string>
+
+    <!-- 도움말 및 피드백 -->
+    <string name="settings_help">도움말 및 피드백</string>
+    <string name="settings_help_footer">피드백과 제안은 버전 및 기기 정보(토큰이나 시크릿 제외)와 함께 이메일로 전송됩니다.</string>
+    <string name="settings_feedback">피드백 보내기</string>
+    <string name="feedback_subject">Orange Cloud 피드백</string>
+    <string name="feedback_no_mail">이메일 앱을 찾을 수 없습니다</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ko/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">보기에서 관리로</string>
+    <string name="whatsnew_1_1_0_detail">이제 도메인 추가, D1 데이터베이스·터널 생성 및 삭제, Worker 변수/시크릿/트리거/도메인, 터널 공개 호스트 이름 경로를 관리할 수 있습니다.</string>
+    <string name="whatsnew_1_0_0_title">OAuth 원탭 로그인</string>
+    <string name="whatsnew_1_0_0_detail">Cloudflare 공식 인증으로 로그인하며 API 토큰을 붙여넣을 필요가 없습니다.</string>
+    <string name="whatsnew_1_0_1_title">도메인 · Workers · 스토리지</string>
+    <string name="whatsnew_1_0_1_detail">DNS, 트래픽 분석, WAF, Snippets, Workers 실시간 로그, R2/D1/KV 스토리지까지 한곳에서.</string>
+</resources>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -41,7 +41,7 @@
     <string name="perm_kv">Armazenamento KV</string>
     <string name="perm_kv_desc">Ler e gravar chave-valor</string>
     <string name="perm_tunnels">Túneis</string>
-    <string name="perm_tunnels_desc">Ver Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">Ver túneis; com acesso de escrita, criar túneis e configurar rotas de nome de host público</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">Ver e alternar regras de firewall</string>
     <string name="perm_zone_settings">Configurações do domínio</string>
@@ -371,10 +371,6 @@
 
     <string name="whatsnew_title">Novidades</string>
     <string name="whatsnew_ok">Entendi</string>
-    <string name="whatsnew_1_0_oauth_title">Login OAuth com um toque</string>
-    <string name="whatsnew_1_0_oauth_detail">Entre com a autorização oficial da Cloudflare, sem colar tokens de API.</string>
-    <string name="whatsnew_1_0_modules_title">Domínios · Workers · Armazenamento</string>
-    <string name="whatsnew_1_0_modules_detail">DNS, análises, WAF, Snippets, logs ao vivo de Workers e armazenamento R2/D1/KV, tudo em um só lugar.</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">Desbloqueie todos os recursos premium</string>
@@ -388,4 +384,154 @@
     <string name="paywall_monthly">Mensal</string>
     <string name="paywall_lifetime">Pagamento único</string>
     <string name="paywall_note">Cobrado pelo Google Play; cancele quando quiser.</string>
+
+
+    <!-- Adicionar domínio -->
+    <string name="addzone_title">Adicionar domínio</string>
+    <string name="addzone_domain_label">Domínio</string>
+    <string name="addzone_domain_hint">Digite um domínio raiz que você já possui (ex.: example.com), sem www nem https://.</string>
+    <string name="addzone_account">Adicionar à conta: %1$s</string>
+    <string name="addzone_ns_note">Após adicionar, a Cloudflare atribui dois servidores de nomes. Entre no seu registrador e troque os NS por eles para ativar o domínio.</string>
+    <string name="addzone_add">Adicionar</string>
+    <string name="addzone_pending">Aguardando ativação</string>
+    <string name="addzone_ns_title">Servidores de nomes</string>
+    <string name="addzone_copy">Copiar servidores de nomes</string>
+    <string name="addzone_copied">Copiado</string>
+    <string name="addzone_steps_title">Próximos passos</string>
+    <string name="addzone_step1">Entre no registrador onde você comprou este domínio.</string>
+    <string name="addzone_step2">Encontre a configuração “Servidores de nomes”.</string>
+    <string name="addzone_step3">Remova os servidores de nomes atuais e substitua pelos dois endereços da Cloudflare acima.</string>
+    <string name="addzone_step4">Salve as alterações. A ativação costuma levar de minutos a horas, até 24 horas.</string>
+    <string name="addzone_done">Concluído</string>
+    <string name="addzone_ns_missing">A Cloudflare ainda não retornou os servidores de nomes. Verifique os detalhes do domínio ou o painel da Cloudflare mais tarde.</string>
+
+    <!-- D1 criar / excluir -->
+    <string name="d1_create_title">Criar banco de dados</string>
+    <string name="d1_create">Criar</string>
+    <string name="d1_created">Criado</string>
+    <string name="d1_name">Nome do banco de dados</string>
+    <string name="d1_location">Local principal</string>
+    <string name="d1_location_hint">O local principal define onde fica a réplica principal. Escolha “Automático” para a Cloudflare colocá-la por perto.</string>
+    <string name="d1_loc_auto">Automático</string>
+    <string name="d1_loc_wnam">Oeste da América do Norte</string>
+    <string name="d1_loc_enam">Leste da América do Norte</string>
+    <string name="d1_loc_weur">Europa Ocidental</string>
+    <string name="d1_loc_eeur">Europa Oriental</string>
+    <string name="d1_loc_apac">Ásia-Pacífico</string>
+    <string name="d1_loc_oc">Oceania</string>
+    <string name="d1_delete_title">Excluir banco de dados</string>
+    <string name="d1_delete_warn">Isso exclui permanentemente o banco de dados %1$s e todas as suas tabelas e dados. Não é possível desfazer nem recuperar.</string>
+    <string name="d1_delete_confirm_label">Digite o nome do banco de dados para confirmar</string>
+    <string name="d1_delete_button">Excluir permanentemente</string>
+
+    <!-- Gerenciamento de Workers -->
+    <string name="worker_manage_secrets">Variáveis e segredos</string>
+    <string name="worker_manage_triggers">Gatilhos</string>
+    <string name="worker_manage_domains">Domínios</string>
+    <string name="worker_secrets_title">Variáveis e segredos</string>
+    <string name="worker_secrets_section">Segredos</string>
+    <string name="worker_secrets_empty">Nenhum segredo</string>
+    <string name="worker_secrets_add">Adicionar segredo</string>
+    <string name="worker_secrets_footer">Os valores dos segredos não podem ser lidos por segurança; a lista mostra apenas nomes. Adicionar o mesmo nome sobrescreve.</string>
+    <string name="worker_secrets_readonly">Somente leitura com a autorização atual (falta workers-scripts.write).</string>
+    <string name="worker_vars_section">Variáveis de ambiente</string>
+    <string name="worker_vars_empty">Nenhuma variável</string>
+    <string name="worker_vars_add">Adicionar variável</string>
+    <string name="worker_vars_footer">Variáveis de texto simples, legíveis e editáveis. Editar uma não afeta outras associações.</string>
+    <string name="worker_var_add_title">Adicionar variável</string>
+    <string name="worker_var_edit_title">Editar variável</string>
+    <string name="worker_secret_add_title">Adicionar segredo</string>
+    <string name="worker_binding_name">Nome</string>
+    <string name="worker_binding_name_hint">Letras, dígitos e sublinhado; não pode começar com dígito.</string>
+    <string name="worker_binding_value">Valor</string>
+    <string name="worker_secret_value">Valor (não pode ser lido após salvar)</string>
+    <string name="worker_other_section">Outras associações (somente leitura)</string>
+    <string name="worker_other_footer">Associações de recursos KV / D1 / R2 e outras aparecem aqui; edite-as com o Wrangler ou o painel.</string>
+    <string name="worker_bind_var">Variável</string>
+    <string name="worker_bind_secret">Segredo</string>
+    <string name="worker_bind_queue">Fila</string>
+    <string name="worker_bind_service">Associação de serviço</string>
+    <string name="worker_bind_browser">Renderização do navegador</string>
+    <string name="worker_triggers_title">Gatilhos</string>
+    <string name="worker_triggers_empty_desc">Adicione uma expressão cron para executar este Worker de forma agendada.</string>
+    <string name="worker_triggers_add">Adicionar gatilho</string>
+    <string name="worker_triggers_footer">O cron é executado em UTC.</string>
+    <string name="worker_cron_expr">Expressão cron</string>
+    <string name="worker_cron_hint">5 campos padrão: minuto hora dia mês dia da semana (UTC).</string>
+    <string name="worker_cron_presets">Comuns</string>
+    <string name="worker_cron_5m">A cada 5 minutos</string>
+    <string name="worker_cron_hourly">A cada hora</string>
+    <string name="worker_cron_daily">Diariamente às 00:00 (UTC)</string>
+    <string name="worker_cron_weekly">Às segundas, 00:00 (UTC)</string>
+    <string name="worker_cron_every_n">A cada %1$d minutos</string>
+    <string name="worker_cron_desc_hourly">A cada hora</string>
+    <string name="worker_cron_desc_daily">Diariamente às %1$s (UTC)</string>
+    <string name="worker_cron_custom">Cron personalizado (UTC)</string>
+    <string name="worker_domains_title">Domínios</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">Subdomínio workers.dev</string>
+    <string name="worker_subdomain_footer">Quando ativado, o Worker fica acessível em script.subdominio.workers.dev.</string>
+    <string name="worker_subdomain_none">O subdomínio workers.dev não está ativado para esta conta</string>
+    <string name="worker_customdomains_section">Domínios personalizados</string>
+    <string name="worker_customdomains_empty">Nenhum domínio personalizado</string>
+    <string name="worker_customdomains_add">Vincular domínio personalizado</string>
+    <string name="worker_customdomains_footer">Aponte um domínio/subdomínio diretamente para este Worker, sem configurar DNS nem certificados.</string>
+    <string name="worker_routes_section">Rotas</string>
+    <string name="worker_routes_empty">Nenhuma rota</string>
+    <string name="worker_routes_add">Adicionar rota</string>
+    <string name="worker_routes_footer">Use um padrão de URL (ex.: example.com/api/*) para enviar as solicitações correspondentes a este Worker.</string>
+    <string name="worker_route_zone">Domínio</string>
+    <string name="worker_route_zone_pick">Selecione</string>
+    <string name="worker_domain_hostname">Nome de host</string>
+    <string name="worker_domain_hostname_hint">Nome de host completo; deve pertencer ao domínio selecionado.</string>
+    <string name="worker_route_pattern">Padrão de rota</string>
+    <string name="worker_route_pattern_hint">Padrão de URL, curingas permitidos, ex.: example.com/*.</string>
+    <string name="worker_attach_domain_title">Vincular domínio personalizado</string>
+    <string name="worker_add_route_title">Adicionar rota</string>
+
+    <!-- Gerenciamento de túneis -->
+    <string name="tunnel_new">Novo túnel</string>
+    <string name="tunnel_new_name">Nome do túnel</string>
+    <string name="tunnel_new_footer">Cria um túnel gerenciado remotamente (configurado pelo painel / por este app).</string>
+    <string name="tunnel_create">Criar</string>
+    <string name="tunnel_connect_section">Executar comando</string>
+    <string name="tunnel_connect_intro">Instale o cloudflared na máquina de destino e execute o comando abaixo como administrador para conectar o túnel.</string>
+    <string name="tunnel_connect_reveal">Mostrar token</string>
+    <string name="tunnel_connect_hide">Ocultar token</string>
+    <string name="tunnel_connect_copy">Copiar comando</string>
+    <string name="tunnel_connect_copied">Comando copiado</string>
+    <string name="tunnel_connect_token_warn">O token equivale às credenciais do túnel. Guarde-o bem e não o compartilhe publicamente.</string>
+    <string name="tunnel_connect_loading">Obtendo token…</string>
+    <string name="tunnel_connect_failed">Não foi possível obter o token</string>
+    <string name="tunnel_hostnames_section">Nomes de host públicos</string>
+    <string name="tunnel_hostnames_empty">Ainda não há nomes de host públicos. Adicione um abaixo.</string>
+    <string name="tunnel_hostnames_empty_ro">Ainda não há nomes de host públicos.</string>
+    <string name="tunnel_hostnames_add">Adicionar nome de host público</string>
+    <string name="tunnel_hostnames_footer">Mapeie um domínio público para um serviço local. Um CNAME com proxy é criado automaticamente ao adicionar um.</string>
+    <string name="tunnel_hostnames_loading">Carregando configuração…</string>
+    <string name="tunnel_local_note">Este túnel é gerenciado localmente (config.yml); gerencie os nomes de host públicos no arquivo de configuração do cloudflared.</string>
+    <string name="tunnel_danger_section">Zona de perigo</string>
+    <string name="tunnel_cleanup">Limpar conexões inativas</string>
+    <string name="tunnel_cleanup_confirm_title">Limpar conexões</string>
+    <string name="tunnel_cleanup_confirm_msg">Remove os registros de conexões desconectadas; instâncias ativas do cloudflared se reconectam automaticamente.</string>
+    <string name="tunnel_delete">Excluir túnel</string>
+    <string name="tunnel_delete_confirm_title">Excluir túnel</string>
+    <string name="tunnel_delete_confirm_msg">Isso exclui o túnel e encerra suas conexões. Não é possível desfazer.</string>
+    <string name="tunnel_host_form_add">Adicionar nome de host público</string>
+    <string name="tunnel_host_form_edit">Editar nome de host público</string>
+    <string name="tunnel_host_hostname">Nome de host público</string>
+    <string name="tunnel_host_protocol">Protocolo</string>
+    <string name="tunnel_host_service">Serviço local</string>
+    <string name="tunnel_host_service_footer">O cloudflared encaminha as solicitações deste nome de host para este endereço local.</string>
+    <string name="tunnel_host_service_other">Endereço de serviço completo, ex.: unix:/path.sock</string>
+    <string name="tunnel_host_path">Caminho</string>
+    <string name="tunnel_host_path_hint">Regex de caminho (opcional), ex.: /api/.*</string>
+    <string name="tunnel_proto_other">Outro</string>
+
+    <!-- Ajuda e feedback -->
+    <string name="settings_help">Ajuda e feedback</string>
+    <string name="settings_help_footer">Feedback e sugestões são enviados ao nosso e-mail com a versão e informações do dispositivo (sem tokens nem segredos).</string>
+    <string name="settings_feedback">Enviar feedback</string>
+    <string name="feedback_subject">Feedback do Orange Cloud</string>
+    <string name="feedback_no_mail">Nenhum app de e-mail encontrado</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">De ver a gerenciar</string>
+    <string name="whatsnew_1_1_0_detail">Agora você pode adicionar domínios, criar e excluir bancos de dados D1 e túneis, gerenciar variáveis/segredos/gatilhos/domínios de Workers e as rotas de nome de host público de um túnel.</string>
+    <string name="whatsnew_1_0_0_title">Login OAuth com um toque</string>
+    <string name="whatsnew_1_0_0_detail">Entre com a autorização oficial da Cloudflare, sem colar tokens de API.</string>
+    <string name="whatsnew_1_0_1_title">Domínios · Workers · Armazenamento</string>
+    <string name="whatsnew_1_0_1_detail">DNS, análises, WAF, Snippets, logs ao vivo de Workers e armazenamento R2/D1/KV, tudo em um só lugar.</string>
+</resources>

--- a/apps/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -42,7 +42,7 @@
     <string name="perm_kv">Armazenamento KV</string>
     <string name="perm_kv_desc">Ler e escrever chave-valor</string>
     <string name="perm_tunnels">Túneis</string>
-    <string name="perm_tunnels_desc">Ver Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">Ver túneis; com acesso de escrita, criar túneis e configurar rotas de nome de anfitrião público</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">Ver e alternar regras de firewall</string>
     <string name="perm_zone_settings">Definições do domínio</string>
@@ -372,10 +372,6 @@
 
     <string name="whatsnew_title">Novidades</string>
     <string name="whatsnew_ok">Entendi</string>
-    <string name="whatsnew_1_0_oauth_title">Início de sessão OAuth com um toque</string>
-    <string name="whatsnew_1_0_oauth_detail">Inicie sessão com a autorização oficial da Cloudflare, sem colar tokens de API.</string>
-    <string name="whatsnew_1_0_modules_title">Domínios · Workers · Armazenamento</string>
-    <string name="whatsnew_1_0_modules_detail">DNS, análises, WAF, Snippets, logs ao vivo de Workers e armazenamento R2/D1/KV, tudo em um só lugar.</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">Desbloqueie todos os recursos premium</string>
@@ -389,4 +385,154 @@
     <string name="paywall_monthly">Mensal</string>
     <string name="paywall_lifetime">Pagamento único</string>
     <string name="paywall_note">Cobrado pelo Google Play; cancele quando quiser.</string>
+
+
+    <!-- Adicionar domínio -->
+    <string name="addzone_title">Adicionar domínio</string>
+    <string name="addzone_domain_label">Domínio</string>
+    <string name="addzone_domain_hint">Introduza um domínio raiz que já possua (ex.: example.com), sem www nem https://.</string>
+    <string name="addzone_account">Adicionar à conta: %1$s</string>
+    <string name="addzone_ns_note">Após adicionar, a Cloudflare atribui dois servidores de nomes. Inicie sessão no seu registrador e altere os NS para eles para ativar o domínio.</string>
+    <string name="addzone_add">Adicionar</string>
+    <string name="addzone_pending">A aguardar ativação</string>
+    <string name="addzone_ns_title">Servidores de nomes</string>
+    <string name="addzone_copy">Copiar servidores de nomes</string>
+    <string name="addzone_copied">Copiado</string>
+    <string name="addzone_steps_title">Passos seguintes</string>
+    <string name="addzone_step1">Inicie sessão no registrador onde comprou este domínio.</string>
+    <string name="addzone_step2">Encontre a definição “Servidores de nomes”.</string>
+    <string name="addzone_step3">Remova os servidores de nomes atuais e substitua pelos dois endereços da Cloudflare acima.</string>
+    <string name="addzone_step4">Guarde as alterações. A ativação costuma demorar de minutos a horas, até 24 horas.</string>
+    <string name="addzone_done">Concluído</string>
+    <string name="addzone_ns_missing">A Cloudflare ainda não devolveu os servidores de nomes. Consulte os detalhes do domínio ou o painel da Cloudflare mais tarde.</string>
+
+    <!-- D1 criar / eliminar -->
+    <string name="d1_create_title">Criar base de dados</string>
+    <string name="d1_create">Criar</string>
+    <string name="d1_created">Criada</string>
+    <string name="d1_name">Nome da base de dados</string>
+    <string name="d1_location">Localização principal</string>
+    <string name="d1_location_hint">A localização principal define onde fica a réplica principal. Escolha “Automática” para a Cloudflare a colocar por perto.</string>
+    <string name="d1_loc_auto">Automática</string>
+    <string name="d1_loc_wnam">Oeste da América do Norte</string>
+    <string name="d1_loc_enam">Leste da América do Norte</string>
+    <string name="d1_loc_weur">Europa Ocidental</string>
+    <string name="d1_loc_eeur">Europa Oriental</string>
+    <string name="d1_loc_apac">Ásia-Pacífico</string>
+    <string name="d1_loc_oc">Oceânia</string>
+    <string name="d1_delete_title">Eliminar base de dados</string>
+    <string name="d1_delete_warn">Esta ação elimina permanentemente a base de dados %1$s e todas as suas tabelas e dados. Não é possível anular nem recuperar.</string>
+    <string name="d1_delete_confirm_label">Escreva o nome da base de dados para confirmar</string>
+    <string name="d1_delete_button">Eliminar permanentemente</string>
+
+    <!-- Gestão de Workers -->
+    <string name="worker_manage_secrets">Variáveis e segredos</string>
+    <string name="worker_manage_triggers">Acionadores</string>
+    <string name="worker_manage_domains">Domínios</string>
+    <string name="worker_secrets_title">Variáveis e segredos</string>
+    <string name="worker_secrets_section">Segredos</string>
+    <string name="worker_secrets_empty">Sem segredos</string>
+    <string name="worker_secrets_add">Adicionar segredo</string>
+    <string name="worker_secrets_footer">Os valores dos segredos não podem ser lidos por segurança; a lista mostra apenas nomes. Adicionar o mesmo nome substitui.</string>
+    <string name="worker_secrets_readonly">Apenas leitura com a autorização atual (falta workers-scripts.write).</string>
+    <string name="worker_vars_section">Variáveis de ambiente</string>
+    <string name="worker_vars_empty">Sem variáveis</string>
+    <string name="worker_vars_add">Adicionar variável</string>
+    <string name="worker_vars_footer">Variáveis de texto simples, legíveis e editáveis. Editar uma não afeta outras associações.</string>
+    <string name="worker_var_add_title">Adicionar variável</string>
+    <string name="worker_var_edit_title">Editar variável</string>
+    <string name="worker_secret_add_title">Adicionar segredo</string>
+    <string name="worker_binding_name">Nome</string>
+    <string name="worker_binding_name_hint">Letras, dígitos e sublinhado; não pode começar por dígito.</string>
+    <string name="worker_binding_value">Valor</string>
+    <string name="worker_secret_value">Valor (não pode ser lido após guardar)</string>
+    <string name="worker_other_section">Outras associações (apenas leitura)</string>
+    <string name="worker_other_footer">As associações de recursos KV / D1 / R2 e outras aparecem aqui; edite-as com o Wrangler ou o painel.</string>
+    <string name="worker_bind_var">Variável</string>
+    <string name="worker_bind_secret">Segredo</string>
+    <string name="worker_bind_queue">Fila</string>
+    <string name="worker_bind_service">Associação de serviço</string>
+    <string name="worker_bind_browser">Renderização do navegador</string>
+    <string name="worker_triggers_title">Acionadores</string>
+    <string name="worker_triggers_empty_desc">Adicione uma expressão cron para executar este Worker de forma agendada.</string>
+    <string name="worker_triggers_add">Adicionar acionador</string>
+    <string name="worker_triggers_footer">O cron é executado em UTC.</string>
+    <string name="worker_cron_expr">Expressão cron</string>
+    <string name="worker_cron_hint">5 campos padrão: minuto hora dia mês dia da semana (UTC).</string>
+    <string name="worker_cron_presets">Comuns</string>
+    <string name="worker_cron_5m">A cada 5 minutos</string>
+    <string name="worker_cron_hourly">A cada hora</string>
+    <string name="worker_cron_daily">Diariamente às 00:00 (UTC)</string>
+    <string name="worker_cron_weekly">Às segundas, 00:00 (UTC)</string>
+    <string name="worker_cron_every_n">A cada %1$d minutos</string>
+    <string name="worker_cron_desc_hourly">A cada hora</string>
+    <string name="worker_cron_desc_daily">Diariamente às %1$s (UTC)</string>
+    <string name="worker_cron_custom">Cron personalizado (UTC)</string>
+    <string name="worker_domains_title">Domínios</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">Subdomínio workers.dev</string>
+    <string name="worker_subdomain_footer">Quando ativado, o Worker fica acessível em script.subdominio.workers.dev.</string>
+    <string name="worker_subdomain_none">O subdomínio workers.dev não está ativado para esta conta</string>
+    <string name="worker_customdomains_section">Domínios personalizados</string>
+    <string name="worker_customdomains_empty">Sem domínios personalizados</string>
+    <string name="worker_customdomains_add">Associar domínio personalizado</string>
+    <string name="worker_customdomains_footer">Aponte um domínio/subdomínio diretamente para este Worker, sem configurar DNS nem certificados.</string>
+    <string name="worker_routes_section">Rotas</string>
+    <string name="worker_routes_empty">Sem rotas</string>
+    <string name="worker_routes_add">Adicionar rota</string>
+    <string name="worker_routes_footer">Use um padrão de URL (ex.: example.com/api/*) para enviar os pedidos correspondentes a este Worker.</string>
+    <string name="worker_route_zone">Domínio</string>
+    <string name="worker_route_zone_pick">Selecione</string>
+    <string name="worker_domain_hostname">Nome de anfitrião</string>
+    <string name="worker_domain_hostname_hint">Nome de anfitrião completo; deve pertencer ao domínio selecionado.</string>
+    <string name="worker_route_pattern">Padrão de rota</string>
+    <string name="worker_route_pattern_hint">Padrão de URL, pode usar * como universal, ex.: example.com/*.</string>
+    <string name="worker_attach_domain_title">Associar domínio personalizado</string>
+    <string name="worker_add_route_title">Adicionar rota</string>
+
+    <!-- Gestão de túneis -->
+    <string name="tunnel_new">Novo túnel</string>
+    <string name="tunnel_new_name">Nome do túnel</string>
+    <string name="tunnel_new_footer">Cria um túnel gerido remotamente (configurado pelo painel / por esta aplicação).</string>
+    <string name="tunnel_create">Criar</string>
+    <string name="tunnel_connect_section">Executar comando</string>
+    <string name="tunnel_connect_intro">Instale o cloudflared na máquina de destino e execute o comando abaixo como administrador para ligar o túnel.</string>
+    <string name="tunnel_connect_reveal">Mostrar token</string>
+    <string name="tunnel_connect_hide">Ocultar token</string>
+    <string name="tunnel_connect_copy">Copiar comando</string>
+    <string name="tunnel_connect_copied">Comando copiado</string>
+    <string name="tunnel_connect_token_warn">O token equivale às credenciais do túnel. Guarde-o bem e não o partilhe publicamente.</string>
+    <string name="tunnel_connect_loading">A obter token…</string>
+    <string name="tunnel_connect_failed">Não foi possível obter o token</string>
+    <string name="tunnel_hostnames_section">Nomes de anfitrião públicos</string>
+    <string name="tunnel_hostnames_empty">Ainda não há nomes de anfitrião públicos. Adicione um abaixo.</string>
+    <string name="tunnel_hostnames_empty_ro">Ainda não há nomes de anfitrião públicos.</string>
+    <string name="tunnel_hostnames_add">Adicionar nome de anfitrião público</string>
+    <string name="tunnel_hostnames_footer">Mapeie um domínio público para um serviço local. Um CNAME com proxy é criado automaticamente ao adicionar um.</string>
+    <string name="tunnel_hostnames_loading">A carregar configuração…</string>
+    <string name="tunnel_local_note">Este túnel é gerido localmente (config.yml); faça a gestão dos nomes de anfitrião públicos no ficheiro de configuração do cloudflared.</string>
+    <string name="tunnel_danger_section">Zona de perigo</string>
+    <string name="tunnel_cleanup">Limpar ligações inativas</string>
+    <string name="tunnel_cleanup_confirm_title">Limpar ligações</string>
+    <string name="tunnel_cleanup_confirm_msg">Remove os registos de ligações terminadas; as instâncias ativas do cloudflared voltam a ligar-se automaticamente.</string>
+    <string name="tunnel_delete">Eliminar túnel</string>
+    <string name="tunnel_delete_confirm_title">Eliminar túnel</string>
+    <string name="tunnel_delete_confirm_msg">Esta ação elimina o túnel e termina as suas ligações. Não é possível anular.</string>
+    <string name="tunnel_host_form_add">Adicionar nome de anfitrião público</string>
+    <string name="tunnel_host_form_edit">Editar nome de anfitrião público</string>
+    <string name="tunnel_host_hostname">Nome de anfitrião público</string>
+    <string name="tunnel_host_protocol">Protocolo</string>
+    <string name="tunnel_host_service">Serviço local</string>
+    <string name="tunnel_host_service_footer">O cloudflared encaminha os pedidos deste nome de anfitrião para este endereço local.</string>
+    <string name="tunnel_host_service_other">Endereço de serviço completo, ex.: unix:/path.sock</string>
+    <string name="tunnel_host_path">Caminho</string>
+    <string name="tunnel_host_path_hint">Regex de caminho (opcional), ex.: /api/.*</string>
+    <string name="tunnel_proto_other">Outro</string>
+
+    <!-- Ajuda e comentários -->
+    <string name="settings_help">Ajuda e comentários</string>
+    <string name="settings_help_footer">Os comentários e sugestões são enviados para o nosso e-mail com a versão e informações do dispositivo (sem tokens nem segredos).</string>
+    <string name="settings_feedback">Enviar comentários</string>
+    <string name="feedback_subject">Comentários do Orange Cloud</string>
+    <string name="feedback_no_mail">Nenhuma aplicação de e-mail encontrada</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">De ver a gerir</string>
+    <string name="whatsnew_1_1_0_detail">Agora pode adicionar domínios, criar e eliminar bases de dados D1 e túneis, gerir variáveis/segredos/acionadores/domínios de Workers e as rotas de nome de anfitrião público de um túnel.</string>
+    <string name="whatsnew_1_0_0_title">Início de sessão OAuth com um toque</string>
+    <string name="whatsnew_1_0_0_detail">Inicie sessão com a autorização oficial da Cloudflare, sem colar tokens de API.</string>
+    <string name="whatsnew_1_0_1_title">Domínios · Workers · Armazenamento</string>
+    <string name="whatsnew_1_0_1_detail">DNS, análises, WAF, Snippets, logs ao vivo de Workers e armazenamento R2/D1/KV, tudo em um só lugar.</string>
+</resources>

--- a/apps/android/app/src/main/res/values-zh-rHK/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/strings.xml
@@ -41,7 +41,7 @@
     <string name="perm_kv">KV 儲存</string>
     <string name="perm_kv_desc">讀寫鍵值</string>
     <string name="perm_tunnels">隧道</string>
-    <string name="perm_tunnels_desc">查看 Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">查看隧道；讀寫可新建隧道、設定公開主機名稱路由</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">查看與啟停防火牆規則</string>
     <string name="perm_zone_settings">域名設定</string>
@@ -371,10 +371,6 @@
 
     <string name="whatsnew_title">新功能</string>
     <string name="whatsnew_ok">好的</string>
-    <string name="whatsnew_1_0_oauth_title">OAuth 一鍵登入</string>
-    <string name="whatsnew_1_0_oauth_detail">用 Cloudflare 官方授權登入，無需手動貼上 API Token。</string>
-    <string name="whatsnew_1_0_modules_title">域名 · Workers · 儲存全覆蓋</string>
-    <string name="whatsnew_1_0_modules_detail">DNS、流量分析、WAF、Snippets、Workers 即時日誌、R2/D1/KV 儲存一應俱全。</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">解鎖全部進階功能</string>
@@ -388,4 +384,154 @@
     <string name="paywall_monthly">月付訂閱</string>
     <string name="paywall_lifetime">一次性買斷</string>
     <string name="paywall_note">訂閱透過 Google Play 計費，可隨時取消。</string>
+
+
+    <!-- 新增域名 -->
+    <string name="addzone_title">新增域名</string>
+    <string name="addzone_domain_label">域名</string>
+    <string name="addzone_domain_hint">輸入你已註冊的根域名（如 example.com），無需帶 www 或 https://。</string>
+    <string name="addzone_account">新增至帳戶：%1$s</string>
+    <string name="addzone_ns_note">新增後，Cloudflare 會為該域名分配兩個名稱伺服器。你需要登入域名註冊商，把 NS 改成它們，域名才會啟用。</string>
+    <string name="addzone_add">新增</string>
+    <string name="addzone_pending">待啟用</string>
+    <string name="addzone_ns_title">名稱伺服器</string>
+    <string name="addzone_copy">複製名稱伺服器</string>
+    <string name="addzone_copied">已複製</string>
+    <string name="addzone_steps_title">接下來</string>
+    <string name="addzone_step1">登入你購買該域名的註冊商（Registrar）。</string>
+    <string name="addzone_step2">找到「名稱伺服器（Nameservers）」設定。</string>
+    <string name="addzone_step3">刪除原有名稱伺服器，替換為上方兩個 Cloudflare 位址。</string>
+    <string name="addzone_step4">儲存變更。啟用通常需幾分鐘到幾小時，最長可達 24 小時。</string>
+    <string name="addzone_done">完成</string>
+    <string name="addzone_ns_missing">Cloudflare 尚未傳回名稱伺服器，請稍後在域名詳情或 Cloudflare 主控台查看。</string>
+
+    <!-- D1 建立 / 刪除 -->
+    <string name="d1_create_title">建立資料庫</string>
+    <string name="d1_create">建立</string>
+    <string name="d1_created">已建立</string>
+    <string name="d1_name">資料庫名稱</string>
+    <string name="d1_location">主要位置</string>
+    <string name="d1_location_hint">主要位置決定資料庫主副本所在地區，選擇「自動」由 Cloudflare 就近分配。</string>
+    <string name="d1_loc_auto">自動</string>
+    <string name="d1_loc_wnam">北美西部</string>
+    <string name="d1_loc_enam">北美東部</string>
+    <string name="d1_loc_weur">歐洲西部</string>
+    <string name="d1_loc_eeur">歐洲東部</string>
+    <string name="d1_loc_apac">亞太地區</string>
+    <string name="d1_loc_oc">大洋洲</string>
+    <string name="d1_delete_title">刪除資料庫</string>
+    <string name="d1_delete_warn">此操作將永久刪除資料庫 %1$s 及其全部資料表與資料，無法復原，也無法還原。</string>
+    <string name="d1_delete_confirm_label">輸入資料庫名稱以確認</string>
+    <string name="d1_delete_button">永久刪除</string>
+
+    <!-- Worker 管理 -->
+    <string name="worker_manage_secrets">變數與密鑰</string>
+    <string name="worker_manage_triggers">觸發器</string>
+    <string name="worker_manage_domains">域名</string>
+    <string name="worker_secrets_title">變數與密鑰</string>
+    <string name="worker_secrets_section">密鑰</string>
+    <string name="worker_secrets_empty">尚無密鑰</string>
+    <string name="worker_secrets_add">新增密鑰</string>
+    <string name="worker_secrets_footer">密鑰值基於安全無法讀取，清單只顯示名稱。同名新增即覆蓋。</string>
+    <string name="worker_secrets_readonly">目前授權僅可查看（缺少 workers-scripts.write）。</string>
+    <string name="worker_vars_section">環境變數</string>
+    <string name="worker_vars_empty">尚無變數</string>
+    <string name="worker_vars_add">新增變數</string>
+    <string name="worker_vars_footer">明文變數（plain_text），可讀可改。改任一項不影響其他繫結。</string>
+    <string name="worker_var_add_title">新增變數</string>
+    <string name="worker_var_edit_title">編輯變數</string>
+    <string name="worker_secret_add_title">新增密鑰</string>
+    <string name="worker_binding_name">名稱</string>
+    <string name="worker_binding_name_hint">字母、數字、底線，且不以數字開頭。</string>
+    <string name="worker_binding_value">值</string>
+    <string name="worker_secret_value">值（儲存後不可讀取）</string>
+    <string name="worker_other_section">其他繫結（唯讀）</string>
+    <string name="worker_other_footer">KV / D1 / R2 等資源繫結在此查看，編輯請用 Wrangler 或主控台。</string>
+    <string name="worker_bind_var">變數</string>
+    <string name="worker_bind_secret">密鑰</string>
+    <string name="worker_bind_queue">佇列</string>
+    <string name="worker_bind_service">Service 繫結</string>
+    <string name="worker_bind_browser">瀏覽器轉譯</string>
+    <string name="worker_triggers_title">觸發器</string>
+    <string name="worker_triggers_empty_desc">新增 Cron 運算式，讓這個 Worker 按計劃自動執行。</string>
+    <string name="worker_triggers_add">新增觸發器</string>
+    <string name="worker_triggers_footer">Cron 按 UTC 時區執行。</string>
+    <string name="worker_cron_expr">Cron 運算式</string>
+    <string name="worker_cron_hint">標準 5 欄位：分 時 日 月 週（UTC）。</string>
+    <string name="worker_cron_presets">常用</string>
+    <string name="worker_cron_5m">每 5 分鐘</string>
+    <string name="worker_cron_hourly">每小時整點</string>
+    <string name="worker_cron_daily">每天 0 點（UTC）</string>
+    <string name="worker_cron_weekly">每週一 0 點（UTC）</string>
+    <string name="worker_cron_every_n">每 %1$d 分鐘</string>
+    <string name="worker_cron_desc_hourly">每小時整點</string>
+    <string name="worker_cron_desc_daily">每天 %1$s（UTC）</string>
+    <string name="worker_cron_custom">自訂 Cron（UTC）</string>
+    <string name="worker_domains_title">域名</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">workers.dev 子域名</string>
+    <string name="worker_subdomain_footer">開啟後該 Worker 可經 指令碼名.子域名.workers.dev 存取。</string>
+    <string name="worker_subdomain_none">該帳戶未開通 workers.dev 子域名</string>
+    <string name="worker_customdomains_section">自訂域名</string>
+    <string name="worker_customdomains_empty">尚無自訂域名</string>
+    <string name="worker_customdomains_add">掛載自訂域名</string>
+    <string name="worker_customdomains_footer">把某個域名/子域名直接指向該 Worker，無需 DNS 與憑證設定。</string>
+    <string name="worker_routes_section">路由</string>
+    <string name="worker_routes_empty">尚無路由</string>
+    <string name="worker_routes_add">新增路由</string>
+    <string name="worker_routes_footer">用 URL 模式（如 example.com/api/*）把符合的請求交給該 Worker。</string>
+    <string name="worker_route_zone">域名</string>
+    <string name="worker_route_zone_pick">請選擇</string>
+    <string name="worker_domain_hostname">主機名稱</string>
+    <string name="worker_domain_hostname_hint">完整主機名稱，須屬於所選域名。</string>
+    <string name="worker_route_pattern">路由模式</string>
+    <string name="worker_route_pattern_hint">URL 模式，可用 * 萬用字元，如 example.com/*。</string>
+    <string name="worker_attach_domain_title">掛載自訂域名</string>
+    <string name="worker_add_route_title">新增路由</string>
+
+    <!-- 隧道管理 -->
+    <string name="tunnel_new">新建隧道</string>
+    <string name="tunnel_new_name">隧道名稱</string>
+    <string name="tunnel_new_footer">將建立一個遠端託管隧道（由主控台／本應用程式管理設定）。</string>
+    <string name="tunnel_create">建立</string>
+    <string name="tunnel_connect_section">執行命令</string>
+    <string name="tunnel_connect_intro">在目標機器上安裝 cloudflared，並以管理員身分執行下面的命令，隧道即可連線。</string>
+    <string name="tunnel_connect_reveal">顯示權杖</string>
+    <string name="tunnel_connect_hide">隱藏權杖</string>
+    <string name="tunnel_connect_copy">複製命令</string>
+    <string name="tunnel_connect_copied">已複製命令</string>
+    <string name="tunnel_connect_token_warn">權杖等同於隧道憑證，請妥善保管，不要公開分享。</string>
+    <string name="tunnel_connect_loading">取得權杖…</string>
+    <string name="tunnel_connect_failed">無法取得權杖</string>
+    <string name="tunnel_hostnames_section">公開主機名稱</string>
+    <string name="tunnel_hostnames_empty">還沒有公開主機名稱，點下方新增。</string>
+    <string name="tunnel_hostnames_empty_ro">還沒有公開主機名稱。</string>
+    <string name="tunnel_hostnames_add">新增公開主機名稱</string>
+    <string name="tunnel_hostnames_footer">把對外域名對應到本機服務。新增時會自動建立橘雲代理的 CNAME。</string>
+    <string name="tunnel_hostnames_loading">載入設定…</string>
+    <string name="tunnel_local_note">該隧道為本機託管（config.yml），公開主機名稱請在 cloudflared 設定檔中管理。</string>
+    <string name="tunnel_danger_section">危險操作</string>
+    <string name="tunnel_cleanup">清理失效連線</string>
+    <string name="tunnel_cleanup_confirm_title">清理連線</string>
+    <string name="tunnel_cleanup_confirm_msg">移除已中斷的連線記錄；運作中的 cloudflared 會自動重新連線。</string>
+    <string name="tunnel_delete">刪除隧道</string>
+    <string name="tunnel_delete_confirm_title">刪除隧道</string>
+    <string name="tunnel_delete_confirm_msg">將刪除該隧道並中斷其連線，此操作無法復原。</string>
+    <string name="tunnel_host_form_add">新增公開主機名稱</string>
+    <string name="tunnel_host_form_edit">編輯公開主機名稱</string>
+    <string name="tunnel_host_hostname">公開主機名稱</string>
+    <string name="tunnel_host_protocol">通訊協定</string>
+    <string name="tunnel_host_service">本機服務</string>
+    <string name="tunnel_host_service_footer">cloudflared 把命中該主機名稱的請求轉送到這個本機位址。</string>
+    <string name="tunnel_host_service_other">完整服務位址，如 unix:/path.sock</string>
+    <string name="tunnel_host_path">路徑</string>
+    <string name="tunnel_host_path_hint">路徑規則運算式（選填），如 /api/.*</string>
+    <string name="tunnel_proto_other">其他</string>
+
+    <!-- 說明與意見回饋 -->
+    <string name="settings_help">說明與意見回饋</string>
+    <string name="settings_help_footer">意見回饋與建議會傳送到我們的信箱，並附帶版本與裝置資訊（不含任何權杖或密鑰）。</string>
+    <string name="settings_feedback">傳送意見回饋</string>
+    <string name="feedback_subject">Orange Cloud 意見回饋</string>
+    <string name="feedback_no_mail">找不到郵件應用程式</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">從查看到管理</string>
+    <string name="whatsnew_1_1_0_detail">現在可以新增域名、建立並刪除 D1 資料庫與隧道，管理 Worker 變數/密鑰/觸發器/域名，以及隧道的公開主機名稱路由。</string>
+    <string name="whatsnew_1_0_0_title">OAuth 一鍵登入</string>
+    <string name="whatsnew_1_0_0_detail">用 Cloudflare 官方授權登入，無需手動貼上 API Token。</string>
+    <string name="whatsnew_1_0_1_title">域名 · Workers · 儲存全覆蓋</string>
+    <string name="whatsnew_1_0_1_detail">DNS、流量分析、WAF、Snippets、Workers 即時日誌、R2/D1/KV 儲存一應俱全。</string>
+</resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -41,7 +41,7 @@
     <string name="perm_kv">KV 儲存</string>
     <string name="perm_kv_desc">讀寫鍵值</string>
     <string name="perm_tunnels">隧道</string>
-    <string name="perm_tunnels_desc">查看 Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">查看隧道；讀寫可新建隧道、設定公開主機名稱路由</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">查看與啟停防火牆規則</string>
     <string name="perm_zone_settings">網域設定</string>
@@ -371,10 +371,6 @@
 
     <string name="whatsnew_title">新功能</string>
     <string name="whatsnew_ok">好的</string>
-    <string name="whatsnew_1_0_oauth_title">OAuth 一鍵登入</string>
-    <string name="whatsnew_1_0_oauth_detail">用 Cloudflare 官方授權登入，無需手動貼上 API Token。</string>
-    <string name="whatsnew_1_0_modules_title">網域 · Workers · 儲存全覆蓋</string>
-    <string name="whatsnew_1_0_modules_detail">DNS、流量分析、WAF、Snippets、Workers 即時日誌、R2/D1/KV 儲存一應俱全。</string>
 
     <string name="paywall_title">Orange Cloud Pro</string>
     <string name="paywall_subtitle">解鎖全部進階功能</string>
@@ -388,4 +384,154 @@
     <string name="paywall_monthly">月付訂閱</string>
     <string name="paywall_lifetime">一次性買斷</string>
     <string name="paywall_note">訂閱透過 Google Play 計費，可隨時取消。</string>
+
+
+    <!-- 新增網域 -->
+    <string name="addzone_title">新增網域</string>
+    <string name="addzone_domain_label">網域</string>
+    <string name="addzone_domain_hint">輸入你已註冊的根網域（如 example.com），無需帶 www 或 https://。</string>
+    <string name="addzone_account">新增至帳號：%1$s</string>
+    <string name="addzone_ns_note">新增後，Cloudflare 會為該網域分配兩個名稱伺服器。你需要登入網域註冊商，把 NS 改成它們，網域才會啟用。</string>
+    <string name="addzone_add">新增</string>
+    <string name="addzone_pending">待啟用</string>
+    <string name="addzone_ns_title">名稱伺服器</string>
+    <string name="addzone_copy">複製名稱伺服器</string>
+    <string name="addzone_copied">已複製</string>
+    <string name="addzone_steps_title">接下來</string>
+    <string name="addzone_step1">登入你購買該網域的註冊商（Registrar）。</string>
+    <string name="addzone_step2">找到「名稱伺服器（Nameservers）」設定。</string>
+    <string name="addzone_step3">刪除原有名稱伺服器，替換為上方兩個 Cloudflare 位址。</string>
+    <string name="addzone_step4">儲存變更。啟用通常需幾分鐘到幾小時，最長可達 24 小時。</string>
+    <string name="addzone_done">完成</string>
+    <string name="addzone_ns_missing">Cloudflare 尚未傳回名稱伺服器，請稍後在網域詳情或 Cloudflare 主控台查看。</string>
+
+    <!-- D1 建立 / 刪除 -->
+    <string name="d1_create_title">建立資料庫</string>
+    <string name="d1_create">建立</string>
+    <string name="d1_created">已建立</string>
+    <string name="d1_name">資料庫名稱</string>
+    <string name="d1_location">主要位置</string>
+    <string name="d1_location_hint">主要位置決定資料庫主副本所在地區，選擇「自動」由 Cloudflare 就近分配。</string>
+    <string name="d1_loc_auto">自動</string>
+    <string name="d1_loc_wnam">北美西部</string>
+    <string name="d1_loc_enam">北美東部</string>
+    <string name="d1_loc_weur">歐洲西部</string>
+    <string name="d1_loc_eeur">歐洲東部</string>
+    <string name="d1_loc_apac">亞太地區</string>
+    <string name="d1_loc_oc">大洋洲</string>
+    <string name="d1_delete_title">刪除資料庫</string>
+    <string name="d1_delete_warn">此操作將永久刪除資料庫 %1$s 及其全部資料表與資料，無法復原，也無法還原。</string>
+    <string name="d1_delete_confirm_label">輸入資料庫名稱以確認</string>
+    <string name="d1_delete_button">永久刪除</string>
+
+    <!-- Worker 管理 -->
+    <string name="worker_manage_secrets">變數與密鑰</string>
+    <string name="worker_manage_triggers">觸發器</string>
+    <string name="worker_manage_domains">網域</string>
+    <string name="worker_secrets_title">變數與密鑰</string>
+    <string name="worker_secrets_section">密鑰</string>
+    <string name="worker_secrets_empty">尚無密鑰</string>
+    <string name="worker_secrets_add">新增密鑰</string>
+    <string name="worker_secrets_footer">密鑰值基於安全無法讀取，清單只顯示名稱。同名新增即覆蓋。</string>
+    <string name="worker_secrets_readonly">目前授權僅可查看（缺少 workers-scripts.write）。</string>
+    <string name="worker_vars_section">環境變數</string>
+    <string name="worker_vars_empty">尚無變數</string>
+    <string name="worker_vars_add">新增變數</string>
+    <string name="worker_vars_footer">明文變數（plain_text），可讀可改。改任一項不影響其他繫結。</string>
+    <string name="worker_var_add_title">新增變數</string>
+    <string name="worker_var_edit_title">編輯變數</string>
+    <string name="worker_secret_add_title">新增密鑰</string>
+    <string name="worker_binding_name">名稱</string>
+    <string name="worker_binding_name_hint">字母、數字、底線，且不以數字開頭。</string>
+    <string name="worker_binding_value">值</string>
+    <string name="worker_secret_value">值（儲存後不可讀取）</string>
+    <string name="worker_other_section">其他繫結（唯讀）</string>
+    <string name="worker_other_footer">KV / D1 / R2 等資源繫結在此查看，編輯請用 Wrangler 或主控台。</string>
+    <string name="worker_bind_var">變數</string>
+    <string name="worker_bind_secret">密鑰</string>
+    <string name="worker_bind_queue">佇列</string>
+    <string name="worker_bind_service">Service 繫結</string>
+    <string name="worker_bind_browser">瀏覽器轉譯</string>
+    <string name="worker_triggers_title">觸發器</string>
+    <string name="worker_triggers_empty_desc">新增 Cron 運算式，讓這個 Worker 按計畫自動執行。</string>
+    <string name="worker_triggers_add">新增觸發器</string>
+    <string name="worker_triggers_footer">Cron 按 UTC 時區執行。</string>
+    <string name="worker_cron_expr">Cron 運算式</string>
+    <string name="worker_cron_hint">標準 5 欄位：分 時 日 月 週（UTC）。</string>
+    <string name="worker_cron_presets">常用</string>
+    <string name="worker_cron_5m">每 5 分鐘</string>
+    <string name="worker_cron_hourly">每小時整點</string>
+    <string name="worker_cron_daily">每天 0 點（UTC）</string>
+    <string name="worker_cron_weekly">每週一 0 點（UTC）</string>
+    <string name="worker_cron_every_n">每 %1$d 分鐘</string>
+    <string name="worker_cron_desc_hourly">每小時整點</string>
+    <string name="worker_cron_desc_daily">每天 %1$s（UTC）</string>
+    <string name="worker_cron_custom">自訂 Cron（UTC）</string>
+    <string name="worker_domains_title">網域</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">workers.dev 子網域</string>
+    <string name="worker_subdomain_footer">開啟後該 Worker 可經 指令碼名.子網域.workers.dev 存取。</string>
+    <string name="worker_subdomain_none">該帳號未開通 workers.dev 子網域</string>
+    <string name="worker_customdomains_section">自訂網域</string>
+    <string name="worker_customdomains_empty">尚無自訂網域</string>
+    <string name="worker_customdomains_add">掛載自訂網域</string>
+    <string name="worker_customdomains_footer">把某個網域/子網域直接指向該 Worker，無需 DNS 與憑證設定。</string>
+    <string name="worker_routes_section">路由</string>
+    <string name="worker_routes_empty">尚無路由</string>
+    <string name="worker_routes_add">新增路由</string>
+    <string name="worker_routes_footer">用 URL 模式（如 example.com/api/*）把符合的請求交給該 Worker。</string>
+    <string name="worker_route_zone">網域</string>
+    <string name="worker_route_zone_pick">請選擇</string>
+    <string name="worker_domain_hostname">主機名稱</string>
+    <string name="worker_domain_hostname_hint">完整主機名稱，須屬於所選網域。</string>
+    <string name="worker_route_pattern">路由模式</string>
+    <string name="worker_route_pattern_hint">URL 模式，可用 * 萬用字元，如 example.com/*。</string>
+    <string name="worker_attach_domain_title">掛載自訂網域</string>
+    <string name="worker_add_route_title">新增路由</string>
+
+    <!-- 隧道管理 -->
+    <string name="tunnel_new">新建隧道</string>
+    <string name="tunnel_new_name">隧道名稱</string>
+    <string name="tunnel_new_footer">將建立一個遠端託管隧道（由主控台／本應用程式管理設定）。</string>
+    <string name="tunnel_create">建立</string>
+    <string name="tunnel_connect_section">執行命令</string>
+    <string name="tunnel_connect_intro">在目標機器上安裝 cloudflared，並以管理員身分執行下面的命令，隧道即可連線。</string>
+    <string name="tunnel_connect_reveal">顯示權杖</string>
+    <string name="tunnel_connect_hide">隱藏權杖</string>
+    <string name="tunnel_connect_copy">複製命令</string>
+    <string name="tunnel_connect_copied">已複製命令</string>
+    <string name="tunnel_connect_token_warn">權杖等同於隧道憑證，請妥善保管，不要公開分享。</string>
+    <string name="tunnel_connect_loading">取得權杖…</string>
+    <string name="tunnel_connect_failed">無法取得權杖</string>
+    <string name="tunnel_hostnames_section">公開主機名稱</string>
+    <string name="tunnel_hostnames_empty">還沒有公開主機名稱，點下方新增。</string>
+    <string name="tunnel_hostnames_empty_ro">還沒有公開主機名稱。</string>
+    <string name="tunnel_hostnames_add">新增公開主機名稱</string>
+    <string name="tunnel_hostnames_footer">把對外網域對應到本機服務。新增時會自動建立橘雲代理的 CNAME。</string>
+    <string name="tunnel_hostnames_loading">載入設定…</string>
+    <string name="tunnel_local_note">該隧道為本機託管（config.yml），公開主機名稱請在 cloudflared 設定檔中管理。</string>
+    <string name="tunnel_danger_section">危險操作</string>
+    <string name="tunnel_cleanup">清理失效連線</string>
+    <string name="tunnel_cleanup_confirm_title">清理連線</string>
+    <string name="tunnel_cleanup_confirm_msg">移除已中斷的連線記錄；運作中的 cloudflared 會自動重新連線。</string>
+    <string name="tunnel_delete">刪除隧道</string>
+    <string name="tunnel_delete_confirm_title">刪除隧道</string>
+    <string name="tunnel_delete_confirm_msg">將刪除該隧道並中斷其連線，此操作無法復原。</string>
+    <string name="tunnel_host_form_add">新增公開主機名稱</string>
+    <string name="tunnel_host_form_edit">編輯公開主機名稱</string>
+    <string name="tunnel_host_hostname">公開主機名稱</string>
+    <string name="tunnel_host_protocol">通訊協定</string>
+    <string name="tunnel_host_service">本機服務</string>
+    <string name="tunnel_host_service_footer">cloudflared 把命中該主機名稱的請求轉送到這個本機位址。</string>
+    <string name="tunnel_host_service_other">完整服務位址，如 unix:/path.sock</string>
+    <string name="tunnel_host_path">路徑</string>
+    <string name="tunnel_host_path_hint">路徑規則運算式（選填），如 /api/.*</string>
+    <string name="tunnel_proto_other">其他</string>
+
+    <!-- 說明與意見回饋 -->
+    <string name="settings_help">說明與意見回饋</string>
+    <string name="settings_help_footer">意見回饋與建議會傳送到我們的信箱，並附帶版本與裝置資訊（不含任何權杖或密鑰）。</string>
+    <string name="settings_feedback">傳送意見回饋</string>
+    <string name="feedback_subject">Orange Cloud 意見回饋</string>
+    <string name="feedback_no_mail">找不到郵件應用程式</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">從查看到管理</string>
+    <string name="whatsnew_1_1_0_detail">現在可以新增網域、建立並刪除 D1 資料庫與隧道，管理 Worker 變數/密鑰/觸發器/網域，以及隧道的公開主機名稱路由。</string>
+    <string name="whatsnew_1_0_0_title">OAuth 一鍵登入</string>
+    <string name="whatsnew_1_0_0_detail">用 Cloudflare 官方授權登入，無需手動貼上 API Token。</string>
+    <string name="whatsnew_1_0_1_title">網域 · Workers · 儲存全覆蓋</string>
+    <string name="whatsnew_1_0_1_detail">DNS、流量分析、WAF、Snippets、Workers 即時日誌、R2/D1/KV 儲存一應俱全。</string>
+</resources>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="perm_kv">KV 存储</string>
     <string name="perm_kv_desc">读写键值</string>
     <string name="perm_tunnels">隧道</string>
-    <string name="perm_tunnels_desc">查看 Cloudflare Tunnel</string>
+    <string name="perm_tunnels_desc">查看隧道；读写可新建隧道、配置公共主机名路由</string>
     <string name="perm_waf">WAF</string>
     <string name="perm_waf_desc">查看与启停防火墙规则</string>
     <string name="perm_zone_settings">域名设置</string>
@@ -408,10 +408,6 @@
     <!-- 新功能弹窗 -->
     <string name="whatsnew_title">新功能</string>
     <string name="whatsnew_ok">好的</string>
-    <string name="whatsnew_1_0_oauth_title">OAuth 一键登录</string>
-    <string name="whatsnew_1_0_oauth_detail">用 Cloudflare 官方授权登录，无需手动粘贴 API Token。</string>
-    <string name="whatsnew_1_0_modules_title">域名 · Workers · 存储全覆盖</string>
-    <string name="whatsnew_1_0_modules_detail">DNS、流量分析、WAF、Snippets、Workers 实时日志、R2/D1/KV 存储一应俱全。</string>
 
     <!-- Paywall（Pro 闸门） -->
     <string name="paywall_title">Orange Cloud Pro</string>
@@ -426,4 +422,153 @@
     <string name="paywall_monthly">月付订阅</string>
     <string name="paywall_lifetime">一次性买断</string>
     <string name="paywall_note">订阅按 Google Play 计费，可随时取消。</string>
+
+    <!-- 添加域名（新建 Zone） -->
+    <string name="addzone_title">添加域名</string>
+    <string name="addzone_domain_label">域名</string>
+    <string name="addzone_domain_hint">输入你已注册的根域名（如 example.com），无需带 www 或 https://。</string>
+    <string name="addzone_account">添加到账号：%1$s</string>
+    <string name="addzone_ns_note">添加后，Cloudflare 会为该域名分配两个名称服务器。你需要登录域名注册商，把 NS 改成它们，域名才会激活。</string>
+    <string name="addzone_add">添加</string>
+    <string name="addzone_pending">待激活</string>
+    <string name="addzone_ns_title">名称服务器</string>
+    <string name="addzone_copy">复制名称服务器</string>
+    <string name="addzone_copied">已复制</string>
+    <string name="addzone_steps_title">接下来</string>
+    <string name="addzone_step1">登录你购买该域名的注册商（Registrar）。</string>
+    <string name="addzone_step2">找到「名称服务器（Nameservers）」设置。</string>
+    <string name="addzone_step3">删除原有名称服务器，替换为上方两个 Cloudflare 地址。</string>
+    <string name="addzone_step4">保存更改。激活通常需几分钟到几小时，最长可达 24 小时。</string>
+    <string name="addzone_done">完成</string>
+    <string name="addzone_ns_missing">Cloudflare 尚未返回名称服务器，请稍后在域名详情或 Cloudflare Dashboard 查看。</string>
+
+    <!-- D1 创建 / 删除 -->
+    <string name="d1_create_title">创建数据库</string>
+    <string name="d1_create">创建</string>
+    <string name="d1_created">已创建</string>
+    <string name="d1_name">数据库名称</string>
+    <string name="d1_location">主要位置</string>
+    <string name="d1_location_hint">主要位置决定数据库主副本所在区域，选择「自动」由 Cloudflare 就近分配。</string>
+    <string name="d1_loc_auto">自动</string>
+    <string name="d1_loc_wnam">北美西部</string>
+    <string name="d1_loc_enam">北美东部</string>
+    <string name="d1_loc_weur">欧洲西部</string>
+    <string name="d1_loc_eeur">欧洲东部</string>
+    <string name="d1_loc_apac">亚太地区</string>
+    <string name="d1_loc_oc">大洋洲</string>
+    <string name="d1_delete_title">删除数据库</string>
+    <string name="d1_delete_warn">此操作将永久删除数据库 %1$s 及其全部表和数据，无法撤销，也无法恢复。</string>
+    <string name="d1_delete_confirm_label">输入数据库名称以确认</string>
+    <string name="d1_delete_button">永久删除</string>
+
+    <!-- Worker 管理：变量与密钥 / 触发器 / 域名 -->
+    <string name="worker_manage_secrets">变量与密钥</string>
+    <string name="worker_manage_triggers">触发器</string>
+    <string name="worker_manage_domains">域名</string>
+    <string name="worker_secrets_title">变量与密钥</string>
+    <string name="worker_secrets_section">密钥</string>
+    <string name="worker_secrets_empty">暂无密钥</string>
+    <string name="worker_secrets_add">添加密钥</string>
+    <string name="worker_secrets_footer">密钥值出于安全无法读取，列表只显示名称。同名添加即覆盖。</string>
+    <string name="worker_secrets_readonly">当前授权仅可查看（缺少 workers-scripts.write）。</string>
+    <string name="worker_vars_section">环境变量</string>
+    <string name="worker_vars_empty">暂无变量</string>
+    <string name="worker_vars_add">添加变量</string>
+    <string name="worker_vars_footer">明文变量（plain_text），可读可改。改任一项不影响其它绑定。</string>
+    <string name="worker_var_add_title">添加变量</string>
+    <string name="worker_var_edit_title">编辑变量</string>
+    <string name="worker_secret_add_title">添加密钥</string>
+    <string name="worker_binding_name">名称</string>
+    <string name="worker_binding_name_hint">字母、数字、下划线，且不以数字开头。</string>
+    <string name="worker_binding_value">值</string>
+    <string name="worker_secret_value">值（保存后不可读取）</string>
+    <string name="worker_other_section">其它绑定（只读）</string>
+    <string name="worker_other_footer">KV / D1 / R2 等资源绑定在此查看，编辑请用 Wrangler 或 Dashboard。</string>
+    <string name="worker_bind_var">变量</string>
+    <string name="worker_bind_secret">密钥</string>
+    <string name="worker_bind_queue">队列</string>
+    <string name="worker_bind_service">Service 绑定</string>
+    <string name="worker_bind_browser">浏览器渲染</string>
+    <string name="worker_triggers_title">触发器</string>
+    <string name="worker_triggers_empty_desc">添加 Cron 表达式，让这个 Worker 按计划自动运行。</string>
+    <string name="worker_triggers_add">添加触发器</string>
+    <string name="worker_triggers_footer">Cron 按 UTC 时区执行。</string>
+    <string name="worker_cron_expr">Cron 表达式</string>
+    <string name="worker_cron_hint">标准 5 字段：分 时 日 月 周（UTC）。</string>
+    <string name="worker_cron_presets">常用</string>
+    <string name="worker_cron_5m">每 5 分钟</string>
+    <string name="worker_cron_hourly">每小时整点</string>
+    <string name="worker_cron_daily">每天 0 点（UTC）</string>
+    <string name="worker_cron_weekly">每周一 0 点（UTC）</string>
+    <string name="worker_cron_every_n">每 %1$d 分钟</string>
+    <string name="worker_cron_desc_hourly">每小时整点</string>
+    <string name="worker_cron_desc_daily">每天 %1$s（UTC）</string>
+    <string name="worker_cron_custom">自定义 Cron（UTC）</string>
+    <string name="worker_domains_title">域名</string>
+    <string name="worker_subdomain_section">workers.dev</string>
+    <string name="worker_subdomain_label">workers.dev 子域</string>
+    <string name="worker_subdomain_footer">开启后该 Worker 可经 脚本名.子域.workers.dev 访问。</string>
+    <string name="worker_subdomain_none">该账号未开通 workers.dev 子域</string>
+    <string name="worker_customdomains_section">自定义域</string>
+    <string name="worker_customdomains_empty">暂无自定义域</string>
+    <string name="worker_customdomains_add">挂载自定义域</string>
+    <string name="worker_customdomains_footer">把某个域名/子域直接指向该 Worker，无需 DNS 与证书配置。</string>
+    <string name="worker_routes_section">路由</string>
+    <string name="worker_routes_empty">暂无路由</string>
+    <string name="worker_routes_add">添加路由</string>
+    <string name="worker_routes_footer">用 URL 模式（如 example.com/api/*）把匹配请求交给该 Worker。</string>
+    <string name="worker_route_zone">域名</string>
+    <string name="worker_route_zone_pick">请选择</string>
+    <string name="worker_domain_hostname">主机名</string>
+    <string name="worker_domain_hostname_hint">完整主机名，须属于所选域名。</string>
+    <string name="worker_route_pattern">路由模式</string>
+    <string name="worker_route_pattern_hint">URL 模式，可用 * 通配，如 example.com/*。</string>
+    <string name="worker_attach_domain_title">挂载自定义域</string>
+    <string name="worker_add_route_title">添加路由</string>
+
+    <!-- Tunnel 管理：创建 / 连接令牌 / 公共主机名 / 危险操作 -->
+    <string name="tunnel_new">新建隧道</string>
+    <string name="tunnel_new_name">隧道名称</string>
+    <string name="tunnel_new_footer">将创建一个远程托管隧道（由 Dashboard / 本应用管理配置）。</string>
+    <string name="tunnel_create">创建</string>
+    <string name="tunnel_connect_section">运行命令</string>
+    <string name="tunnel_connect_intro">在目标机器上安装 cloudflared，并以管理员身份运行下面的命令，隧道即可连接。</string>
+    <string name="tunnel_connect_reveal">显示令牌</string>
+    <string name="tunnel_connect_hide">隐藏令牌</string>
+    <string name="tunnel_connect_copy">复制命令</string>
+    <string name="tunnel_connect_copied">已复制命令</string>
+    <string name="tunnel_connect_token_warn">令牌等同于隧道凭据，请妥善保管，不要公开分享。</string>
+    <string name="tunnel_connect_loading">获取令牌…</string>
+    <string name="tunnel_connect_failed">无法获取令牌</string>
+    <string name="tunnel_hostnames_section">公共主机名</string>
+    <string name="tunnel_hostnames_empty">还没有公共主机名，点下方添加。</string>
+    <string name="tunnel_hostnames_empty_ro">还没有公共主机名。</string>
+    <string name="tunnel_hostnames_add">添加公共主机名</string>
+    <string name="tunnel_hostnames_footer">把对外域名映射到本地服务。新增时会自动创建橙云代理的 CNAME。</string>
+    <string name="tunnel_hostnames_loading">加载配置…</string>
+    <string name="tunnel_local_note">该隧道为本地托管（config.yml），公共主机名请在 cloudflared 配置文件中管理。</string>
+    <string name="tunnel_danger_section">危险操作</string>
+    <string name="tunnel_cleanup">清理失活连接</string>
+    <string name="tunnel_cleanup_confirm_title">清理连接</string>
+    <string name="tunnel_cleanup_confirm_msg">移除已断开的连接记录；活跃的 cloudflared 会自动重连。</string>
+    <string name="tunnel_delete">删除隧道</string>
+    <string name="tunnel_delete_confirm_title">删除隧道</string>
+    <string name="tunnel_delete_confirm_msg">将删除该隧道并断开其连接，此操作不可撤销。</string>
+    <string name="tunnel_host_form_add">添加公共主机名</string>
+    <string name="tunnel_host_form_edit">编辑公共主机名</string>
+    <string name="tunnel_host_hostname">公共主机名</string>
+    <string name="tunnel_host_protocol">协议</string>
+    <string name="tunnel_host_service">本地服务</string>
+    <string name="tunnel_host_service_footer">cloudflared 把命中该主机名的请求转发到这个本地地址。</string>
+    <string name="tunnel_host_service_other">完整服务地址，如 unix:/path.sock</string>
+    <string name="tunnel_host_path">路径</string>
+    <string name="tunnel_host_path_hint">路径正则（可选），如 /api/.*</string>
+    <string name="tunnel_proto_other">其他</string>
+
+    <!-- 帮助与反馈 -->
+    <string name="settings_help">帮助与反馈</string>
+    <string name="settings_help_footer">问题反馈与建议会发送到我们的邮箱，并附带版本与设备信息（不含任何令牌或密钥）。</string>
+    <string name="settings_feedback">发送反馈</string>
+    <string name="feedback_subject">Orange Cloud 反馈</string>
+    <string name="feedback_no_mail">未找到邮件应用</string>
 </resources>

--- a/apps/android/app/src/main/res/values/whatsnew.xml
+++ b/apps/android/app/src/main/res/values/whatsnew.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
+<resources>
+    <string name="whatsnew_1_1_0_title">从查看到管理</string>
+    <string name="whatsnew_1_1_0_detail">现在可以添加域名、新建并删除 D1 数据库与隧道，管理 Worker 变量/密钥/触发器/域名，以及隧道的公共主机名路由。</string>
+    <string name="whatsnew_1_0_0_title">OAuth 一键登录</string>
+    <string name="whatsnew_1_0_0_detail">用 Cloudflare 官方授权登录，无需手动粘贴 API Token。</string>
+    <string name="whatsnew_1_0_1_title">域名 · Workers · 存储全覆盖</string>
+    <string name="whatsnew_1_0_1_detail">DNS、流量分析、WAF、Snippets、Workers 实时日志、R2/D1/KV 存储一应俱全。</string>
+</resources>

--- a/apps/android/fastlane/Fastfile
+++ b/apps/android/fastlane/Fastfile
@@ -18,11 +18,34 @@ platform :android do
 
   desc "上传 AAB + 元数据 + 截图到指定轨道。track: internal(默认)/alpha(封闭测试)/beta/production"
   lane :deploy do |options|
+    track = options[:track] || "internal"
     upload_to_play_store(
-      track: options[:track] || "internal",
+      track: track,
       aab: "app/build/outputs/bundle/playRelease/app-play-release.aab",
       skip_upload_images: true,
       skip_upload_screenshots: false,
     )
+    # 上架生产轨后回调官网，翻出该版本的更新历史（Play 无发布 webhook，故主动通知）。
+    notify_website_release if track == "production"
+  end
+
+  # 把当前 versionName 通过共享密钥头发给官网 /api/play/release。
+  # 需环境变量 PLAY_RELEASE_SECRET（与 Worker secret 同值）。
+  private_lane :notify_website_release do
+    version = ENV["PLAY_RELEASE_VERSION"] ||
+      File.read("../app/build.gradle.kts")[/versionName\s*=\s*"([^"]+)"/, 1]
+    secret = ENV["PLAY_RELEASE_SECRET"]
+    if version.nil? || secret.nil? || secret.empty?
+      UI.important("跳过官网回调：缺 versionName 或 PLAY_RELEASE_SECRET")
+      next
+    end
+    require "net/http"
+    require "uri"
+    require "json"
+    uri = URI("https://orange-cloud.chatiro.app/api/play/release")
+    req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json", "X-Play-Secret" => secret)
+    req.body = { version: version }.to_json
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+    UI.message("官网 Android 上架信号 v#{version} → HTTP #{res.code} #{res.body}")
   end
 end


### PR DESCRIPTION
## 概要 / Summary
Android 对齐 iOS 1.3.0 的管理能力（`versionName 1.1` / `versionCode 2`）。

Brings Android up to iOS 1.3.0's management features.

## 变更 / Changes
- 添加域名（AddZoneSheet）、Worker 变量/密钥/触发器/域名路由、D1 建库/删库、Tunnel 完整管理（新建/令牌/公共主机名路由）
- `CfApiClient` 加 `postChecked`/`putChecked` + 单 part multipart；`Scopes` 加 `argotunnel.write`
- What's New 接入单一数据源（生成 `.kt` + 9× `whatsnew.xml`）；`strings` 九语补齐
- fastlane `deploy track:production` 后回调官网 `/api/play/release` 翻牌

## 依赖 / Depends on
fastlane 回调依赖 #11 的 `/api/play/release`，建议该 PR 先合并并部署。
