### PR TITLE
chore(changelog): iOS 1.4.0 发布说明（What's New 扩至 13 语）

### DIFF
--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,5 +1,211 @@
 [
   {
+    "version": "1.4.0",
+    "date": "2026.06.25",
+    "channel": "App Store",
+    "inApp": true,
+    "items": [
+      {
+        "icon": "checkmark.seal",
+        "title": {
+          "zh-Hans": "SSL 证书与加密设置",
+          "en": "SSL Certificates & Encryption",
+          "zh-Hant": "SSL 憑證與加密設定",
+          "zh-HK": "SSL 憑證與加密設定",
+          "ja": "SSL 証明書と暗号化設定",
+          "es-MX": "Certificados SSL y cifrado",
+          "ko": "SSL 인증서 및 암호화 설정",
+          "pt-BR": "Certificados SSL e criptografia",
+          "pt-PT": "Certificados SSL e encriptação",
+          "de": "SSL-Zertifikate & Verschlüsselung",
+          "fr": "Certificats SSL et chiffrement",
+          "ar": "شهادات SSL والتشفير",
+          "tr": "SSL sertifikaları ve şifreleme"
+        },
+        "detail": {
+          "zh-Hans": "查看域名的边缘证书与到期时间，开关 Universal SSL，并调整 SSL/TLS 加密模式。",
+          "en": "View your domain's edge certificates and expiry dates, toggle Universal SSL, and adjust the SSL/TLS encryption mode.",
+          "zh-Hant": "檢視網域的邊緣憑證與到期時間，開關 Universal SSL，並調整 SSL/TLS 加密模式。",
+          "zh-HK": "查看域名的邊緣憑證與到期時間，開關 Universal SSL，並調整 SSL/TLS 加密模式。",
+          "ja": "ドメインのエッジ証明書と有効期限を確認し、Universal SSL のオン/オフや SSL/TLS 暗号化モードを変更できます。",
+          "es-MX": "Consulta los certificados perimetrales de tu dominio y sus fechas de vencimiento, activa o desactiva Universal SSL y ajusta el modo de cifrado SSL/TLS.",
+          "ko": "도메인의 엣지 인증서와 만료일을 확인하고 Universal SSL을 켜고 끄며 SSL/TLS 암호화 모드를 조정하세요.",
+          "pt-BR": "Veja os certificados de borda do seu domínio e as datas de validade, ative ou desative o Universal SSL e ajuste o modo de criptografia SSL/TLS.",
+          "pt-PT": "Veja os certificados de extremidade do seu domínio e as datas de validade, ative ou desative o Universal SSL e ajuste o modo de encriptação SSL/TLS.",
+          "de": "Sieh dir die Edge-Zertifikate deiner Domain samt Ablaufdatum an, schalte Universal SSL ein oder aus und passe den SSL/TLS-Verschlüsselungsmodus an.",
+          "fr": "Consultez les certificats edge de votre domaine et leurs dates d'expiration, activez ou désactivez Universal SSL et ajustez le mode de chiffrement SSL/TLS.",
+          "ar": "اطّلع على الشهادات الطرفية لنطاقك وتواريخ انتهائها، وفعّل Universal SSL أو عطّله، واضبط وضع تشفير SSL/TLS.",
+          "tr": "Alan adınızın uç sertifikalarını ve son kullanma tarihlerini görüntüleyin, Universal SSL'i açıp kapatın ve SSL/TLS şifreleme modunu ayarlayın."
+        }
+      },
+      {
+        "icon": "arrow.triangle.branch",
+        "title": {
+          "zh-Hans": "Transform Rules",
+          "en": "Transform Rules",
+          "zh-Hant": "Transform Rules",
+          "zh-HK": "Transform Rules",
+          "ja": "Transform Rules",
+          "es-MX": "Transform Rules",
+          "ko": "Transform Rules",
+          "pt-BR": "Transform Rules",
+          "pt-PT": "Transform Rules",
+          "de": "Transform Rules",
+          "fr": "Transform Rules",
+          "ar": "Transform Rules",
+          "tr": "Transform Rules"
+        },
+        "detail": {
+          "zh-Hans": "查看并编辑 URL 重写、请求头与响应头规则，直接在手机上管理流量改写。",
+          "en": "View and edit URL rewrite, request header, and response header rules — manage traffic transformations right from your phone.",
+          "zh-Hant": "檢視並編輯 URL 重寫、請求標頭與回應標頭規則，直接在手機上管理流量改寫。",
+          "zh-HK": "查看並編輯 URL 重寫、請求標頭與回應標頭規則，直接在手機上管理流量改寫。",
+          "ja": "URL の書き換え、リクエストヘッダー、レスポンスヘッダーのルールを表示・編集し、トラフィックの変換をスマホから管理できます。",
+          "es-MX": "Consulta y edita reglas de reescritura de URL, de encabezados de solicitud y de respuesta, y gestiona las transformaciones de tráfico desde tu teléfono.",
+          "ko": "URL 재작성, 요청 헤더, 응답 헤더 규칙을 확인하고 편집하여 트래픽 변환을 휴대폰에서 바로 관리하세요.",
+          "pt-BR": "Veja e edite regras de reescrita de URL, de cabeçalhos de solicitação e de resposta, gerenciando as transformações de tráfego direto do seu celular.",
+          "pt-PT": "Veja e edite regras de reescrita de URL, de cabeçalhos de pedido e de resposta, gerindo as transformações de tráfego diretamente do seu telemóvel.",
+          "de": "Sieh dir Regeln für URL-Rewrites, Request- und Response-Header an, bearbeite sie und verwalte Traffic-Transformationen direkt vom Handy aus.",
+          "fr": "Consultez et modifiez les règles de réécriture d'URL, d'en-têtes de requête et de réponse, et gérez les transformations de trafic directement depuis votre téléphone.",
+          "ar": "اعرض وحرّر قواعد إعادة كتابة عناوين URL وترويسات الطلب والاستجابة، وأدِر تحويلات حركة المرور مباشرةً من هاتفك.",
+          "tr": "URL yeniden yazma, istek başlığı ve yanıt başlığı kurallarını görüntüleyip düzenleyin; trafik dönüşümlerini doğrudan telefonunuzdan yönetin."
+        }
+      },
+      {
+        "icon": "hand.raised",
+        "title": {
+          "zh-Hans": "IP 访问规则",
+          "en": "IP Access Rules",
+          "zh-Hant": "IP 存取規則",
+          "zh-HK": "IP 存取規則",
+          "ja": "IP アクセスルール",
+          "es-MX": "Reglas de acceso por IP",
+          "ko": "IP 액세스 규칙",
+          "pt-BR": "Regras de acesso por IP",
+          "pt-PT": "Regras de acesso por IP",
+          "de": "IP-Zugriffsregeln",
+          "fr": "Règles d'accès IP",
+          "ar": "قواعد الوصول حسب IP",
+          "tr": "IP erişim kuralları"
+        },
+        "detail": {
+          "zh-Hans": "按 IP、网段、ASN 或国家/地区拦截、质询或放行访问，随时增删规则。",
+          "en": "Block, challenge, or allow visitors by IP, IP range, ASN, or country — add and remove rules anytime.",
+          "zh-Hant": "依 IP、網段、ASN 或國家/地區封鎖、質詢或放行存取，隨時新增或刪除規則。",
+          "zh-HK": "按 IP、網段、ASN 或國家/地區封鎖、質詢或放行存取，隨時新增或刪除規則。",
+          "ja": "IP、IP 範囲、ASN、国/地域ごとにアクセスをブロック・チャレンジ・許可でき、ルールはいつでも追加・削除できます。",
+          "es-MX": "Bloquea, desafía o permite el acceso por IP, rango de IP, ASN o país, y agrega o elimina reglas cuando quieras.",
+          "ko": "IP, IP 범위, ASN 또는 국가/지역별로 접근을 차단·검증·허용하고 규칙을 언제든 추가하거나 삭제하세요.",
+          "pt-BR": "Bloqueie, desafie ou permita o acesso por IP, intervalo de IP, ASN ou país, e adicione ou remova regras quando quiser.",
+          "pt-PT": "Bloqueie, desafie ou permita o acesso por IP, intervalo de IP, ASN ou país, e adicione ou remova regras quando quiser.",
+          "de": "Blockiere, fordere heraus oder erlaube Besucher nach IP, IP-Bereich, ASN oder Land – Regeln jederzeit hinzufügen oder entfernen.",
+          "fr": "Bloquez, défiez ou autorisez les visiteurs par IP, plage d'IP, ASN ou pays, et ajoutez ou supprimez des règles à tout moment.",
+          "ar": "احظر الزوّار أو تحقّق منهم أو اسمح لهم حسب IP أو نطاق IP أو ASN أو الدولة، وأضِف القواعد أو احذفها في أي وقت.",
+          "tr": "Ziyaretçileri IP, IP aralığı, ASN veya ülkeye göre engelleyin, doğrulayın ya da izin verin; kuralları istediğiniz zaman ekleyip kaldırın."
+        }
+      },
+      {
+        "icon": "shippingbox",
+        "title": {
+          "zh-Hans": "R2 存储升级",
+          "en": "R2 Storage Upgrades",
+          "zh-Hant": "R2 儲存升級",
+          "zh-HK": "R2 儲存升級",
+          "ja": "R2 ストレージの強化",
+          "es-MX": "Mejoras en R2 Storage",
+          "ko": "R2 스토리지 개선",
+          "pt-BR": "Melhorias no R2 Storage",
+          "pt-PT": "Melhorias no R2 Storage",
+          "de": "R2-Storage-Upgrades",
+          "fr": "Améliorations du stockage R2",
+          "ar": "تحسينات تخزين R2",
+          "tr": "R2 depolama geliştirmeleri"
+        },
+        "detail": {
+          "zh-Hans": "以文件夹方式浏览对象，复制或移动文件，查看各存储桶用量，并管理公开访问域名与 CORS。",
+          "en": "Browse objects by folder, copy or move files, view per-bucket usage, and manage public access domains and CORS.",
+          "zh-Hant": "以資料夾方式瀏覽物件，複製或移動檔案，檢視各儲存桶用量，並管理公開存取網域與 CORS。",
+          "zh-HK": "以資料夾方式瀏覽物件，複製或移動檔案，查看各儲存桶用量，並管理公開存取域名與 CORS。",
+          "ja": "オブジェクトをフォルダ単位で閲覧し、ファイルのコピーや移動、バケットごとの使用量の確認、公開アクセス用ドメインと CORS の管理ができます。",
+          "es-MX": "Explora objetos por carpeta, copia o mueve archivos, consulta el uso por bucket y administra los dominios de acceso público y CORS.",
+          "ko": "객체를 폴더별로 탐색하고 파일을 복사하거나 이동하며, 버킷별 사용량을 확인하고 공개 액세스 도메인과 CORS를 관리하세요.",
+          "pt-BR": "Navegue pelos objetos por pasta, copie ou mova arquivos, veja o uso por bucket e gerencie domínios de acesso público e CORS.",
+          "pt-PT": "Navegue pelos objetos por pasta, copie ou mova ficheiros, veja a utilização por bucket e faça a gestão de domínios de acesso público e CORS.",
+          "de": "Durchsuche Objekte nach Ordnern, kopiere oder verschiebe Dateien, sieh dir die Nutzung pro Bucket an und verwalte Domains für öffentlichen Zugriff sowie CORS.",
+          "fr": "Parcourez les objets par dossier, copiez ou déplacez des fichiers, consultez l'utilisation par bucket et gérez les domaines d'accès public et le CORS.",
+          "ar": "تصفّح الكائنات حسب المجلد، وانسخ الملفات أو انقلها، واطّلع على الاستخدام لكل حاوية، وأدِر نطاقات الوصول العام وسياسات CORS.",
+          "tr": "Nesneleri klasör klasör inceleyin, dosyaları kopyalayın veya taşıyın, paket başına kullanımı görün ve genel erişim alan adları ile CORS'u yönetin."
+        }
+      },
+      {
+        "icon": "link",
+        "title": {
+          "zh-Hans": "按 URL 精准清缓存",
+          "en": "Purge Cache by URL",
+          "zh-Hant": "依 URL 精準清除快取",
+          "zh-HK": "按 URL 精準清除緩存",
+          "ja": "URL 単位でのキャッシュ削除",
+          "es-MX": "Purga de caché por URL",
+          "ko": "URL 단위 캐시 제거",
+          "pt-BR": "Limpeza de cache por URL",
+          "pt-PT": "Limpeza de cache por URL",
+          "de": "Cache gezielt per URL leeren",
+          "fr": "Purge du cache par URL",
+          "ar": "تفريغ ذاكرة التخزين المؤقت حسب URL",
+          "tr": "URL'ye göre önbellek temizleme"
+        },
+        "detail": {
+          "zh-Hans": "无需清空整站，指定单个或多个 URL 精准刷新缓存；并新增性能与缓存设置页。",
+          "en": "Refresh the cache for specific URLs without clearing the whole site — plus a new performance and cache settings page.",
+          "zh-Hant": "不必清空整站，指定單一或多個 URL 精準刷新快取；並新增效能與快取設定頁。",
+          "zh-HK": "不必清空整站，指定單一或多個 URL 精準刷新緩存；並新增效能與緩存設定頁。",
+          "ja": "サイト全体を消さずに、特定の URL だけキャッシュを更新できます。パフォーマンスとキャッシュの設定ページも追加しました。",
+          "es-MX": "Actualiza la caché de URLs específicas sin borrar todo el sitio, y estrena una página de ajustes de rendimiento y caché.",
+          "ko": "사이트 전체를 비우지 않고 특정 URL의 캐시만 새로 고치세요. 성능 및 캐시 설정 페이지도 추가되었습니다.",
+          "pt-BR": "Atualize o cache de URLs específicas sem limpar o site inteiro — e conte com uma nova página de configurações de desempenho e cache.",
+          "pt-PT": "Atualize a cache de URLs específicos sem limpar o site inteiro — e conte com uma nova página de definições de desempenho e cache.",
+          "de": "Aktualisiere den Cache gezielt für einzelne URLs, ohne die ganze Website zu leeren – dazu eine neue Seite für Leistungs- und Cache-Einstellungen.",
+          "fr": "Actualisez le cache d'URL précises sans vider tout le site, avec en prime une nouvelle page de réglages de performance et de cache.",
+          "ar": "حدّث ذاكرة التخزين المؤقت لعناوين URL محددة دون مسح الموقع بأكمله — مع صفحة جديدة لإعدادات الأداء والتخزين المؤقت.",
+          "tr": "Tüm siteyi temizlemeden belirli URL'lerin önbelleğini yenileyin; ayrıca yeni bir performans ve önbellek ayarları sayfası eklendi."
+        }
+      },
+      {
+        "icon": "globe",
+        "title": {
+          "zh-Hans": "更多语言与稳定性",
+          "en": "More Languages & Stability",
+          "zh-Hant": "更多語言與穩定性",
+          "zh-HK": "更多語言與穩定性",
+          "ja": "言語の追加と安定性の向上",
+          "es-MX": "Más idiomas y estabilidad",
+          "ko": "언어 추가 및 안정성 향상",
+          "pt-BR": "Mais idiomas e estabilidade",
+          "pt-PT": "Mais idiomas e estabilidade",
+          "de": "Mehr Sprachen & Stabilität",
+          "fr": "Plus de langues et de stabilité",
+          "ar": "لغات أكثر واستقرار أفضل",
+          "tr": "Daha fazla dil ve kararlılık"
+        },
+        "detail": {
+          "zh-Hans": "新增德语、法语、阿拉伯语与土耳其语；并改进崩溃诊断，帮助更快定位疑难问题。",
+          "en": "Added German, French, Arabic, and Turkish, plus improved crash diagnostics to track down tricky issues faster.",
+          "zh-Hant": "新增德語、法語、阿拉伯語與土耳其語；並改進當機診斷，協助更快定位疑難問題。",
+          "zh-HK": "新增德語、法語、阿拉伯語與土耳其語；並改進崩潰診斷，協助更快定位疑難問題。",
+          "ja": "ドイツ語・フランス語・アラビア語・トルコ語に対応し、クラッシュ診断も改善して、やっかいな問題をより早く特定できるようにしました。",
+          "es-MX": "Agregamos alemán, francés, árabe y turco, y mejoramos el diagnóstico de fallos para detectar problemas difíciles más rápido.",
+          "ko": "독일어, 프랑스어, 아랍어, 터키어를 추가하고 충돌 진단을 개선하여 까다로운 문제를 더 빠르게 찾아냅니다.",
+          "pt-BR": "Adicionamos alemão, francês, árabe e turco, e melhoramos o diagnóstico de falhas para identificar problemas difíceis mais rápido.",
+          "pt-PT": "Adicionámos alemão, francês, árabe e turco, e melhorámos o diagnóstico de falhas para identificar problemas difíceis mais depressa.",
+          "de": "Deutsch, Französisch, Arabisch und Türkisch kommen hinzu, dazu eine verbesserte Absturzdiagnose, um knifflige Probleme schneller aufzuspüren.",
+          "fr": "Ajout de l'allemand, du français, de l'arabe et du turc, ainsi qu'un diagnostic de plantage amélioré pour cerner plus vite les problèmes délicats.",
+          "ar": "أضفنا الألمانية والفرنسية والعربية والتركية، وحسّنّا تشخيص الأعطال لتحديد المشكلات الصعبة بشكل أسرع.",
+          "tr": "Almanca, Fransızca, Arapça ve Türkçe eklendi; ayrıca zorlu sorunları daha hızlı bulmak için çökme tanılaması iyileştirildi."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.3.2",
     "date": "2026.06.24",
     "channel": "App Store",
@@ -16,7 +222,11 @@
           "es-MX": "Reglas de WAF en lenguaje natural",
           "ko": "자연어로 WAF 규칙 작성",
           "pt-BR": "Regras de WAF em linguagem natural",
-          "pt-PT": "Regras de WAF em linguagem natural"
+          "pt-PT": "Regras de WAF em linguagem natural",
+          "de": "WAF-Regeln in natürlicher Sprache",
+          "fr": "Règles WAF en langage naturel",
+          "ar": "قواعد WAF بلغة طبيعية",
+          "tr": "Doğal dilde WAF kuralları"
         },
         "detail": {
           "zh-Hans": "在支持 Apple 智能的设备上，用一句话描述需求即可生成 WAF 自定义规则，也能把现有规则翻译成大白话；全程在设备上离线完成。",
@@ -27,7 +237,11 @@
           "es-MX": "En dispositivos con Apple Intelligence, describe lo que necesitas en una frase para generar una regla personalizada de WAF; también traduce reglas existentes a lenguaje sencillo. Todo en el dispositivo y sin conexión.",
           "ko": "Apple Intelligence를 지원하는 기기에서 한 문장으로 설명하면 WAF 사용자 지정 규칙을 생성하고, 기존 규칙을 쉬운 말로 풀어 줍니다. 모든 처리는 기기에서 오프라인으로 이뤄집니다.",
           "pt-BR": "Em dispositivos com a Apple Intelligence, descreva o que precisa em uma frase para gerar uma regra personalizada do WAF — e traduza regras existentes para uma linguagem simples. Tudo no dispositivo e off-line.",
-          "pt-PT": "Em dispositivos com a Apple Intelligence, descreva o que precisa numa frase para gerar uma regra personalizada do WAF — e traduza regras existentes para linguagem simples. Tudo no dispositivo e offline."
+          "pt-PT": "Em dispositivos com a Apple Intelligence, descreva o que precisa numa frase para gerar uma regra personalizada do WAF — e traduza regras existentes para linguagem simples. Tudo no dispositivo e offline.",
+          "de": "Auf Geräten mit Apple Intelligence beschreibst du dein Anliegen in einem Satz, um eine WAF-Custom-Regel zu generieren – und übersetzt bestehende Regeln in einfache Worte. Läuft vollständig offline auf dem Gerät.",
+          "fr": "Sur les appareils dotés d’Apple Intelligence, décrivez votre besoin en une phrase pour générer une règle WAF personnalisée — et traduisez les règles existantes en langage simple. Tout se passe hors ligne, sur l’appareil.",
+          "ar": "على الأجهزة المزوّدة بـ Apple Intelligence، صِف ما تريده بجملة واحدة لإنشاء قاعدة WAF مخصصة — وترجم القواعد الحالية إلى كلمات بسيطة. يتم كل ذلك على الجهاز ودون اتصال.",
+          "tr": "Apple Intelligence olan cihazlarda, isteğinizi bir cümleyle tanımlayarak özel bir WAF kuralı oluşturun — ve mevcut kuralları sade bir dile çevirin. Tamamen cihazda, çevrimdışı çalışır."
         }
       },
       {
@@ -41,7 +255,11 @@
           "es-MX": "Corrección de cierre al iniciar",
           "ko": "실행 시 충돌 수정",
           "pt-BR": "Correção de falha ao abrir",
-          "pt-PT": "Correção de falha ao abrir"
+          "pt-PT": "Correção de falha ao abrir",
+          "de": "Absturz beim Start behoben",
+          "fr": "Correction d’un plantage au démarrage",
+          "ar": "إصلاح تعطّل عند البدء",
+          "tr": "Başlangıç çökmesi düzeltildi"
         },
         "detail": {
           "zh-Hans": "修复了 App 在部分 iOS 17 设备上一启动就闪退的问题。",
@@ -52,7 +270,11 @@
           "es-MX": "Se corrigió un problema por el que la app podía cerrarse al iniciar en algunos dispositivos con iOS 17.",
           "ko": "일부 iOS 17 기기에서 앱을 실행하자마자 종료되던 문제를 수정했습니다.",
           "pt-BR": "Corrigimos um problema em que o app podia fechar ao abrir em alguns dispositivos com iOS 17.",
-          "pt-PT": "Corrigimos um problema em que a app podia fechar ao abrir em alguns dispositivos com iOS 17."
+          "pt-PT": "Corrigimos um problema em que a app podia fechar ao abrir em alguns dispositivos com iOS 17.",
+          "de": "Ein Problem wurde behoben, bei dem die App auf einigen iOS-17-Geräten beim Start abstürzen konnte.",
+          "fr": "Correction d’un problème qui pouvait faire planter l’app au démarrage sur certains appareils iOS 17.",
+          "ar": "تم إصلاح مشكلة قد تتسبب في تعطّل التطبيق عند البدء على بعض أجهزة iOS 17.",
+          "tr": "Bazı iOS 17 cihazlarında uygulamanın başlangıçta çökebildiği bir sorun düzeltildi."
         }
       },
       {
@@ -66,7 +288,11 @@
           "es-MX": "Inicio de sesión más estable",
           "ko": "더 안정적인 로그인",
           "pt-BR": "Login mais estável",
-          "pt-PT": "Início de sessão mais estável"
+          "pt-PT": "Início de sessão mais estável",
+          "de": "Stabilere Anmeldung",
+          "fr": "Connexion plus fiable",
+          "ar": "تسجيل دخول أكثر استقرارًا",
+          "tr": "Daha kararlı oturum açma"
         },
         "detail": {
           "zh-Hans": "登录信息改为仅在本机安全保管，修复了偶尔被登出、需要重新登录的问题；登录状态不再通过 iCloud 在设备间同步。",
@@ -77,7 +303,11 @@
           "es-MX": "Los datos de inicio de sesión ahora se guardan de forma segura solo en tu dispositivo, lo que corrige cierres de sesión inesperados ocasionales. El estado de inicio de sesión ya no se sincroniza entre dispositivos mediante iCloud.",
           "ko": "로그인 정보를 기기에만 안전하게 저장하도록 변경하여 간헐적으로 로그아웃되던 문제를 수정했습니다. 로그인 상태는 더 이상 iCloud로 기기 간에 동기화되지 않습니다.",
           "pt-BR": "As informações de login agora ficam guardadas com segurança apenas no seu dispositivo, corrigindo desconexões inesperadas ocasionais. O estado de login não é mais sincronizado entre dispositivos via iCloud.",
-          "pt-PT": "As informações de início de sessão passam a ser guardadas em segurança apenas no seu dispositivo, corrigindo terminações de sessão inesperadas ocasionais. O estado de início de sessão deixa de ser sincronizado entre dispositivos através do iCloud."
+          "pt-PT": "As informações de início de sessão passam a ser guardadas em segurança apenas no seu dispositivo, corrigindo terminações de sessão inesperadas ocasionais. O estado de início de sessão deixa de ser sincronizado entre dispositivos através do iCloud.",
+          "de": "Anmeldedaten werden jetzt nur noch sicher auf deinem Gerät gespeichert, wodurch gelegentliche unerwartete Abmeldungen behoben werden. Der Anmeldestatus wird nicht mehr über iCloud zwischen Geräten synchronisiert.",
+          "fr": "Les informations de connexion sont désormais conservées en sécurité uniquement sur votre appareil, corrigeant des déconnexions inattendues occasionnelles. L’état de connexion n’est plus synchronisé entre appareils via iCloud.",
+          "ar": "تُحفظ معلومات تسجيل الدخول الآن بأمان على جهازك فقط، ما يصلح حالات تسجيل الخروج غير المتوقعة أحيانًا. ولم تعد حالة تسجيل الدخول تتزامن بين الأجهزة عبر iCloud.",
+          "tr": "Oturum açma bilgileri artık yalnızca cihazınızda güvenle saklanır; bu, ara sıra yaşanan beklenmedik oturum kapanmalarını giderir. Oturum durumu artık iCloud ile cihazlar arasında eşitlenmez."
         }
       }
     ]
