### PR TITLE
发版 iOS 1.5.1：修复 iOS 17.0 概览页导航栏崩溃

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -489,7 +489,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -509,7 +509,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -521,7 +521,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -542,7 +542,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -553,7 +553,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -576,7 +576,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -587,7 +587,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -610,7 +610,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -622,7 +622,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -644,7 +644,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -656,7 +656,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -698,7 +698,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -722,7 +722,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -741,7 +741,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/UI/AvailabilityCompat.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/UI/AvailabilityCompat.swift
@@ -8,6 +8,32 @@
 
 import SwiftUI
 import UIKit
+import TipKit
+
+extension ProcessInfo {
+    /// 当前系统是否落在 iOS 17.0.x（17.0 / 17.0.1 / 17.0.2 / 17.0.3）。
+    /// 这一窄段的 TipKit 把 popover 锚定到导航栏 bar button 时，会在
+    /// `-[UINavigationBar layoutSubviews]` 阶段抛未捕获异常导致崩溃，Apple 自 17.1 起修复。
+    /// 仅用于对这段版本做最小化 UI 降级，勿扩大到 17.1+。
+    nonisolated static var isBuggyTipKitNavBar: Bool {
+        let v = processInfo.operatingSystemVersion
+        return v.majorVersion == 17 && v.minorVersion == 0
+    }
+}
+
+extension View {
+    /// `popoverTip` 的安全封装：iOS 17.0.x 上跳过（见 ``ProcessInfo/isBuggyTipKitNavBar``），
+    /// 避免导航栏锚定的 TipKit popover 崩溃；17.1+ 与更高版本行为不变，正常展示气泡提示。
+    /// 适用于挂在工具栏 bar button 上的提示；非导航栏场景同样安全（17.0.x 仅少展示一次提示）。
+    @ViewBuilder
+    func safePopoverTip<T: Tip>(_ tip: T) -> some View {
+        if ProcessInfo.isBuggyTipKitNavBar {
+            self
+        } else {
+            popoverTip(tip)
+        }
+    }
+}
 
 extension View {
     /// 详情页：iOS 18+ 应用 Zoom 导航转场；iOS 17 原样返回（标准 push）。

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -407,7 +407,7 @@ struct DashboardView: View {
                 )
                 .symbolEffect(.bounce, value: session.selectedAccount?.id)
         }
-        .popoverTip(accountSwitchTip)
+        .safePopoverTip(accountSwitchTip)
         .accessibilityLabel("切换账号")
         .accessibilityValue(session.selectedAccount?.name ?? "")
     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerTailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerTailView.swift
@@ -37,7 +37,7 @@ struct WorkerTailView: View {
                 ) {
                     viewModel.isPaused.toggle()
                 }
-                .popoverTip(TailPauseTip())
+                .safePopoverTip(TailPauseTip())
                 Button("清屏", systemImage: "xmark.bin") {
                     viewModel.clear()
                 }

--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,5 +1,46 @@
 [
   {
+    "version": "1.5.1",
+    "date": "2026.06.26",
+    "channel": "App Store",
+    "inApp": false,
+    "items": [
+      {
+        "icon": "wrench.and.screwdriver",
+        "title": {
+          "zh-Hans": "稳定性修复",
+          "en": "Stability fixes",
+          "zh-Hant": "穩定性修復",
+          "zh-HK": "穩定性修復",
+          "ja": "安定性の改善",
+          "es-MX": "Correcciones de estabilidad",
+          "ko": "안정성 개선",
+          "pt-BR": "Correções de estabilidade",
+          "pt-PT": "Correções de estabilidade",
+          "de": "Stabilitätsverbesserungen",
+          "fr": "Corrections de stabilité",
+          "ar": "تحسينات الاستقرار",
+          "tr": "Kararlılık düzeltmeleri"
+        },
+        "detail": {
+          "zh-Hans": "修复了部分 iOS 17.0 设备上打开概览页可能崩溃的问题。",
+          "en": "Fixed a rare crash when opening the dashboard on some devices running iOS 17.0.",
+          "zh-Hant": "修復了部分 iOS 17.0 裝置上開啟概覽頁可能閃退的問題。",
+          "zh-HK": "修復了部分 iOS 17.0 裝置上開啟概覽頁可能閃退的問題。",
+          "ja": "一部の iOS 17.0 デバイスで概要画面を開くとまれにクラッシュする問題を修正しました。",
+          "es-MX": "Se corrigió un fallo poco frecuente al abrir el panel en algunos dispositivos con iOS 17.0.",
+          "ko": "일부 iOS 17.0 기기에서 대시보드를 열 때 드물게 발생하던 비정상 종료 문제를 수정했습니다.",
+          "pt-BR": "Corrigida uma falha rara ao abrir o painel em alguns dispositivos com iOS 17.0.",
+          "pt-PT": "Corrigida uma falha rara ao abrir o painel em alguns dispositivos com iOS 17.0.",
+          "de": "Ein seltener Absturz beim Öffnen der Übersicht auf einigen Geräten mit iOS 17.0 wurde behoben.",
+          "fr": "Correction d'un plantage rare à l'ouverture du tableau de bord sur certains appareils sous iOS 17.0.",
+          "ar": "تم إصلاح تعطل نادر عند فتح لوحة المعلومات على بعض الأجهزة التي تعمل بنظام iOS 17.0.",
+          "tr": "Bazı iOS 17.0 cihazlarda panoyu açarken nadiren oluşan çökme sorunu giderildi."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.5.0",
     "date": "2026.06.26",
     "channel": "App Store",


### PR DESCRIPTION
## 摘要 / Summary

[中文]
**1.5.1（build 17）—— 纯稳定性修复。**

部分 iOS 17.0 设备一打开「概览」页就崩溃（仅 17.0.x，17.1+ 不复现）。崩溃栈定位到 `-[UINavigationBar layoutSubviews]` 抛未捕获异常，根因是 **TipKit 的 `popoverTip` 锚定到导航栏 bar button**——这是 iOS 17.0.x 的系统级缺陷，Apple 自 17.1 修复。

[English]
**1.5.1 (build 17) — stability fix only.**

Some iOS 17.0 devices crashed immediately on opening the dashboard (17.0.x only; fixed by Apple in 17.1). The crash stack pointed at an uncaught exception in `-[UINavigationBar layoutSubviews]`, caused by a **TipKit `popoverTip` anchored to a navigation-bar bar button** — a system-level defect on iOS 17.0.x.

## 改动 / Changes

- 新增 `ProcessInfo.isBuggyTipKitNavBar`（精确匹配 17.0.x：`major==17 && minor==0`）+ `View.safePopoverTip` 封装
- `DashboardView` 账号菜单、`WorkerTailView` 实时日志两处工具栏 `popoverTip` 改用 `safePopoverTip`
- 仅在 17.0.x 跳过气泡提示，其余版本行为完全不变
- 版本号 1.5.0 → **1.5.1**、build 16 → **17**（各 8 处对齐）
- `packages/changelog/ios.json` 增加 1.5.1 条目（`inApp:false`，纯 bug 修复只进官网更新历史、App 内不弹窗）

## 验证 / Verification

- `xcodebuild -scheme "Orange Cloud" build` ✅ BUILD SUCCEEDED，无 error、无版本不匹配 warning
- `pnpm changelog:gen` + `pnpm changelog:check` ✅ 通过（`inApp:false` 故生成物零变化）

## 备注 / Note

崩溃报告（type 309 `.ips`）不含异常 reason 文本，本修复基于崩溃栈 + 版本特征的强推断。建议送审前在 iOS 17.0 模拟器复现旧崩溃并验证新版不崩。