### PR TITLE
feat(ios): 免费账号账户级数据无权限的门控与三端提示

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/ContentView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/ContentView.swift
@@ -41,6 +41,8 @@ struct ContentView: View {
                                     UsageLinkRow()
                                 }
                                 .buttonStyle(.plain)
+                            } else if bridge.accountAnalyticsUnavailable {
+                                AccountUsageUnavailableRow()
                             }
                         }
                         .padding(.horizontal, 4)
@@ -112,6 +114,29 @@ private struct ZoneRow: View {
                 .foregroundStyle(.tertiary)
         }
         .padding(.vertical, 7)
+        .padding(.horizontal, 10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+/// 账户级数据无权限（免费账号）：用量入口替换为只读提示，不可点
+private struct AccountUsageUnavailableRow: View {
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "lock")
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("账户级用量不可用")
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                Text("通常需付费版账号")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 2)
+        }
+        .padding(.vertical, 8)
         .padding(.horizontal, 10)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
     }

--- a/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/Localizable.xcstrings
@@ -1,6 +1,110 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "账户级用量不可用" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account usage unavailable"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uso de la cuenta no disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント使用量は利用できません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 사용량을 사용할 수 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uso da conta indisponível"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilização da conta indisponível"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳戶級用量不可用"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳戶級用量不可用"
+          }
+        }
+      }
+    },
+    "通常需付费版账号" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usually needs a paid account"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suele requerir una cuenta de pago"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通常は有料アカウントが必要"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보통 유료 계정이 필요"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geralmente requer conta paga"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requer normalmente conta paga"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通常需付費版帳號"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通常需付費版帳戶"
+          }
+        }
+      }
+    },
     "%@" : {
 
     },