@@ -99,7 +329,11 @@
           "es-MX": "Nuevo ícono de la app",
           "ko": "새로운 앱 아이콘",
           "pt-BR": "Novo ícone do app",
-          "pt-PT": "Novo ícone da app"
+          "pt-PT": "Novo ícone da app",
+          "de": "Neues App-Symbol",
+          "fr": "Nouvelle icône d’app",
+          "ar": "أيقونة تطبيق جديدة",
+          "tr": "Yeni uygulama simgesi"
         },
         "detail": {
           "zh-Hans": "用 Icon Composer 重制的 Liquid Glass 图标，在 iOS 18 及更新系统上随明暗与着色自适应。",
@@ -110,7 +344,11 @@
           "es-MX": "Un ícono Liquid Glass rehecho con Icon Composer que se adapta a los modos claro, oscuro y con tono en iOS 18 y versiones posteriores.",
           "ko": "Icon Composer로 다시 만든 Liquid Glass 아이콘이 iOS 18 이상에서 라이트·다크·틴트 모드에 맞춰 바뀝니다.",
           "pt-BR": "Um ícone Liquid Glass refeito com o Icon Composer que se adapta aos modos claro, escuro e colorido no iOS 18 e versões posteriores.",
-          "pt-PT": "Um ícone Liquid Glass refeito com o Icon Composer que se adapta aos modos claro, escuro e colorido no iOS 18 e versões posteriores."
+          "pt-PT": "Um ícone Liquid Glass refeito com o Icon Composer que se adapta aos modos claro, escuro e colorido no iOS 18 e versões posteriores.",
+          "de": "Ein mit Icon Composer neu erstelltes Liquid-Glass-Symbol, das sich unter iOS 18 und neuer an helle, dunkle und getönte Modi anpasst.",
+          "fr": "Une icône Liquid Glass refaite avec Icon Composer qui s’adapte aux modes clair, sombre et teinté sur iOS 18 et versions ultérieures.",
+          "ar": "أيقونة Liquid Glass أُعيد تصميمها باستخدام Icon Composer، تتكيّف مع الأوضاع الفاتح والداكن والملوّن على iOS 18 والأحدث.",
+          "tr": "Icon Composer ile yeniden oluşturulan ve iOS 18 ve sonrasında açık, koyu ve renkli modlara uyum sağlayan bir Liquid Glass simgesi."
         }
       },
       {
@@ -124,7 +362,11 @@
           "es-MX": "Corrección de rutas de Worker",
           "ko": "Worker 경로 수정",
           "pt-BR": "Correção de rotas do Worker",
-          "pt-PT": "Correção de rotas do Worker"
+          "pt-PT": "Correção de rotas do Worker",
+          "de": "Worker-Routen-Korrektur",
+          "fr": "Correction des routes de Worker",
+          "ar": "إصلاح مسارات Worker",
+          "tr": "Worker rota düzeltmesi"
         },
         "detail": {
           "zh-Hans": "修复部分账号下 Worker 的域名与路由无法加载的问题。",
@@ -135,7 +377,11 @@
           "es-MX": "Se corrigió un problema por el que los dominios y rutas de un Worker no cargaban en algunas cuentas.",
           "ko": "일부 계정에서 Worker의 도메인과 경로가 로드되지 않던 문제를 수정했습니다.",
           "pt-BR": "Corrigimos um problema em que os domínios e rotas de um Worker não carregavam em algumas contas.",
-          "pt-PT": "Corrigimos um problema em que os domínios e rotas de um Worker não carregavam em algumas contas."
+          "pt-PT": "Corrigimos um problema em que os domínios e rotas de um Worker não carregavam em algumas contas.",
+          "de": "Ein Problem wurde behoben, bei dem Domains und Routen eines Workers für einige Konten nicht geladen wurden.",
+          "fr": "Correction d’un problème où les domaines et routes d’un Worker ne se chargeaient pas pour certains comptes.",
+          "ar": "تم إصلاح مشكلة لم تكن فيها نطاقات Worker ومساراته تُحمّل لبعض الحسابات.",
+          "tr": "Bazı hesaplarda bir Worker’ın alan adlarının ve rotalarının yüklenmediği bir sorun düzeltildi."
         }
       },
       {
@@ -149,7 +395,11 @@
           "es-MX": "Mejoras de estabilidad",
           "ko": "안정성 향상",
           "pt-BR": "Melhorias de estabilidade",
-          "pt-PT": "Melhorias de estabilidade"
+          "pt-PT": "Melhorias de estabilidade",
+          "de": "Stabilitätsverbesserungen",
+          "fr": "Améliorations de stabilité",
+          "ar": "تحسينات في الاستقرار",
+          "tr": "Kararlılık iyileştirmeleri"
         },
         "detail": {
           "zh-Hans": "修复极少数情况下因本地缓存异常导致的启动问题，并优化若干细节。",
@@ -160,7 +410,11 @@
           "es-MX": "Se corrigió un problema poco frecuente de inicio causado por una caché local dañada y se pulieron varios detalles.",
           "ko": "드물게 로컬 캐시 손상으로 앱이 시작되지 않던 문제를 수정하고 여러 부분을 다듬었습니다.",
           "pt-BR": "Corrigimos um problema raro de inicialização causado por um cache local corrompido e refinamos vários detalhes.",
-          "pt-PT": "Corrigimos um problema raro de arranque causado por uma cache local danificada e refinámos vários detalhes."
+          "pt-PT": "Corrigimos um problema raro de arranque causado por uma cache local danificada e refinámos vários detalhes.",
+          "de": "Ein seltenes Startproblem durch einen beschädigten lokalen Cache wurde behoben, dazu verschiedene Verfeinerungen.",
+          "fr": "Correction d’un rare problème de démarrage causé par un cache local corrompu, ainsi que diverses améliorations.",
+          "ar": "تم إصلاح مشكلة بدء نادرة ناتجة عن تلف التخزين المؤقت المحلي، مع تحسينات متنوعة.",
+          "tr": "Bozuk yerel önbellekten kaynaklanan nadir bir başlangıç sorunu düzeltildi ve çeşitli iyileştirmeler yapıldı."
         }
       }
     ]
@@ -182,7 +436,11 @@
           "es-MX": "Agregar dominio",
           "ko": "도메인 추가",
           "pt-BR": "Adicionar domínio",
-          "pt-PT": "Adicionar domínio"
+          "pt-PT": "Adicionar domínio",
+          "de": "Domain hinzufügen",
+          "fr": "Ajouter un domaine",
+          "ar": "إضافة نطاق",
+          "tr": "Alan adı ekle"
         },
         "detail": {
           "zh-Hans": "在 App 里把已注册的域名加入账号，并拿到要去注册商处配置的名称服务器。",
@@ -193,7 +451,11 @@
           "es-MX": "Agrega a tu cuenta un dominio que ya tengas y obtén los servidores de nombres para configurarlos en tu registrador.",
           "ko": "이미 보유한 도메인을 계정에 추가하고 등록 대행자에 설정할 네임서버를 받으세요.",
           "pt-BR": "Adicione à sua conta um domínio que você já tem e obtenha os servidores de nomes para configurar no seu registrador.",
-          "pt-PT": "Adicione à sua conta um domínio que já possui e obtenha os servidores de nomes para configurar no seu registador."
+          "pt-PT": "Adicione à sua conta um domínio que já possui e obtenha os servidores de nomes para configurar no seu registador.",
+          "de": "Füge eine Domain, die dir bereits gehört, deinem Konto hinzu und erhalte die Nameserver, die du bei deinem Registrar einträgst.",
+          "fr": "Ajoutez à votre compte un domaine que vous possédez déjà et obtenez les serveurs de noms à configurer chez votre registraire.",
+          "ar": "أضِف نطاقًا تملكه بالفعل إلى حسابك واحصل على خوادم الأسماء لضبطها لدى مُسجِّل النطاق.",
+          "tr": "Zaten sahip olduğunuz bir alan adını hesabınıza ekleyin ve kayıt kuruluşunuzda ayarlamanız gereken ad sunucularını alın."
         }
       },
       {
@@ -207,7 +469,11 @@
           "es-MX": "Gestión de túneles",
           "ko": "터널 관리",
           "pt-BR": "Gerenciamento de túneis",
-          "pt-PT": "Gestão de túneis"
+          "pt-PT": "Gestão de túneis",
+          "de": "Tunnel-Verwaltung",
+          "fr": "Gestion des tunnels",
+          "ar": "إدارة الأنفاق",
+          "tr": "Tünel yönetimi"
         },
         "detail": {
           "zh-Hans": "不再只是查看——新建隧道、获取连接令牌与命令、配置公共主机名路由。",
@@ -218,7 +484,11 @@
           "es-MX": "Ya no solo para ver: crea túneles, obtén tokens y comandos de conexión y configura el enrutamiento por nombre de host público.",
           "ko": "이제 보기만이 아니라 터널 생성, 연결 토큰과 명령 가져오기, 공개 호스트 이름 라우팅 구성까지.",
           "pt-BR": "Não é mais só visualizar: crie túneis, obtenha tokens e comandos de conexão e configure o roteamento por nome de host público.",
-          "pt-PT": "Já não é só visualizar: crie túneis, obtenha tokens e comandos de ligação e configure o encaminhamento por nome de anfitrião público."
+          "pt-PT": "Já não é só visualizar: crie túneis, obtenha tokens e comandos de ligação e configure o encaminhamento por nome de anfitrião público.",
+          "de": "Mehr als nur Ansehen – Tunnel erstellen, Verbindungstoken und Befehle abrufen und Routing öffentlicher Hostnamen konfigurieren.",
+          "fr": "Plus seulement consulter — créez des tunnels, obtenez des jetons de connexion et des commandes, et configurez le routage des noms d’hôte publics.",
+          "ar": "أكثر من مجرد عرض الآن — أنشئ الأنفاق، واحصل على رموز الاتصال والأوامر، واضبط توجيه أسماء المضيفين العامة.",
+          "tr": "Artık yalnızca görüntülemek değil — tüneller oluşturun, bağlantı belirteçleri ve komutları alın ve genel ana makine adı yönlendirmesini yapılandırın."
         }
       },
       {
@@ -232,7 +502,11 @@
           "es-MX": "Gestión de bases de datos D1",
           "ko": "D1 데이터베이스 관리",
           "pt-BR": "Gerenciamento de bancos de dados D1",
-          "pt-PT": "Gestão de bases de dados D1"
+          "pt-PT": "Gestão de bases de dados D1",
+          "de": "D1-Datenbankverwaltung",
+          "fr": "Gestion de base de données D1",
+          "ar": "إدارة قاعدة بيانات D1",
+          "tr": "D1 veritabanı yönetimi"
         },
         "detail": {
           "zh-Hans": "直接新建 D1 数据库，或在原样确认库名后安全删除。",
@@ -243,7 +517,11 @@
           "es-MX": "Crea una base de datos D1, o elimínala de forma segura tras confirmar su nombre exacto.",
           "ko": "D1 데이터베이스를 만들거나, 데이터베이스 이름을 그대로 확인한 뒤 안전하게 삭제하세요.",
           "pt-BR": "Crie um banco de dados D1 ou exclua-o com segurança após confirmar o nome exato.",
-          "pt-PT": "Crie uma base de dados D1 ou elimine-a com segurança após confirmar o nome exato."
+          "pt-PT": "Crie uma base de dados D1 ou elimine-a com segurança após confirmar o nome exato.",
+          "de": "Erstelle eine D1-Datenbank oder lösche eine sicher, nachdem du ihren genauen Namen bestätigt hast.",
+          "fr": "Créez une base de données D1, ou supprimez-en une en toute sécurité après avoir confirmé son nom exact.",
+          "ar": "أنشئ قاعدة بيانات D1، أو احذف واحدة بأمان بعد تأكيد اسمها بالضبط.",
+          "tr": "Bir D1 veritabanı oluşturun veya tam adını doğruladıktan sonra birini güvenle silin."
         }
       },
       {
@@ -257,7 +535,11 @@
           "es-MX": "Variables y secretos",
           "ko": "변수와 시크릿",
           "pt-BR": "Variáveis e segredos",
-          "pt-PT": "Variáveis e segredos"
+          "pt-PT": "Variáveis e segredos",
+          "de": "Variablen & Secrets",
+          "fr": "Variables et secrets",
+          "ar": "المتغيرات والأسرار",
+          "tr": "Değişkenler ve Gizli Bilgiler"
         },
         "detail": {
           "zh-Hans": "管理 Worker 的环境变量与密钥，随手增删改。",
@@ -268,7 +550,11 @@
           "es-MX": "Gestiona las variables de entorno y los secretos de un Worker: agrega, edita y elimina al instante.",
           "ko": "Worker의 환경 변수와 시크릿을 관리하고 언제든 추가·편집·삭제하세요.",
           "pt-BR": "Gerencie as variáveis de ambiente e os segredos de um Worker: adicione, edite e remova na hora.",
-          "pt-PT": "Faça a gestão das variáveis de ambiente e dos segredos de um Worker: adicione, edite e remova na hora."
+          "pt-PT": "Faça a gestão das variáveis de ambiente e dos segredos de um Worker: adicione, edite e remova na hora.",
+          "de": "Verwalte die Umgebungsvariablen und Secrets eines Workers – jederzeit hinzufügen, bearbeiten und entfernen.",
+          "fr": "Gérez les variables d’environnement et les secrets d’un Worker — ajoutez, modifiez et supprimez à la volée.",
+          "ar": "أدِر متغيرات البيئة والأسرار لـ Worker — إضافة وتعديل وحذف في أي وقت.",
+          "tr": "Bir Worker’ın ortam değişkenlerini ve gizli bilgilerini yönetin — anında ekleyin, düzenleyin ve kaldırın."
         }
       },
       {
@@ -282,7 +568,11 @@
           "es-MX": "Activadores Cron",
           "ko": "Cron 트리거",
           "pt-BR": "Gatilhos Cron",
-          "pt-PT": "Gatilhos Cron"
+          "pt-PT": "Gatilhos Cron",
+          "de": "Cron-Trigger",
+          "fr": "Déclencheurs Cron",
+          "ar": "مشغّلات Cron",
+          "tr": "Cron Tetikleyicileri"
         },
         "detail": {
           "zh-Hans": "查看与增删 Cron 触发器，让 Worker 按计划自动运行。",
@@ -293,7 +583,11 @@
           "es-MX": "Consulta, agrega y elimina activadores Cron para que un Worker se ejecute automáticamente según un horario.",
           "ko": "Cron 트리거를 보고 추가·삭제하여 Worker가 일정에 따라 자동으로 실행되게 하세요.",
           "pt-BR": "Veja, adicione e remova gatilhos Cron para que um Worker seja executado automaticamente conforme a programação.",
-          "pt-PT": "Veja, adicione e remova gatilhos Cron para que um Worker seja executado automaticamente conforme o agendamento."
+          "pt-PT": "Veja, adicione e remova gatilhos Cron para que um Worker seja executado automaticamente conforme o agendamento.",
+          "de": "Sieh dir Cron-Trigger an, füge sie hinzu und entferne sie, damit ein Worker planmäßig automatisch läuft.",
+          "fr": "Consultez, ajoutez et supprimez des déclencheurs Cron pour qu’un Worker s’exécute automatiquement selon un planning.",
+          "ar": "اعرض مشغّلات Cron وأضِفها واحذفها ليعمل الـ Worker تلقائيًا وفق جدول.",
+          "tr": "Bir Worker’ın programa göre otomatik çalışması için Cron tetikleyicilerini görüntüleyin, ekleyin ve kaldırın."
         }
       },
       {
@@ -307,7 +601,11 @@
           "es-MX": "Dominios y rutas",
           "ko": "도메인과 라우트",
           "pt-BR": "Domínios e rotas",
-          "pt-PT": "Domínios e rotas"
+          "pt-PT": "Domínios e rotas",
+          "de": "Domains & Routen",
+          "fr": "Domaines et routes",
+          "ar": "النطاقات والمسارات",
+          "tr": "Alan adları ve Rotalar"
         },
         "detail": {
           "zh-Hans": "管理 workers.dev 子域、自定义域与路由，掌控 Worker 的访问入口。",
@@ -318,7 +616,11 @@
           "es-MX": "Gestiona el subdominio workers.dev, los dominios personalizados y las rutas para controlar cómo se accede a un Worker.",
           "ko": "workers.dev 서브도메인, 사용자 지정 도메인, 라우트를 관리해 Worker 접근 경로를 제어하세요.",
           "pt-BR": "Gerencie o subdomínio workers.dev, domínios personalizados e rotas para controlar como um Worker é acessado.",
-          "pt-PT": "Faça a gestão do subdomínio workers.dev, domínios personalizados e rotas para controlar como um Worker é acedido."
+          "pt-PT": "Faça a gestão do subdomínio workers.dev, domínios personalizados e rotas para controlar como um Worker é acedido.",
+          "de": "Verwalte die workers.dev-Subdomain, eigene Domains und Routen, um zu steuern, wie ein Worker erreicht wird.",
+          "fr": "Gérez le sous-domaine workers.dev, les domaines personnalisés et les routes pour contrôler l’accès à un Worker.",
+          "ar": "أدِر نطاق workers.dev الفرعي والنطاقات المخصصة والمسارات للتحكم في كيفية الوصول إلى Worker.",
+          "tr": "Bir Worker’a nasıl erişileceğini denetlemek için workers.dev alt alan adını, özel alan adlarını ve rotaları yönetin."
         }
       }
     ]