--- a/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/WatchBridge.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/WatchBridge.swift
@@ -20,6 +20,7 @@ final class WatchBridge: NSObject {
 
     var zones:       [WidgetZoneMetrics] = []
     var usage:       WidgetUsageData?
+    var accountAnalyticsUnavailable: Bool = false   // 账户级数据无权限（免费账号）
     var accountName: String = ""
     var lastUpdated: Date?
     var hasToken:    Bool = false
@@ -64,6 +65,7 @@ final class WatchBridge: NSObject {
     private func loadFromStore() {
         zones = WidgetDataStore.loadZones()
         usage = WidgetDataStore.loadUsage()
+        accountAnalyticsUnavailable = !WidgetDataStore.loadAccountAnalyticsAvailable()
         let defaults = UserDefaults(suiteName: WidgetSnapshot.appGroupID)
         accountName = defaults?.string(forKey: Self.accountNameKey) ?? ""
         hasToken = SharedAuth.currentValidAccessToken() != nil
@@ -76,6 +78,9 @@ final class WatchBridge: NSObject {
         }
         WidgetDataStore.saveZones(payload.zones)
         if let usage = payload.usage { WidgetDataStore.saveUsage(usage) }
+        let unavailable = payload.accountAnalyticsUnavailable ?? false
+        WidgetDataStore.saveAccountAnalyticsAvailable(!unavailable)
+        accountAnalyticsUnavailable = unavailable
         if let name = payload.accountName {
             UserDefaults(suiteName: WidgetSnapshot.appGroupID)?.set(name, forKey: Self.accountNameKey)
             accountName = name

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Connectivity/WatchSessionManager.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Connectivity/WatchSessionManager.swift
@@ -50,6 +50,7 @@ final class WatchSessionManager: NSObject {
             accountName: authManager?.currentSession?.label,
             zones:       Array(WidgetDataStore.loadZones().prefix(12)),
             usage:       WidgetDataStore.loadUsage(),
+            accountAnalyticsUnavailable: !WidgetDataStore.loadAccountAnalyticsAvailable(),
             updatedAt:   Date()
         )
     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/APIError.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/APIError.swift
@@ -14,6 +14,7 @@ nonisolated enum APIError: LocalizedError {
     case cloudflareError(code: Int, message: String)  // CF 业务错误
     case decodingError(Error)            // 解析失败
     case networkError(Error)             // 网络错误
+    case accountNotAuthorized            // 账户级数据集未授权（GraphQL authz；免费账号常态，无法区分无权限/计划未开通）
 
     var errorDescription: String? {
         switch self {
@@ -25,6 +26,13 @@ nonisolated enum APIError: LocalizedError {
         case .cloudflareError(_, let msg): return msg
         case .decodingError:               return String(localized: "数据解析失败")
         case .networkError(let e):         return String(localized: "网络错误：\(e.localizedDescription)")
+        case .accountNotAuthorized:        return String(localized: "此账号暂无账户级数据查询权限")
         }
+    }
+
+    /// 是否为账户级数据集未授权（用于 UI 降级到「免费账号无账户级数据」态）
+    var isAccountNotAuthorized: Bool {
+        if case .accountNotAuthorized = self { return true }
+        return false
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
@@ -169,6 +169,11 @@ actor CFAPIClient {
             // GraphQL 错误时 HTTP 仍为 200——网络层只看状态码看不到这层，这里单独记，
             // 便于排查「请求 200 但数据没出来」（如数据集权限/字段不可用）。
             AppLog.network.error("graphQL error (\(envelope.errors?.count ?? 1)): \(first.message)")
+            // authz（账户级数据集未授权）单独抛——调用方据此降级到「免费账号无账户级数据」态，
+            // 并停发同账号其余注定失败的账户级查询。
+            if envelope.errors?.contains(where: \.isAuthz) == true {
+                throw APIError.accountNotAuthorized
+            }
             throw APIError.cloudflareError(code: 0, message: first.message)
         }
         guard let data = envelope.data else {

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -1,6 +1,110 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "此账号暂无账户级数据查询权限" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account-level data isn’t available for this account"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los datos de nivel de cuenta no están disponibles para esta cuenta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このアカウントではアカウントレベルのデータを利用できません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 계정에서는 계정 수준 데이터를 사용할 수 없습니다"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os dados no nível da conta não estão disponíveis para esta conta"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os dados ao nível da conta não estão disponíveis para esta conta"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此帳號暫無帳戶級資料查詢權限"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此帳戶暫無帳戶級數據查詢權限"
+          }
+        }
+      }
+    },
+    "Workers / R2 / D1 / KV 用量通常需要付费版 Cloudflare 账号；域名流量分析不受影响。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workers / R2 / D1 / KV usage usually requires a paid Cloudflare account. Domain traffic analytics still work."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El uso de Workers / R2 / D1 / KV suele requerir una cuenta de pago de Cloudflare. El análisis de tráfico de dominios sigue disponible."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workers / R2 / D1 / KV の使用量には通常、有料の Cloudflare アカウントが必要です。ドメインのトラフィック分析は引き続き利用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workers / R2 / D1 / KV 사용량은 일반적으로 유료 Cloudflare 계정이 필요합니다. 도메인 트래픽 분석은 계속 사용할 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O uso de Workers / R2 / D1 / KV geralmente requer uma conta paga da Cloudflare. A análise de tráfego de domínios continua funcionando."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A utilização de Workers / R2 / D1 / KV requer normalmente uma conta paga da Cloudflare. A análise de tráfego de domínios continua a funcionar."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workers / R2 / D1 / KV 用量通常需要付費版 Cloudflare 帳號；網域流量分析不受影響。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workers / R2 / D1 / KV 用量通常需要付費版 Cloudflare 帳戶；域名流量分析不受影響。"
+          }
+        }
+      }
+    },
     "此设备不支持设备端 AI（需要 iOS 26 及支持 Apple 智能的机型）。" : {
       "localizations" : {
         "en" : {

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/GraphQLModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/GraphQLModels.swift
@@ -19,4 +19,15 @@ nonisolated struct GraphQLResponse<D: Codable & Sendable>: Codable, Sendable {
 
 nonisolated struct GraphQLError: Codable, Sendable {
     let message: String
+    let extensions: Extensions?
+
+    nonisolated struct Extensions: Codable, Sendable {
+        let code: String?
+    }
+
+    /// 账户级数据集未授权：CF 用同一个 authz 码兼指「token 无权限」与「计划未开通该数据集」
+    /// （Cloudflare 支持已确认两者无法区分），免费账号查账户级 analytics 即命中。
+    var isAuthz: Bool {
+        extensions?.code == "authz" || message == "not authorized for that account"
+    }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
@@ -30,11 +30,14 @@ final class DashboardViewModel {
     private(set) var loadFailed = false
     /// 用量加载完成但账号级分析全部失败（区分「仍在加载」与「加载失败」，避免永远卡骨架）
     private(set) var usageLoadFailed = false
+    /// 账户级数据集未授权（免费账号常态）：UI 显示「无账户级数据权限」而非重试，且停发后续账户级查询
+    private(set) var accountAnalyticsUnavailable = false
 
     private var loadedZoneIds: Set<String> = []
     private var assetsLoadedForAccount: String?
     private var usageLoadedForAccount: String?
     private var billingAttemptedForAccount: String?
+    private var analyticsUnavailableForAccount: String?
 
     // 加载跑在 VM 持有的非结构化 Task：.task(id:)/.refreshable 的手势或 body 重建会取消视图任务，
     // 若请求直接 await 在视图任务里，URLSession 把取消转成 .cancelled → try? 吞成 nil → 用量/资产
@@ -164,6 +167,14 @@ final class DashboardViewModel {
 
     private func performLoadUsage(accountId: String, fallbackPeriodStart: Date?, force: Bool) async {
         usageLoadFailed = false   // 重试期间先回骨架态，加载完再据结果定
+
+        // 已知该账号无账户级数据权限：非强制刷新直接降级，不再发注定 authz/403 失败的查询。
+        // 下拉刷新（force）会重探，便于用户升级套餐后自动恢复。
+        if !force, analyticsUnavailableForAccount == accountId {
+            accountAnalyticsUnavailable = true
+            return
+        }
+
         if force || billingAttemptedForAccount != accountId {
             billingAttemptedForAccount = accountId
             billing = (try? await accountService.listSubscriptions(accountId: accountId))
@@ -183,8 +194,27 @@ final class DashboardViewModel {
 
         // Workers 用量（账号级 GraphQL）。注意 HTTP 200 不代表 GraphQL 成功——Cloudflare 即使
         // 数据集报错也回 200，错误在响应体 errors 里（CFAPIClient.graphQL 会记 "graphQL error"）。
-        // 失败不再整段放弃：继续拉 R2/D1/KV，能显示多少显示多少；全部失败才标记失败态、不卡骨架。
-        let workers = try? await analyticsService.accountUsage(accountId: accountId, periodStart: periodStart)
+        // Workers 是账户级 analytics 的代表：命中 authz = 整账号无账户级数据权限（CF 的 authz 是
+        // 账号级、各账户级数据集同进同退）→ 直接降级并停发 R2/D1/KV/CPU 等其余注定失败的查询。
+        let workers: AccountUsage?
+        do {
+            workers = try await analyticsService.accountUsage(accountId: accountId, periodStart: periodStart)
+        } catch let error as APIError where error.isAccountNotAuthorized {
+            accountAnalyticsUnavailable = true
+            analyticsUnavailableForAccount = accountId
+            self.usage = nil
+            usageLoadFailed = false
+            persistAnalyticsAvailability(false)
+            AppLog.network.info("account-level analytics not authorized; skipping account datasets for account=\(accountId)")
+            return
+        } catch {
+            workers = nil   // 其它失败（多为临时）：继续尝试 R2/D1/KV，能显示多少显示多少
+        }
+
+        // 账户级有权限（或仅 Workers 本次临时失败）：清除不可用态
+        accountAnalyticsUnavailable = false
+        analyticsUnavailableForAccount = nil
+
         var usage = workers ?? AccountUsage(
             workersRequestsToday: 0, workersRequestsMonth: 0, workersErrorsMonth: 0,
             cpuP50Us: nil, cpuP99Us: nil, cpuTimeMonthUs: nil, cpuTimeTodayUs: nil
@@ -238,12 +268,20 @@ final class DashboardViewModel {
             self.usage = usage
             usageLoadFailed = false
             usageLoadedForAccount = accountId
+            persistAnalyticsAvailability(true)
         } else {
             // 账号级分析全部失败（多为 GraphQL 数据集权限问题，见网络日志 "graphQL error"）。
             // 标记失败态让 UI 显示重试而非永远骨架；不写 usageLoadedForAccount，下次进入会重试。
             usageLoadFailed = true
             AppLog.network.error("account usage load produced no data (all account-level datasets failed)")
         }
+    }
+
+    /// 把账户级数据可用性落到 App Group 并广播给 Widget / Watch（统一一处，避免各端不一致）
+    private func persistAnalyticsAvailability(_ available: Bool) {
+        WidgetDataStore.saveAccountAnalyticsAvailable(available)
+        WidgetCenter.shared.reloadTimelines(ofKind: "UsageWidget")
+        WatchSessionManager.shared.pushCurrentState()
     }
 
     /// 拉取各 Zone 的 24h 流量。zone 集合没变化时跳过（Tab 切换不重复请求）。

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerMetricsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerMetricsViewModel.swift
@@ -17,6 +17,8 @@ final class WorkerMetricsViewModel {
     private(set) var series: [WorkerSeriesPoint] = []
     var isLoading = false
     var error: String?
+    /// 账户级数据集未授权（免费账号）：视图显示「无账户级数据权限」而非报错
+    private(set) var accountAnalyticsUnavailable = false
 
     private var cache: [AnalyticsTimeRange: (metrics: WorkerMetrics, series: [WorkerSeriesPoint])] = [:]
     private let analyticsService: AnalyticsService
@@ -37,6 +39,7 @@ final class WorkerMetricsViewModel {
         }
         isLoading = true
         error = nil
+        accountAnalyticsUnavailable = false
         do {
             // 序列查询失败不阻塞摘要（datetimeHour/date 分组属较新 schema）
             async let metricsTask = analyticsService.workerMetrics(
@@ -51,6 +54,9 @@ final class WorkerMetricsViewModel {
             cache[range] = (metrics, series)
             self.metrics = metrics
             self.series = series
+        } catch let error as APIError where error.isAccountNotAuthorized {
+            accountAnalyticsUnavailable = true
+            self.error = nil
         } catch {
             self.error = error.localizedDescription
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -519,6 +519,8 @@ struct DashboardView: View {
                     .glassIsland(cornerRadius: OCLayout.chipRadius)
             } else if let usage = viewModel.usage {
                 usageGrid(usage)
+            } else if viewModel.accountAnalyticsUnavailable {
+                accountAnalyticsUnavailableCard
             } else if viewModel.usageLoadFailed {
                 Label("用量加载失败，下拉刷新重试", systemImage: "exclamationmark.triangle")
                     .font(.footnote)
@@ -530,6 +532,26 @@ struct DashboardView: View {
                 usageSkeleton
             }
         }
+    }
+
+    /// 账户级数据无权限（免费账号常态）——中性提示 + 付费说明，区别于「加载失败可重试」
+    private var accountAnalyticsUnavailableCard: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text("此账号暂无账户级数据查询权限")
+                .font(.subheadline.weight(.medium))
+                .multilineTextAlignment(.center)
+            Text("Workers / R2 / D1 / KV 用量通常需要付费版 Cloudflare 账号；域名流量分析不受影响。")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 18)
+        .padding(.horizontal, 12)
+        .glassIsland(cornerRadius: OCLayout.chipRadius)
     }
 
     /// 用量宫格骨架：与真实瓦片同形状的 2×2 占位

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
@@ -180,6 +180,10 @@ struct WorkerDetailView: View {
                                 .monospacedDigit()
                         }
                     }
+                } else if metricsViewModel.accountAnalyticsUnavailable {
+                    Label("此账号暂无账户级数据查询权限", systemImage: "chart.bar.xaxis")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                 } else if let error = metricsViewModel.error {
                     Label(error, systemImage: "exclamationmark.triangle")
                         .font(.footnote)

--- a/apps/ios/Orange Cloud/OrangeCloudWidgets/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/OrangeCloudWidgets/Localizable.xcstrings
@@ -1,6 +1,58 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "账户级用量不可用" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account usage unavailable"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uso de la cuenta no disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント使用量は利用できません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 사용량을 사용할 수 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uso da conta indisponível"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilização da conta indisponível"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳戶級用量不可用"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳戶級用量不可用"
+          }
+        }
+      }
+    },
     "—" : {
 
     },

--- a/apps/ios/Orange Cloud/OrangeCloudWidgets/UsageFetcher.swift
+++ b/apps/ios/Orange Cloud/OrangeCloudWidgets/UsageFetcher.swift
@@ -307,6 +307,19 @@ nonisolated enum UsageFetcher {
         struct Viewer: Decodable { let accounts: [Node] }
     }
 
+    /// 只探 GraphQL 错误层的 authz 码（账户级无权限）；与数据解码分开，HTTP 200 也要看 body
+    private struct GraphQLErrorPeek: Decodable {
+        let errors: [Item]?
+        struct Item: Decodable {
+            let message: String?
+            let extensions: Ext?
+            struct Ext: Decodable { let code: String? }
+        }
+        var isAuthz: Bool {
+            errors?.contains { $0.extensions?.code == "authz" || $0.message == "not authorized for that account" } ?? false
+        }
+    }
+
     /// 通用 GraphQL：取第一个 account 节点解码为 N
     private static func graphQLFirstAccount<N: Decodable>(
         token: String, query: String, variables: [String: String]
@@ -322,8 +335,17 @@ nonisolated enum UsageFetcher {
         request.httpBody = encoded
 
         guard let (data, response) = try? await URLSession.shared.data(for: request),
-              (response as? HTTPURLResponse)?.statusCode == 200,
-              let decoded = try? JSONDecoder().decode(GraphQLEnvelope<N>.self, from: data) else { return nil }
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+        // GraphQL authz（账户级无权限）：HTTP 仍 200、错误在 body。落标志到 App Group，
+        // 让用量 Widget 即便 App 未打开也能显示「账户级用量不可用」。
+        if let peek = try? JSONDecoder().decode(GraphQLErrorPeek.self, from: data), peek.isAuthz {
+            WidgetDataStore.saveAccountAnalyticsAvailable(false)
+            return nil
+        }
+        guard let decoded = try? JSONDecoder().decode(GraphQLEnvelope<N>.self, from: data) else { return nil }
+        if decoded.data?.viewer.accounts.first != nil {
+            WidgetDataStore.saveAccountAnalyticsAvailable(true)
+        }
         return decoded.data?.viewer.accounts.first
     }
 

--- a/apps/ios/Orange Cloud/OrangeCloudWidgets/UsageWidget.swift
+++ b/apps/ios/Orange Cloud/OrangeCloudWidgets/UsageWidget.swift
@@ -22,6 +22,7 @@ nonisolated struct UsageWidgetEntry: TimelineEntry {
     let date: Date
     let service: WidgetUsageService?
     let missingName: String?     // 所选服务无数据时的名称（用于提示文案）
+    var unavailable: Bool = false   // 账户级数据无权限（免费账号）→ 显示专用提示而非「打开 App 同步」
 }
 
 /// 画廊/占位用的示例数据——跟随所选服务，避免看起来像"参数没生效"
@@ -75,11 +76,13 @@ nonisolated struct UsageWidgetProvider: AppIntentTimelineProvider {
         // 自取数优先（共享钥匙串 token 直查所选服务），失败回退 App 写入的快照
         let fresh = await UsageFetcher.freshService(configuration.serviceId)
         let service = fresh ?? resolveService(configuration.serviceId)
-        usageLog.info("timeline: fresh=\(fresh?.id ?? "nil", privacy: .public) resolved=\(service?.id ?? "nil", privacy: .public)")
+        let unavailable = service == nil && !WidgetDataStore.loadAccountAnalyticsAvailable()
+        usageLog.info("timeline: fresh=\(fresh?.id ?? "nil", privacy: .public) resolved=\(service?.id ?? "nil", privacy: .public) unavailable=\(unavailable, privacy: .public)")
         let entry = UsageWidgetEntry(
             date: .now,
             service: service,
-            missingName: service == nil ? (configuration.service?.name ?? "Workers") : nil
+            missingName: service == nil ? (configuration.service?.name ?? "Workers") : nil,
+            unavailable: unavailable
         )
         let next = Calendar.current.date(byAdding: .minute, value: 30, to: .now) ?? .now
         return Timeline(entries: [entry], policy: .after(next))
@@ -124,6 +127,8 @@ struct UsageWidgetView: View {
             case .systemMedium: mediumView(service)
             default:            smallView(service)
             }
+        } else if entry.unavailable {
+            WidgetEmptyHint(text: String(localized: "账户级用量不可用"))
         } else {
             WidgetEmptyHint(text: entry.missingName.map { String(localized: "暂无 \($0) 用量数据\n打开 App 刷新") }
                 ?? String(localized: "打开 App 同步用量"))
@@ -149,6 +154,8 @@ struct UsageWidgetView: View {
             } icon: {
                 Image(systemName: "gauge.medium")
             }
+        } else if entry.unavailable {
+            Label(String(localized: "账户级用量不可用"), systemImage: "lock")
         } else {
             Label("Orange Cloud", systemImage: "gauge.medium")
         }
@@ -210,6 +217,10 @@ struct UsageWidgetView: View {
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        } else if entry.unavailable {
+            Text("账户级用量不可用")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         } else {
             Text(entry.missingName.map { String(localized: "暂无 \($0) 用量数据") } ?? String(localized: "打开 App 同步用量"))
                 .font(.caption2)

--- a/apps/ios/Orange Cloud/Shared/WatchBridgePayload.swift
+++ b/apps/ios/Orange Cloud/Shared/WatchBridgePayload.swift
@@ -17,6 +17,7 @@ nonisolated struct WatchBridgePayload: Codable, Sendable {
     var accountName: String?
     var zones:       [WidgetZoneMetrics] // 复用 Widget 快照模型
     var usage:       WidgetUsageData?
+    var accountAnalyticsUnavailable: Bool? = nil   // 账户级数据无权限（免费账号）→ watch 显示提示，可选兼容旧载荷
     var updatedAt:   Date
 
     /// applicationContext 载荷：单个 Data blob（plist 兼容，避免逐字段类型转换）

--- a/apps/ios/Orange Cloud/Shared/WidgetSnapshot.swift
+++ b/apps/ios/Orange Cloud/Shared/WidgetSnapshot.swift
@@ -72,6 +72,7 @@ nonisolated enum WidgetDataStore {
 
     private static let zonesKey = "widgetZoneMetrics"
     private static let usageKey = "widgetUsageData"
+    private static let analyticsAvailableKey = "accountAnalyticsAvailable"
 
     static func saveZones(_ zones: [WidgetZoneMetrics]) {
         guard let defaults = UserDefaults(suiteName: WidgetSnapshot.appGroupID),
@@ -96,5 +97,16 @@ nonisolated enum WidgetDataStore {
         guard let defaults = UserDefaults(suiteName: WidgetSnapshot.appGroupID),
               let data = defaults.data(forKey: usageKey) else { return nil }
         return try? JSONDecoder().decode(WidgetUsageData.self, from: data)
+    }
+
+    /// 当前账号是否拥有账户级数据（analytics）查询权限。未知时默认 true，避免首次误报不可用。
+    static func saveAccountAnalyticsAvailable(_ available: Bool) {
+        UserDefaults(suiteName: WidgetSnapshot.appGroupID)?.set(available, forKey: analyticsAvailableKey)
+    }
+
+    static func loadAccountAnalyticsAvailable() -> Bool {
+        guard let defaults = UserDefaults(suiteName: WidgetSnapshot.appGroupID),
+              defaults.object(forKey: analyticsAvailableKey) != nil else { return true }
+        return defaults.bool(forKey: analyticsAvailableKey)
     }
 }


### PR DESCRIPTION
## 概要 / Summary

免费 Cloudflare 账号查账户级 GraphQL 数据集会返回 `authz`「not authorized for that account」（CF 支持已确认该码无法区分「无权限」与「计划未开通」，且 `/graphql/settings` 自身也被同一道闸挡住、无法预探）。本 PR 让 App 识别该错误后**停发**注定失败的账户级查询，并在**主 App / Widget / Watch 三端**给出中性提示；域名（zone）流量分析不受影响。

Free Cloudflare accounts get `authz` "not authorized for that account" on account-level GraphQL datasets. This PR detects it, stops issuing the doomed account-level queries, and surfaces a neutral "no account-level data access" state across the main app / widget / watch. Zone traffic analytics are unaffected.

## 改动 / Changes
- 识别层：`GraphQLError.extensions.code` → 新增 `APIError.accountNotAuthorized`（`CFAPIClient.graphQL` 命中 authz 单独抛）
- 查询逻辑：`DashboardViewModel` 探到 authz 即停发 R2/D1/KV/CPU/订阅，按账号记忆、下拉刷新重探；`WorkerMetricsViewModel` 同步门控
- 三端 UI：主 App 用量区 + 单 Worker 指标、用量 Widget（含锁屏）、Apple Watch 用量入口
- 跨端下发：App Group 标志位 + Watch 桥接载荷；用量 Widget 自取数也独立识别 authz
- 本地化：主 App / Widget / Watch 三套 catalog 补齐 9 语

编译：主 App + Widget + Watch `BUILD SUCCEEDED`（Xcode-beta / iOS 模拟器目标，无 error、无版本警告）。