@@ -340,7 +642,11 @@
           "es-MX": "App de Apple Watch",
           "ko": "Apple Watch 앱",
           "pt-BR": "App do Apple Watch",
-          "pt-PT": "App do Apple Watch"
+          "pt-PT": "App do Apple Watch",
+          "de": "Apple Watch App",
+          "fr": "App Apple Watch",
+          "ar": "تطبيق Apple Watch",
+          "tr": "Apple Watch uygulaması"
         },
         "detail": {
           "zh-Hans": "把域名状态与流量概览带上手腕，还能添加到表盘复杂功能随时一瞥。",
@@ -351,7 +657,11 @@
           "es-MX": "Lleva a tu muñeca el estado de los dominios y el resumen de tráfico, con complicaciones en la carátula para verlo de un vistazo.",
           "ko": "도메인 상태와 트래픽 개요를 손목에서 확인하고, 시계 페이스 컴플리케이션으로 언제든 한눈에 볼 수 있어요.",
           "pt-BR": "Leve o status dos domínios e o resumo de tráfego para o pulso, com complicações no mostrador para ver num relance.",
-          "pt-PT": "Leve o estado dos domínios e o resumo de tráfego para o pulso, com complicações no mostrador para ver num relance."
+          "pt-PT": "Leve o estado dos domínios e o resumo de tráfego para o pulso, com complicações no mostrador para ver num relance.",
+          "de": "Bring Domain-Status und Traffic-Übersicht an dein Handgelenk – mit Komplikationen auf dem Zifferblatt für einen Blick jederzeit.",
+          "fr": "Apportez l’état des domaines et l’aperçu du trafic à votre poignet, avec des complications sur le cadran pour un coup d’œil à tout moment.",
+          "ar": "انقل حالة النطاقات ونظرة عامة على حركة المرور إلى معصمك، مع تعقيدات على واجهة الساعة لإلقاء نظرة في أي وقت.",
+          "tr": "Alan adı durumunu ve trafik genel görünümünü bileğinize taşıyın; istediğiniz an bir bakış için saat kadranı komplikasyonlarıyla."
         }
       },
       {
@@ -365,7 +675,11 @@
           "es-MX": "Snippets",
           "ko": "Snippets",
           "pt-BR": "Snippets",
-          "pt-PT": "Snippets"
+          "pt-PT": "Snippets",
+          "de": "Snippets",
+          "fr": "Snippets",
+          "ar": "Snippets",
+          "tr": "Snippets"
         },
         "detail": {
           "zh-Hans": "在域名详情查看、编辑、新建 Cloudflare 边缘代码片段，并管理触发规则——轻量版 Workers，Pro 解锁。",
@@ -376,7 +690,11 @@
           "es-MX": "Consulta, edita y crea snippets de borde de Cloudflare —y gestiona sus reglas de activación— desde los detalles del dominio. Workers ligeros, desbloqueados con Pro.",
           "ko": "도메인 상세에서 Cloudflare 엣지 코드 조각을 보고, 편집하고, 만들고 트리거 규칙을 관리하세요 — 가벼운 Workers, Pro로 잠금 해제.",
           "pt-BR": "Veja, edite e crie snippets de borda da Cloudflare — e gerencie suas regras de acionamento — nos detalhes do domínio. Workers leves, desbloqueados com o Pro.",
-          "pt-PT": "Veja, edite e crie snippets de periferia da Cloudflare — e faça a gestão das suas regras de acionamento — nos detalhes do domínio. Workers leves, desbloqueados com o Pro."
+          "pt-PT": "Veja, edite e crie snippets de periferia da Cloudflare — e faça a gestão das suas regras de acionamento — nos detalhes do domínio. Workers leves, desbloqueados com o Pro.",
+          "de": "Sieh dir Cloudflare-Edge-Code-Snippets in den Domain-Details an, bearbeite und erstelle sie und verwalte ihre Trigger-Regeln – leichtgewichtige Workers, freigeschaltet mit Pro.",
+          "fr": "Consultez, modifiez et créez des snippets de code en périphérie Cloudflare — et gérez leurs règles de déclenchement — directement dans les détails du domaine. Des Workers légers, débloqués avec Pro.",
+          "ar": "اعرض مقتطفات شفرة Cloudflare على الحافة وعدّلها وأنشئها، وأدِر قواعد تشغيلها — مباشرةً في تفاصيل النطاق. Workers خفيفة، تُفتَح مع Pro.",
+          "tr": "Cloudflare uç kod snippet’lerini alan adı ayrıntılarında görüntüleyin, düzenleyin ve oluşturun — ayrıca tetikleme kurallarını yönetin. Hafif Workers, Pro ile açılır."
         }
       },
       {
@@ -390,7 +708,11 @@
           "es-MX": "Totalmente accesible",
           "ko": "완전한 접근성",
           "pt-BR": "Totalmente acessível",
-          "pt-PT": "Totalmente acessível"
+          "pt-PT": "Totalmente acessível",
+          "de": "Vollständig barrierefrei",
+          "fr": "Entièrement accessible",
+          "ar": "متاح بالكامل لذوي الاحتياجات",
+          "tr": "Tamamen erişilebilir"
         },
         "detail": {
           "zh-Hans": "VoiceOver、更大字体、不只靠颜色区分、足够对比度全面达标，配合系统辅助功能更顺手。",
@@ -401,7 +723,11 @@
           "es-MX": "VoiceOver, texto más grande, indicaciones que no dependen solo del color y contraste suficiente: todo listo para funcionar bien con las funciones de accesibilidad del sistema.",
           "ko": "VoiceOver, 더 큰 텍스트, 색상에만 의존하지 않는 표시, 충분한 대비를 모두 지원하여 시스템 손쉬운 사용 기능과 매끄럽게 어울립니다.",
           "pt-BR": "VoiceOver, texto maior, indicações que não dependem só da cor e contraste suficiente — tudo pronto para funcionar bem com os recursos de acessibilidade do sistema.",
-          "pt-PT": "VoiceOver, texto maior, indicações que não dependem só da cor e contraste suficiente — tudo pronto para funcionar bem com as funcionalidades de acessibilidade do sistema."
+          "pt-PT": "VoiceOver, texto maior, indicações que não dependem só da cor e contraste suficiente — tudo pronto para funcionar bem com as funcionalidades de acessibilidade do sistema.",
+          "de": "VoiceOver, größerer Text, nicht nur farbabhängige Hinweise und ausreichender Kontrast – alles erfüllt, sodass die App reibungslos mit den Bedienungshilfen des Systems funktioniert.",
+          "fr": "VoiceOver, texte plus grand, repères ne reposant pas uniquement sur la couleur et contraste suffisant — tout est en place, pour que l’app fonctionne sans accroc avec les fonctionnalités d’accessibilité du système.",
+          "ar": "‏VoiceOver ونص أكبر وإشارات لا تعتمد على اللون وحده وتباين كافٍ — كل ذلك متوفر، لتعمل التطبيق بسلاسة مع ميزات تسهيلات الاستخدام في النظام.",
+          "tr": "VoiceOver, daha büyük metin, yalnızca renge dayanmayan ipuçları ve yeterli kontrast — hepsi mevcut; böylece uygulama, sistemin erişilebilirlik özellikleriyle sorunsuz çalışır."
         }
       },
       {
@@ -415,7 +741,11 @@
           "es-MX": "Más idiomas",
           "ko": "더 많은 언어",
           "pt-BR": "Mais idiomas",
-          "pt-PT": "Mais idiomas"
+          "pt-PT": "Mais idiomas",
+          "de": "Weitere Sprachen",
+          "fr": "Plus de langues",
+          "ar": "المزيد من اللغات",
+          "tr": "Daha fazla dil"
         },
         "detail": {
           "zh-Hans": "新增西班牙语、韩语、葡萄牙语，现已支持九种语言。",
@@ -426,7 +756,11 @@
           "es-MX": "Agregamos español, coreano y portugués: ahora en nueve idiomas.",
           "ko": "스페인어, 한국어, 포르투갈어가 추가되어 이제 9개 언어를 지원합니다.",
           "pt-BR": "Adicionamos espanhol, coreano e português — agora em nove idiomas.",
-          "pt-PT": "Adicionámos espanhol, coreano e português — agora em nove idiomas."
+          "pt-PT": "Adicionámos espanhol, coreano e português — agora em nove idiomas.",
+          "de": "Spanisch, Koreanisch und Portugiesisch hinzugefügt – jetzt in neun Sprachen verfügbar.",
+          "fr": "Ajout de l’espagnol, du coréen et du portugais — désormais disponible en neuf langues.",
+          "ar": "أُضيفت الإسبانية والكورية والبرتغالية — متاح الآن بتسع لغات.",
+          "tr": "İspanyolca, Korece ve Portekizce eklendi — artık dokuz dilde."
         }
       },
       {
@@ -440,7 +774,11 @@
           "es-MX": "Actualización más fluida",
           "ko": "더 매끄러운 새로고침",
           "pt-BR": "Atualização mais fluida",
-          "pt-PT": "Atualização mais fluida"
+          "pt-PT": "Atualização mais fluida",
+          "de": "Reibungsloseres Aktualisieren",
+          "fr": "Actualisation plus fluide",
+          "ar": "تحديث أكثر سلاسة",
+          "tr": "Daha akıcı yenileme"
         },
         "detail": {
           "zh-Hans": "刷新失败不再弹窗打断，下拉刷新更稳定可靠。",
@@ -451,7 +789,11 @@
           "es-MX": "Los errores al actualizar ya no interrumpen con alertas y deslizar para actualizar es más confiable.",
           "ko": "새로고침 실패 시 더 이상 알림으로 방해하지 않으며, 당겨서 새로고침이 더 안정적입니다.",
           "pt-BR": "Falhas ao atualizar não interrompem mais com alertas, e o puxar para atualizar ficou mais confiável.",
-          "pt-PT": "As falhas ao atualizar já não interrompem com alertas, e o puxar para atualizar ficou mais fiável."
+          "pt-PT": "As falhas ao atualizar já não interrompem com alertas, e o puxar para atualizar ficou mais fiável.",
+          "de": "Aktualisierungsfehler unterbrechen nicht mehr mit Hinweisen, und das Ziehen zum Aktualisieren ist zuverlässiger.",
+          "fr": "Les échecs d’actualisation n’interrompent plus avec des alertes, et le tirer-pour-actualiser est plus fiable.",
+          "ar": "لم تعد أخطاء التحديث تقاطعك بتنبيهات، وأصبح السحب للتحديث أكثر موثوقية.",
+          "tr": "Yenileme hataları artık uyarılarla bölmüyor ve yenilemek için çekme daha güvenilir."
         }
       }
     ]
@@ -473,7 +815,11 @@
           "es-MX": "Cambiar de cuenta ahora filtra todo: Workers, almacenamiento y estadísticas siguen la cuenta seleccionada",
           "ko": "계정을 전환하면 Workers, 스토리지, 통계 등 모든 리소스가 선택한 계정만 따라 표시됩니다",
           "pt-BR": "Trocar de conta agora filtra tudo: Workers, armazenamento e estatísticas seguem a conta selecionada",
-          "pt-PT": "Mudar de conta passa a filtrar tudo: Workers, armazenamento e estatísticas seguem a conta selecionada"
+          "pt-PT": "Mudar de conta passa a filtrar tudo: Workers, armazenamento e estatísticas seguem a conta selecionada",
+          "de": "Beim Kontowechsel wird jetzt alles gefiltert – Workers, Speicher und Statistiken folgen dem ausgewählten Konto.",
+          "fr": "Le changement de compte filtre désormais tout : Workers, stockage et statistiques suivent le compte sélectionné.",
+          "ar": "أصبح تبديل الحساب الآن يفلتر كل شيء — تتبع Workers والتخزين والإحصاءات الحساب المحدد.",
+          "tr": "Hesap değiştirmek artık her şeyi filtreliyor — Workers, depolama ve istatistikler seçtiğiniz hesabı izliyor."
         }
       },
       {
@@ -486,7 +832,11 @@
           "es-MX": "Inicio de sesión más robusto: se corrigió la autorización que caducaba demasiado pronto y el reinicio de sesión tras un breve corte de red",
           "ko": "더 탄탄해진 로그인: 인증이 너무 일찍 만료되고 짧은 네트워크 끊김 후 다시 로그인을 요구하던 문제를 수정",
           "pt-BR": "Login mais robusto: corrigimos a autorização que expirava cedo demais e o novo pedido de login após uma breve queda de rede",
-          "pt-PT": "Início de sessão mais robusto: corrigimos a autorização que expirava cedo demais e o novo pedido de início de sessão após uma breve falha de rede"
+          "pt-PT": "Início de sessão mais robusto: corrigimos a autorização que expirava cedo demais e o novo pedido de início de sessão após uma breve falha de rede",
+          "de": "Stabilere Anmeldung: Behoben, dass die Autorisierung zu früh ablief und nach einem kurzen Netzwerkaussetzer erneut zur Anmeldung aufgefordert wurde.",
+          "fr": "Connexion plus robuste : correction de l’autorisation qui expirait trop tôt et des nouvelles demandes de connexion après une brève coupure réseau.",
+          "ar": "تسجيل دخول أكثر متانة: إصلاح انتهاء صلاحية التفويض مبكرًا جدًا وطلب إعادة تسجيل الدخول بعد انقطاع شبكي قصير.",
+          "tr": "Daha sağlam oturum açma: yetkilendirmenin çok erken sona ermesi ve kısa bir ağ kesintisinden sonra yeniden oturum açma istenmesi düzeltildi."
         }
       }
     ]
@@ -508,7 +858,11 @@
           "es-MX": "Se redujo el requisito mínimo de iOS, para que funcione en muchos más iPhone y iPad",
           "ko": "최소 시스템 요구 사항을 낮춰 훨씬 더 많은 iPhone과 iPad에서 사용할 수 있습니다",
           "pt-BR": "Reduzimos o requisito mínimo de iOS, para rodar em muito mais iPhone e iPad",
-          "pt-PT": "Reduzimos o requisito mínimo de iOS, para funcionar em muitos mais iPhone e iPad"
+          "pt-PT": "Reduzimos o requisito mínimo de iOS, para funcionar em muitos mais iPhone e iPad",
+          "de": "Mindest-iOS-Anforderung gesenkt, sodass weit mehr iPhone und iPad sie ausführen können.",
+          "fr": "Abaissement de la version iOS minimale requise, pour que bien plus d’iPhone et d’iPad puissent l’utiliser.",
+          "ar": "خفض الحد الأدنى لمتطلبات iOS، ليعمل على عدد أكبر بكثير من أجهزة iPhone وiPad.",
+          "tr": "Minimum iOS gereksinimi düşürüldü; böylece çok daha fazla iPhone ve iPad çalıştırabiliyor."
         }
       }
     ]
@@ -530,7 +884,11 @@
           "es-MX": "Primera beta pública",
           "ko": "첫 공개 베타",
           "pt-BR": "Primeira beta pública",
-          "pt-PT": "Primeira beta pública"
+          "pt-PT": "Primeira beta pública",
+          "de": "Erste öffentliche Beta",
+          "fr": "Première bêta publique",
+          "ar": "أول إصدار تجريبي عام",
+          "tr": "İlk herkese açık beta"
         }
       },
       {
@@ -543,7 +901,11 @@
           "es-MX": "Inicio de sesión con OAuth oficial · sin tokens de API",
           "ko": "공식 OAuth 로그인 · API 토큰 불필요",
           "pt-BR": "Login com OAuth oficial · sem tokens de API",
-          "pt-PT": "Início de sessão com OAuth oficial · sem tokens de API"
+          "pt-PT": "Início de sessão com OAuth oficial · sem tokens de API",
+          "de": "Offizielle OAuth-Anmeldung · kein API-Token nötig",
+          "fr": "Connexion OAuth officielle · aucun jeton d’API requis",
+          "ar": "تسجيل دخول OAuth الرسمي · دون الحاجة إلى رمز API",
+          "tr": "Resmi OAuth oturum açma · API belirteci gerekmez"
         }
       },
       {
@@ -556,7 +918,11 @@
           "es-MX": "Lista de dominios · gestión completa de DNS",
           "ko": "도메인 목록 · DNS 전체 관리",
           "pt-BR": "Lista de domínios · gerenciamento completo de DNS",
-          "pt-PT": "Lista de domínios · gestão completa de DNS"
+          "pt-PT": "Lista de domínios · gestão completa de DNS",
+          "de": "Domain-Liste · vollständige DNS-Verwaltung",
+          "fr": "Liste des domaines · gestion DNS complète",
+          "ar": "قائمة النطاقات · إدارة DNS كاملة",
+          "tr": "Alan adı listesi · tam DNS yönetimi"
         }
       },
       {
@@ -569,7 +935,11 @@
           "es-MX": "Análisis de tráfico (solicitudes / ancho de banda / caché / amenazas)",
           "ko": "트래픽 분석 (요청 / 대역폭 / 캐시 / 위협)",
           "pt-BR": "Análise de tráfego (solicitações / largura de banda / cache / ameaças)",
-          "pt-PT": "Análise de tráfego (pedidos / largura de banda / cache / ameaças)"
+          "pt-PT": "Análise de tráfego (pedidos / largura de banda / cache / ameaças)",
+          "de": "Traffic-Analyse (Anfragen / Bandbreite / Cache / Bedrohungen)",
+          "fr": "Analyses de trafic (requêtes / bande passante / cache / menaces)",
+          "ar": "تحليلات حركة المرور (الطلبات / النطاق الترددي / التخزين المؤقت / التهديدات)",
+          "tr": "Trafik analizleri (istekler / bant genişliği / önbellek / tehditler)"
         }
       },
       {
@@ -582,7 +952,11 @@
           "es-MX": "Lista de Workers · registros en vivo",
           "ko": "Workers 목록 · 실시간 로그 tail",
           "pt-BR": "Lista de Workers · logs em tempo real",
-          "pt-PT": "Lista de Workers · registos em tempo real"
+          "pt-PT": "Lista de Workers · registos em tempo real",
+          "de": "Workers-Liste · Live-Log-Tail",
+          "fr": "Liste des Workers · suivi des journaux en direct",
+          "ar": "قائمة Workers · تتبّع السجلات المباشر",
+          "tr": "Workers listesi · canlı günlük takibi"
         }
       },
       {
@@ -595,7 +969,11 @@
           "es-MX": "Explorador de objetos R2 · consola SQL D1 · gestión KV",
           "ko": "R2 객체 탐색 · D1 SQL 콘솔 · KV 관리",
           "pt-BR": "Explorador de objetos R2 · console SQL D1 · gerenciamento KV",
-          "pt-PT": "Explorador de objetos R2 · consola SQL D1 · gestão KV"
+          "pt-PT": "Explorador de objetos R2 · consola SQL D1 · gestão KV",
+          "de": "R2-Objektbrowser · D1-SQL-Konsole · KV-Verwaltung",
+          "fr": "Explorateur d’objets R2 · console SQL D1 · gestion KV",
+          "ar": "متصفح كائنات R2 · وحدة تحكم D1 SQL · إدارة KV",
+          "tr": "R2 nesne tarayıcısı · D1 SQL konsolu · KV yönetimi"
         }
       },
       {
@@ -608,7 +986,11 @@
           "es-MX": "Reglas WAF personalizadas · estado de Cloudflare Tunnel",
           "ko": "WAF 사용자 지정 규칙 · Cloudflare Tunnel 상태",
           "pt-BR": "Regras WAF personalizadas · status do Cloudflare Tunnel",
-          "pt-PT": "Regras WAF personalizadas · estado do Cloudflare Tunnel"
+          "pt-PT": "Regras WAF personalizadas · estado do Cloudflare Tunnel",
+          "de": "WAF-Custom-Regeln · Cloudflare-Tunnel-Status",
+          "fr": "Règles WAF personnalisées · état de Cloudflare Tunnel",
+          "ar": "قواعد WAF المخصصة · حالة Cloudflare Tunnel",
+          "tr": "WAF özel kuralları · Cloudflare Tunnel durumu"
         }
       },
       {
@@ -621,7 +1003,11 @@
           "es-MX": "Widgets de pantalla de inicio · atajos de Siri · varias cuentas",
           "ko": "홈 화면 위젯 · Siri 단축어 · 다중 계정",
           "pt-BR": "Widgets da tela de início · atalhos da Siri · várias contas",
-          "pt-PT": "Widgets do ecrã principal · atalhos da Siri · várias contas"
+          "pt-PT": "Widgets do ecrã principal · atalhos da Siri · várias contas",
+          "de": "Home-Bildschirm-Widgets · Siri-Kurzbefehle · mehrere Konten",
+          "fr": "Widgets d’écran d’accueil · raccourcis Siri · multicompte",
+          "ar": "أدوات الشاشة الرئيسية · اختصارات Siri · حسابات متعددة",
+          "tr": "Ana ekran widget’ları · Siri kısayolları · çoklu hesap"
         }
       },
       {
@@ -634,7 +1020,11 @@
           "es-MX": "Suscripción Pro · compra única",
           "ko": "Pro 구독 · 일회성 구매",
           "pt-BR": "Assinatura Pro · compra única",
-          "pt-PT": "Subscrição Pro · compra única"
+          "pt-PT": "Subscrição Pro · compra única",
+          "de": "Pro-Abo · Einmalkauf",
+          "fr": "Abonnement Pro · achat unique",
+          "ar": "اشتراك Pro · شراء لمرة واحدة",
+          "tr": "Pro aboneliği · tek seferlik satın alım"
         }
       }
     ]

--- a/packages/changelog/scripts/gen-ios.mjs
+++ b/packages/changelog/scripts/gen-ios.mjs
@@ -1,7 +1,7 @@
 // CODEGEN —— 由 ios.json 生成 iOS 的「新功能」内容。运行：`pnpm changelog:gen`（或 gen:ios）。
 // 产出两个 codegen 独占文件（folder-sync 自动纳入 target，无需改 pbxproj）：
 //   Core/WhatsNew/WhatsNewReleases.generated.swift  —— releases 数组（仅 inApp 版本）
-//   Core/WhatsNew/WhatsNew.xcstrings                —— 9 语字符串目录（table = "WhatsNew"）
+//   Core/WhatsNew/WhatsNew.xcstrings                —— 13 语字符串目录（table = "WhatsNew"）
 // 手维护的 WhatsNew.swift 只引用 WhatsNewGenerated.releases；Localizable.xcstrings 完全不动。
 
 import { readFileSync } from "node:fs";
@@ -13,7 +13,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repo = join(here, "..", "..", "..");
 const IOS = join(repo, "apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew");
 
-const LOCALES = ["zh-Hans", "en", "zh-Hant", "zh-HK", "ja", "es-MX", "ko", "pt-BR", "pt-PT"];
+const LOCALES = ["zh-Hans", "en", "zh-Hant", "zh-HK", "ja", "es-MX", "ko", "pt-BR", "pt-PT", "de", "fr", "ar", "tr"];
 const releases = JSON.parse(readFileSync(join(here, "..", "ios.json"), "utf8"));
 const isNewer = (a, b) => a.localeCompare(b, undefined, { numeric: true }) > 0;
 


### PR DESCRIPTION
## iOS 1.4.0 变更日志（单一数据源）

往 `packages/changelog/ios.json` 顶部加 1.4.0 条目，What's New 文案补齐至 **13 语**（含 de/fr/ar/tr）。

- 内容：域名安全（SSL/Transform/IP 规则）+ R2 升级 + 按 URL 清缓存
- `gen-ios.mjs` 配合微调
- 产物（WhatsNewReleases.generated.swift / WhatsNew.xcstrings）由 `pnpm changelog:gen` 生成，随 iOS 1.4.0 发布分支构建

> 官网按 D1 `live_versions` 门控展示，1.4.0 上架前不会提前显示。仅改 changelog 数据源，不含 app 代码。