### PR TITLE
feat(android): 1.4.2 — Workers AI 分类/详情/修复 + 开发者平台 Pro 门控

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         // 实况通知促升(API36) 均 if-guard 渐进增强，Android 9–11 落固定品牌调色板与常驻通知回退。
         minSdk = 28
         targetSdk = 36
-        versionCode = 6
-        versionName = "1.4.1"
+        versionCode = 7
+        versionName = "1.4.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
@@ -5,6 +5,12 @@ import jiamin.chen.orangecloud.R
 // ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。
 internal val whatsNewReleases: List<WhatsNewRelease> = listOf(
     WhatsNewRelease(
+        version = "1.4.2",
+        items = listOf(
+            WhatsNewItem(R.string.whatsnew_1_4_2_0_title, R.string.whatsnew_1_4_2_0_detail),
+        ),
+    ),
+    WhatsNewRelease(
         version = "1.4",
         items = listOf(
             WhatsNewItem(R.string.whatsnew_1_4_0_title, R.string.whatsnew_1_4_0_detail),

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/devplatform/DevPlatformScreens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/devplatform/DevPlatformScreens.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -82,6 +83,7 @@ import jiamin.chen.orangecloud.data.model.AIModel
 import jiamin.chen.orangecloud.data.model.CFQueue
 import jiamin.chen.orangecloud.data.model.DurableObjectNamespace
 import jiamin.chen.orangecloud.data.model.HyperdriveConfig
+import jiamin.chen.orangecloud.ui.storage.StorageGroupedListBody
 import jiamin.chen.orangecloud.ui.storage.StorageListBody
 import jiamin.chen.orangecloud.ui.storage.StorageRow
 
@@ -326,19 +328,24 @@ private fun HyperdriveCreateForm(isSaving: Boolean, onSave: (name: String, schem
 @Composable
 fun WorkersAIScreen(
     onBack: () -> Unit,
-    onRunModel: (String) -> Unit,
+    onOpenModel: (AIModel) -> Unit,
     viewModel: WorkersAIViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     DevListScaffold(stringResource(R.string.dev_workers_ai), state.isLoading, onBack, { viewModel.load() }) { onSky ->
-        StorageListBody(state, onSky, Icons.Outlined.Psychology, stringResource(R.string.dev_workers_ai_empty), { viewModel.load() }) { m: AIModel ->
-            val isTextGen = m.taskName.contains("Text Generation", ignoreCase = true)
+        StorageGroupedListBody(
+            state = state,
+            onSky = onSky,
+            emptyIcon = Icons.Outlined.Psychology,
+            emptyText = stringResource(R.string.dev_workers_ai_empty),
+            onRetry = { viewModel.load() },
+            groupOf = { it.taskName },
+        ) { m: AIModel ->
             StorageRow(
                 Icons.Outlined.Psychology,
                 m.shortName,
-                m.taskName.ifBlank { null },
-                showChevron = isTextGen && viewModel.canRun,
-                onClick = if (isTextGen && viewModel.canRun) ({ onRunModel(m.id) }) else null,
+                m.description?.takeIf { it.isNotBlank() } ?: m.name,
+                onClick = { onOpenModel(m) },
             )
         }
     }
@@ -364,41 +371,77 @@ fun AIRunScreen(onBack: () -> Unit, viewModel: AIRunViewModel = hiltViewModel())
                 Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                OutlinedTextField(
-                    value = state.prompt,
-                    onValueChange = viewModel::updatePrompt,
-                    label = { Text(stringResource(R.string.dev_ai_prompt)) },
-                    minLines = 3,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Button(
-                    onClick = { viewModel.run() },
-                    enabled = state.prompt.isNotBlank() && !state.isRunning,
-                    colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (state.isRunning) {
-                        CircularProgressIndicator(Modifier.height(18.dp).width(18.dp), strokeWidth = 2.dp, color = Color.White)
-                        Spacer(Modifier.width(8.dp))
-                    } else {
-                        Icon(Icons.AutoMirrored.Outlined.Send, contentDescription = null, modifier = Modifier.width(18.dp))
-                        Spacer(Modifier.width(8.dp))
+                // 模型信息卡（说明 / 任务 / 模型 ID，参考 iOS 详情页）
+                Surface(color = MaterialTheme.colorScheme.surfaceContainerLow, shape = RoundedCornerShape(16.dp), modifier = Modifier.fillMaxWidth()) {
+                    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        if (state.description.isNotBlank()) {
+                            Text(state.description, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
+                        }
+                        if (state.task.isNotBlank()) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(stringResource(R.string.dev_ai_info_task), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                Spacer(Modifier.weight(1f))
+                                Text(state.task, fontSize = 13.sp, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
+                            }
+                        }
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(stringResource(R.string.dev_ai_info_model), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            SelectionContainer {
+                                Text(state.model, fontSize = 12.sp, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                        }
                     }
-                    Text(stringResource(R.string.dev_ai_run))
                 }
-                state.error?.let {
-                    Text(it, color = MaterialTheme.colorScheme.error, fontSize = 13.sp)
-                }
-                if (state.response.isNotBlank()) {
-                    Surface(color = MaterialTheme.colorScheme.surfaceContainerLow, shape = RoundedCornerShape(16.dp), modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            state.response,
-                            fontSize = 14.sp,
-                            fontFamily = FontFamily.Monospace,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(16.dp),
+
+                when {
+                    state.isTextGen && state.canRun -> {
+                        Text(stringResource(R.string.dev_ai_playground), fontSize = 13.sp, fontWeight = FontWeight.Bold, color = onSky)
+                        OutlinedTextField(
+                            value = state.prompt,
+                            onValueChange = viewModel::updatePrompt,
+                            label = { Text(stringResource(R.string.dev_ai_prompt)) },
+                            minLines = 3,
+                            modifier = Modifier.fillMaxWidth(),
                         )
+                        Button(
+                            onClick = { viewModel.run() },
+                            enabled = state.prompt.isNotBlank() && !state.isRunning,
+                            colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            if (state.isRunning) {
+                                CircularProgressIndicator(Modifier.height(18.dp).width(18.dp), strokeWidth = 2.dp, color = Color.White)
+                                Spacer(Modifier.width(8.dp))
+                            } else {
+                                Icon(Icons.AutoMirrored.Outlined.Send, contentDescription = null, modifier = Modifier.width(18.dp))
+                                Spacer(Modifier.width(8.dp))
+                            }
+                            Text(stringResource(R.string.dev_ai_run))
+                        }
+                        Text(stringResource(R.string.dev_ai_run_note), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        state.error?.let {
+                            Text(it, color = MaterialTheme.colorScheme.error, fontSize = 13.sp)
+                        }
+                        if (state.response.isNotBlank()) {
+                            Surface(color = MaterialTheme.colorScheme.surfaceContainerLow, shape = RoundedCornerShape(16.dp), modifier = Modifier.fillMaxWidth()) {
+                                SelectionContainer {
+                                    Text(
+                                        state.response,
+                                        fontSize = 14.sp,
+                                        fontFamily = FontFamily.Monospace,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        modifier = Modifier.padding(16.dp),
+                                    )
+                                }
+                            }
+                        }
                     }
+
+                    state.isTextGen ->
+                        Text(stringResource(R.string.dev_ai_needs_write), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+                    else ->
+                        Text(stringResource(R.string.dev_ai_unsupported), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/devplatform/DevPlatformViewModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/devplatform/DevPlatformViewModels.kt
@@ -186,22 +186,36 @@ class WorkersAIViewModel @Inject constructor(
 
 data class AIRunUiState(
     val model: String = "",
+    val task: String = "",
+    val description: String = "",
+    val canRun: Boolean = false,
     val prompt: String = "",
     val response: String = "",
     val isRunning: Boolean = false,
     val error: String? = null,
-)
+) {
+    /** 仅文本生成模型可在 App 内试运行（输入/输出契约与 iOS 一致）。 */
+    val isTextGen: Boolean get() = task.contains("Text Generation", ignoreCase = true)
+}
 
 @HiltViewModel
 class AIRunViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val accountStore: AccountStore,
     private val repository: DeveloperPlatformRepository,
+    authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val model: String = checkNotNull(savedStateHandle["model"])
 
-    private val _uiState = MutableStateFlow(AIRunUiState(model = model))
+    private val _uiState = MutableStateFlow(
+        AIRunUiState(
+            model = model,
+            task = savedStateHandle.get<String>("task").orEmpty(),
+            description = savedStateHandle.get<String>("desc").orEmpty(),
+            canRun = authRepository.hasScope(Scopes.AI_WRITE),
+        ),
+    )
     val uiState: StateFlow<AIRunUiState> = _uiState.asStateFlow()
 
     fun updatePrompt(text: String) = _uiState.update { it.copy(prompt = text) }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/root/OrangeCloudRoot.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/root/OrangeCloudRoot.kt
@@ -161,7 +161,7 @@ private object Dest {
     const val DEV_HYPERDRIVE = "dev/hyperdrive"
     const val DEV_DO = "dev/do"
     const val DEV_ASSISTANT = "dev/assistant"
-    const val AI_RUN_ROUTE = "dev/ai/run/{model}"
+    const val AI_RUN_ROUTE = "dev/ai/run/{model}?task={task}&desc={desc}"
     const val STORAGE = "storage"
     const val SETTINGS = "settings"
     const val IDENTITY_ROUTE = "identity/{sessionId}"
@@ -230,7 +230,8 @@ private object Dest {
         "snippetEdit/$zoneId?zoneName=${Uri.encode(zoneName)}&name=${Uri.encode(name)}"
     fun redirectItems(listId: String, listName: String): String = "redirects/$listId?listName=${Uri.encode(listName)}"
     fun pagesDetail(project: String): String = "pages/${Uri.encode(project)}"
-    fun aiRun(model: String): String = "dev/ai/run/${Uri.encode(model)}"
+    fun aiModel(model: String, task: String, desc: String): String =
+        "dev/ai/run/${Uri.encode(model)}?task=${Uri.encode(task)}&desc=${Uri.encode(desc)}"
     fun identity(sessionId: String): String = "identity/${Uri.encode(sessionId)}"
     fun tunnelDetail(id: String, name: String): String = "tunnel/$id?tunnelName=${Uri.encode(name)}"
     fun worker(scriptName: String): String = "worker/${Uri.encode(scriptName)}"
@@ -608,28 +609,34 @@ private fun MainScaffold() {
                 )
             }
             composable(Dest.DEV_WORKERS_AI) {
-                WorkersAIScreen(
-                    onBack = { navController.popBackStack() },
-                    onRunModel = { model -> navController.navigate(Dest.aiRun(model)) },
-                )
+                ProGate {
+                    WorkersAIScreen(
+                        onBack = { navController.popBackStack() },
+                        onOpenModel = { m -> navController.navigate(Dest.aiModel(m.name ?: m.id, m.taskName, m.description.orEmpty())) },
+                    )
+                }
             }
             composable(
                 route = Dest.AI_RUN_ROUTE,
-                arguments = listOf(navArgument("model") { type = NavType.StringType }),
+                arguments = listOf(
+                    navArgument("model") { type = NavType.StringType },
+                    navArgument("task") { type = NavType.StringType; defaultValue = "" },
+                    navArgument("desc") { type = NavType.StringType; defaultValue = "" },
+                ),
             ) {
-                AIRunScreen(onBack = { navController.popBackStack() })
+                ProGate { AIRunScreen(onBack = { navController.popBackStack() }) }
             }
             composable(Dest.DEV_AI_GATEWAY) {
-                AIGatewayScreen(onBack = { navController.popBackStack() })
+                ProGate { AIGatewayScreen(onBack = { navController.popBackStack() }) }
             }
             composable(Dest.DEV_QUEUES) {
-                QueuesScreen(onBack = { navController.popBackStack() })
+                ProGate { QueuesScreen(onBack = { navController.popBackStack() }) }
             }
             composable(Dest.DEV_HYPERDRIVE) {
-                HyperdriveScreen(onBack = { navController.popBackStack() })
+                ProGate { HyperdriveScreen(onBack = { navController.popBackStack() }) }
             }
             composable(Dest.DEV_DO) {
-                DurableObjectsScreen(onBack = { navController.popBackStack() })
+                ProGate { DurableObjectsScreen(onBack = { navController.popBackStack() }) }
             }
             composable(
                 route = Dest.WORKER_ROUTE,

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageCommon.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageCommon.kt
@@ -71,6 +71,61 @@ fun <T> StorageListBody(
     }
 }
 
+/**
+ * 与 StorageListBody 同样的状态外壳，但把条目按 groupOf 分组成小节（参考 iOS Workers AI 按任务类型分组）。
+ * 排序：「Text Generation」置顶，其余按任务名字母序。空任务归入「其它」。
+ */
+@Composable
+fun <T> StorageGroupedListBody(
+    state: StorageListUiState<T>,
+    onSky: Color,
+    emptyIcon: ImageVector,
+    emptyText: String,
+    onRetry: () -> Unit,
+    groupOf: (T) -> String,
+    itemContent: @Composable (T) -> Unit,
+) {
+    when {
+        state.missingScope ->
+            SkyEmptyState(Icons.Outlined.Lock, stringResource(R.string.scope_missing), onSky, stringResource(R.string.common_refresh), onRetry)
+
+        state.items.isEmpty() && state.isLoading ->
+            Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator(color = onSky) }
+
+        state.items.isEmpty() && state.hasError ->
+            SkyEmptyState(emptyIcon, stringResource(R.string.error_generic), onSky, stringResource(R.string.common_refresh), onRetry)
+
+        state.items.isEmpty() ->
+            SkyEmptyState(emptyIcon, emptyText, onSky, stringResource(R.string.common_refresh), onRetry)
+
+        else -> {
+            val other = stringResource(R.string.dev_ai_task_other)
+            val groups = state.items.groupBy { groupOf(it).ifBlank { other } }
+                .toList()
+                .sortedWith(
+                    compareByDescending<Pair<String, List<T>>> { it.first == "Text Generation" }.thenBy { it.first },
+                )
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                groups.forEach { (group, rows) ->
+                    item(key = "h:$group") {
+                        Text(
+                            group,
+                            color = onSky,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 13.sp,
+                            modifier = Modifier.padding(top = 6.dp, bottom = 2.dp, start = 4.dp),
+                        )
+                    }
+                    rows.forEach { row -> item { itemContent(row) } }
+                }
+            }
+        }
+    }
+}
+
 /** 字节人类可读（B/KB/MB/GB/TB）。 */
 fun formatBytes(bytes: Long): String {
     if (bytes < 1024) return "$bytes B"

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -988,4 +988,11 @@
     <string name="pages_deployed">تم النشر</string>
     <string name="pages_deploy_empty">لم يُعثر على ملفات قابلة للنشر</string>
     <string name="pages_deploy_too_big">الملف %1$s يتجاوز حد 25 ميجابايت</string>
+    <string name="dev_ai_task_other">أخرى</string>
+    <string name="dev_ai_info_task">المهمة</string>
+    <string name="dev_ai_info_model">النموذج</string>
+    <string name="dev_ai_playground">التجربة</string>
+    <string name="dev_ai_run_note">يرسل رسالة مستخدم واحدة ويعرض رد النموذج. يستهلك حصة Workers AI لحسابك (10,000 Neuron مجانًا يوميًا).</string>
+    <string name="dev_ai_needs_write">يتطلب تشغيل نموذج توليد النص إذن الكتابة في Workers AI (ai.write). سجّل الخروج ثم أعد المنح مع تحديد هذا الإذن.</string>
+    <string name="dev_ai_unsupported">تختلف صيغة إدخال/إخراج هذا النموذج عن توليد النص، لذا لا يمكن تشغيله داخل التطبيق بعد.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ar/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ar/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">تحسينات Workers AI</string>
+    <string name="whatsnew_1_4_2_0_detail">تصفّح النماذج مجمّعة حسب نوع المهمة، واعرض تفاصيل النموذج، وأصلحنا التشغيل التجريبي لنماذج توليد النص.</string>
     <string name="whatsnew_1_4_0_title">منصّة المطوّرين الجديدة</string>
     <string name="whatsnew_1_4_0_detail">أصبح Workers إلى جانب Workers AI وAI Gateway والطوابير وHyperdrive وDurable Objects وPages في مركز واحد.</string>
     <string name="whatsnew_1_4_1_title">قواعد التخزين المؤقت وتحديد المعدّل وتوجيه البريد</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -988,4 +988,11 @@
     <string name="pages_deployed">Bereitgestellt</string>
     <string name="pages_deploy_empty">Keine bereitstellbaren Dateien gefunden</string>
     <string name="pages_deploy_too_big">Datei %1$s überschreitet das 25-MB-Limit</string>
+    <string name="dev_ai_task_other">Sonstige</string>
+    <string name="dev_ai_info_task">Aufgabe</string>
+    <string name="dev_ai_info_model">Modell</string>
+    <string name="dev_ai_playground">Ausprobieren</string>
+    <string name="dev_ai_run_note">Sendet eine Nutzernachricht und zeigt die Antwort des Modells. Verbraucht das Workers-AI-Kontingent deines Kontos (10.000 Neuronen pro Tag kostenlos).</string>
+    <string name="dev_ai_needs_write">Das Ausführen eines Textgenerierungsmodells erfordert die Workers-AI-Schreibberechtigung (ai.write). Melde dich ab und autorisiere erneut mit aktivierter Berechtigung.</string>
+    <string name="dev_ai_unsupported">Das Eingabe-/Ausgabeformat dieses Modells unterscheidet sich von der Textgenerierung und kann in der App noch nicht ausgeführt werden.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-de/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-de/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers-AI-Verbesserungen</string>
+    <string name="whatsnew_1_4_2_0_detail">Modelle nach Aufgabentyp gruppiert durchsuchen, Modelldetails ansehen – und der Testlauf für Textgenerierungsmodelle wurde behoben.</string>
     <string name="whatsnew_1_4_0_title">Neue Entwicklerplattform</string>
     <string name="whatsnew_1_4_0_detail">Workers steht jetzt zusammen mit Workers AI, AI Gateway, Queues, Hyperdrive, Durable Objects und Pages in einem Hub.</string>
     <string name="whatsnew_1_4_1_title">Cache Rules, Rate Limiting &amp; E-Mail-Routing</string>

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -1051,4 +1051,11 @@
     <string name="pages_deployed">Deployed</string>
     <string name="pages_deploy_empty">No deployable files found</string>
     <string name="pages_deploy_too_big">File %1$s exceeds the 25 MB limit</string>
+    <string name="dev_ai_task_other">Other</string>
+    <string name="dev_ai_info_task">Task</string>
+    <string name="dev_ai_info_model">Model</string>
+    <string name="dev_ai_playground">Playground</string>
+    <string name="dev_ai_run_note">Sends one user message and shows the model\'s reply. Uses your account\'s Workers AI quota (10,000 free Neurons per day).</string>
+    <string name="dev_ai_needs_write">Running a text-generation model requires Workers AI write permission (ai.write). Sign out and authorize again with that permission enabled.</string>
+    <string name="dev_ai_unsupported">This model\'s input/output format differs from text generation, so it can\'t be run in the app yet.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-en/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-en/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI improvements</string>
+    <string name="whatsnew_1_4_2_0_detail">Browse models grouped by task type, view model details, and the text-generation test run is fixed.</string>
     <string name="whatsnew_1_4_0_title">New Developer Platform</string>
     <string name="whatsnew_1_4_0_detail">Workers now sits alongside Workers AI, AI Gateway, Queues, Hyperdrive, Durable Objects and Pages in a single Developer Platform hub.</string>
     <string name="whatsnew_1_4_1_title">Cache Rules, Rate Limiting &amp; Email Routing</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -1028,4 +1028,11 @@
     <string name="pages_deployed">Desplegado</string>
     <string name="pages_deploy_empty">No se encontraron archivos para desplegar</string>
     <string name="pages_deploy_too_big">El archivo %1$s supera el límite de 25 MB</string>
+    <string name="dev_ai_task_other">Otros</string>
+    <string name="dev_ai_info_task">Tarea</string>
+    <string name="dev_ai_info_model">Modelo</string>
+    <string name="dev_ai_playground">Prueba</string>
+    <string name="dev_ai_run_note">Envía un mensaje de usuario y muestra la respuesta del modelo. Consume la cuota de Workers AI de tu cuenta (10 000 Neuronas gratis al día).</string>
+    <string name="dev_ai_needs_write">Ejecutar un modelo de generación de texto requiere permiso de escritura de Workers AI (ai.write). Cierra sesión y vuelve a autorizar con ese permiso marcado.</string>
+    <string name="dev_ai_unsupported">El formato de entrada/salida de este modelo difiere de la generación de texto, por lo que aún no se puede ejecutar en la app.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-es/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-es/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Mejoras en Workers AI</string>
+    <string name="whatsnew_1_4_2_0_detail">Explora los modelos agrupados por tipo de tarea, consulta sus detalles y se corrigió la prueba de los modelos de generación de texto.</string>
     <string name="whatsnew_1_4_0_title">Nueva plataforma para desarrolladores</string>
     <string name="whatsnew_1_4_0_detail">Workers ahora convive con Workers AI, AI Gateway, Colas, Hyperdrive, Durable Objects y Pages en un único centro.</string>
     <string name="whatsnew_1_4_1_title">Cache Rules, límite de velocidad y enrutamiento de correo</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -988,4 +988,11 @@
     <string name="pages_deployed">Déployé</string>
     <string name="pages_deploy_empty">Aucun fichier déployable trouvé</string>
     <string name="pages_deploy_too_big">Le fichier %1$s dépasse la limite de 25 Mo</string>
+    <string name="dev_ai_task_other">Autres</string>
+    <string name="dev_ai_info_task">Tâche</string>
+    <string name="dev_ai_info_model">Modèle</string>
+    <string name="dev_ai_playground">Essayer</string>
+    <string name="dev_ai_run_note">Envoie un message utilisateur et affiche la réponse du modèle. Consomme le quota Workers AI de votre compte (10 000 Neurones gratuits par jour).</string>
+    <string name="dev_ai_needs_write">L\'exécution d\'un modèle de génération de texte nécessite l\'autorisation d\'écriture Workers AI (ai.write). Déconnectez-vous et réautorisez en cochant cette autorisation.</string>
+    <string name="dev_ai_unsupported">Le format d\'entrée/sortie de ce modèle diffère de la génération de texte ; il ne peut pas encore être exécuté dans l\'app.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-fr/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Améliorations de Workers AI</string>
+    <string name="whatsnew_1_4_2_0_detail">Parcourez les modèles regroupés par type de tâche, consultez leurs détails et l\'essai des modèles de génération de texte est corrigé.</string>
     <string name="whatsnew_1_4_0_title">Nouvelle plateforme développeur</string>
     <string name="whatsnew_1_4_0_detail">Workers rejoint Workers AI, AI Gateway, Queues, Hyperdrive, Durable Objects et Pages dans un hub unique.</string>
     <string name="whatsnew_1_4_1_title">Cache Rules, limitation de débit &amp; routage e-mail</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -1027,4 +1027,11 @@
     <string name="pages_deployed">デプロイしました</string>
     <string name="pages_deploy_empty">デプロイ可能なファイルが見つかりません</string>
     <string name="pages_deploy_too_big">ファイル %1$s が 25 MB の上限を超えています</string>
+    <string name="dev_ai_task_other">その他</string>
+    <string name="dev_ai_info_task">タスク</string>
+    <string name="dev_ai_info_model">モデル</string>
+    <string name="dev_ai_playground">試し実行</string>
+    <string name="dev_ai_run_note">ユーザーメッセージを1件送信し、モデルの応答を表示します。アカウントの Workers AI 使用量（1日あたり1万 Neuron 無料）を消費します。</string>
+    <string name="dev_ai_needs_write">テキスト生成モデルの試し実行には Workers AI の書き込み権限（ai.write）が必要です。ログアウトしてから、その権限を選択して再認証してください。</string>
+    <string name="dev_ai_unsupported">このモデルの入出力形式はテキスト生成と異なるため、アプリ内での試し実行には現在対応していません。</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ja/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ja/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI の改善</string>
+    <string name="whatsnew_1_4_2_0_detail">モデルをタスク種別ごとに分類して閲覧でき、モデルの詳細表示と、テキスト生成モデルの試し実行の不具合を修正しました。</string>
     <string name="whatsnew_1_4_0_title">新しい「開発者プラットフォーム」</string>
     <string name="whatsnew_1_4_0_detail">Workers に加え、Workers AI・AI Gateway・キュー・Hyperdrive・Durable Objects・Pages を一つの「開発者プラットフォーム」にまとめました。</string>
     <string name="whatsnew_1_4_1_title">キャッシュルール・レート制限・メールルーティング</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -1027,4 +1027,11 @@
     <string name="pages_deployed">배포됨</string>
     <string name="pages_deploy_empty">배포할 파일을 찾지 못했습니다</string>
     <string name="pages_deploy_too_big">파일 %1$s 이(가) 25 MB 한도를 초과했습니다</string>
+    <string name="dev_ai_task_other">기타</string>
+    <string name="dev_ai_info_task">작업</string>
+    <string name="dev_ai_info_model">모델</string>
+    <string name="dev_ai_playground">체험 실행</string>
+    <string name="dev_ai_run_note">사용자 메시지 한 개를 보내고 모델의 응답을 표시합니다. 계정의 Workers AI 사용량(하루 1만 뉴런 무료)을 소비합니다.</string>
+    <string name="dev_ai_needs_write">텍스트 생성 모델을 실행하려면 Workers AI 쓰기 권한(ai.write)이 필요합니다. 로그아웃한 후 해당 권한을 선택하여 다시 인증하세요.</string>
+    <string name="dev_ai_unsupported">이 모델의 입력/출력 형식은 텍스트 생성과 달라 아직 앱에서 실행할 수 없습니다.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ko/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI 개선</string>
+    <string name="whatsnew_1_4_2_0_detail">모델을 작업 유형별로 묶어 살펴보고 모델 상세 정보를 확인할 수 있으며, 텍스트 생성 모델의 시험 실행 오류를 수정했습니다.</string>
     <string name="whatsnew_1_4_0_title">새로운 개발자 플랫폼</string>
     <string name="whatsnew_1_4_0_detail">Workers와 함께 Workers AI, AI Gateway, 큐, Hyperdrive, Durable Objects, Pages를 하나의 개발자 플랫폼 허브로 모았습니다.</string>
     <string name="whatsnew_1_4_1_title">캐시 규칙, 속도 제한, 이메일 라우팅</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1027,4 +1027,11 @@
     <string name="pages_deployed">Implantado</string>
     <string name="pages_deploy_empty">Nenhum arquivo implantável encontrado</string>
     <string name="pages_deploy_too_big">O arquivo %1$s excede o limite de 25 MB</string>
+    <string name="dev_ai_task_other">Outros</string>
+    <string name="dev_ai_info_task">Tarefa</string>
+    <string name="dev_ai_info_model">Modelo</string>
+    <string name="dev_ai_playground">Testar</string>
+    <string name="dev_ai_run_note">Envia uma mensagem de usuário e mostra a resposta do modelo. Consome a cota de Workers AI da sua conta (10.000 Neurônios grátis por dia).</string>
+    <string name="dev_ai_needs_write">Executar um modelo de geração de texto requer permissão de escrita do Workers AI (ai.write). Saia da conta e autorize novamente com essa permissão marcada.</string>
+    <string name="dev_ai_unsupported">O formato de entrada/saída deste modelo difere da geração de texto, então ainda não é possível executá-lo no app.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Melhorias no Workers AI</string>
+    <string name="whatsnew_1_4_2_0_detail">Navegue pelos modelos agrupados por tipo de tarefa, veja os detalhes do modelo e corrigimos o teste dos modelos de geração de texto.</string>
     <string name="whatsnew_1_4_0_title">Nova Plataforma para Desenvolvedores</string>
     <string name="whatsnew_1_4_0_detail">Workers agora fica ao lado de Workers AI, AI Gateway, Filas, Hyperdrive, Durable Objects e Pages em um hub único.</string>
     <string name="whatsnew_1_4_1_title">Cache Rules, limite de taxa e roteamento de e-mail</string>

--- a/apps/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1028,4 +1028,11 @@
     <string name="pages_deployed">Implementado</string>
     <string name="pages_deploy_empty">Nenhum ficheiro implementável encontrado</string>
     <string name="pages_deploy_too_big">O ficheiro %1$s excede o limite de 25 MB</string>
+    <string name="dev_ai_task_other">Outros</string>
+    <string name="dev_ai_info_task">Tarefa</string>
+    <string name="dev_ai_info_model">Modelo</string>
+    <string name="dev_ai_playground">Testar</string>
+    <string name="dev_ai_run_note">Envia uma mensagem de utilizador e mostra a resposta do modelo. Consome a quota de Workers AI da sua conta (10 000 Neurónios grátis por dia).</string>
+    <string name="dev_ai_needs_write">Executar um modelo de geração de texto requer permissão de escrita do Workers AI (ai.write). Termine sessão e autorize novamente com essa permissão selecionada.</string>
+    <string name="dev_ai_unsupported">O formato de entrada/saída deste modelo difere da geração de texto, pelo que ainda não é possível executá-lo na app.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Melhorias no Workers AI</string>
+    <string name="whatsnew_1_4_2_0_detail">Navegue pelos modelos agrupados por tipo de tarefa, veja os detalhes do modelo e corrigimos o teste dos modelos de geração de texto.</string>
     <string name="whatsnew_1_4_0_title">Nova Plataforma para Programadores</string>
     <string name="whatsnew_1_4_0_detail">O Workers fica agora ao lado de Workers AI, AI Gateway, Filas, Hyperdrive, Durable Objects e Pages num único centro.</string>
     <string name="whatsnew_1_4_1_title">Cache Rules, limite de taxa e encaminhamento de e-mail</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -988,4 +988,11 @@
     <string name="pages_deployed">Dağıtıldı</string>
     <string name="pages_deploy_empty">Dağıtılabilir dosya bulunamadı</string>
     <string name="pages_deploy_too_big">%1$s dosyası 25 MB sınırını aşıyor</string>
+    <string name="dev_ai_task_other">Diğer</string>
+    <string name="dev_ai_info_task">Görev</string>
+    <string name="dev_ai_info_model">Model</string>
+    <string name="dev_ai_playground">Deneme</string>
+    <string name="dev_ai_run_note">Bir kullanıcı mesajı gönderir ve modelin yanıtını gösterir. Hesabınızın Workers AI kotasını kullanır (günde 10.000 Neuron ücretsiz).</string>
+    <string name="dev_ai_needs_write">Bir metin oluşturma modelini çalıştırmak Workers AI yazma izni (ai.write) gerektirir. Oturumu kapatıp bu izni seçerek yeniden yetki verin.</string>
+    <string name="dev_ai_unsupported">Bu modelin giriş/çıkış biçimi metin oluşturmadan farklı olduğundan uygulama içinde henüz çalıştırılamıyor.</string>
 </resources>

--- a/apps/android/app/src/main/res/values-tr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-tr/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI iyileştirmeleri</string>
+    <string name="whatsnew_1_4_2_0_detail">Modelleri görev türüne göre gruplandırarak inceleyin, model ayrıntılarını görün; metin oluşturma modellerinin deneme çalıştırması düzeltildi.</string>
     <string name="whatsnew_1_4_0_title">Yeni Geliştirici Platformu</string>
     <string name="whatsnew_1_4_0_detail">Workers artık Workers AI, AI Gateway, Kuyruklar, Hyperdrive, Durable Objects ve Pages ile tek bir merkezde.</string>
     <string name="whatsnew_1_4_1_title">Önbellek Kuralları, Hız Sınırlama ve E-posta Yönlendirme</string>

--- a/apps/android/app/src/main/res/values-zh-rHK/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/strings.xml
@@ -1027,4 +1027,11 @@
     <string name="pages_deployed">已部署</string>
     <string name="pages_deploy_empty">未找到可部署的文件</string>
     <string name="pages_deploy_too_big">文件 %1$s 超過 25 MB 上限</string>
+    <string name="dev_ai_task_other">其他</string>
+    <string name="dev_ai_info_task">任務</string>
+    <string name="dev_ai_info_model">模型</string>
+    <string name="dev_ai_playground">試運行</string>
+    <string name="dev_ai_run_note">傳送一則用戶訊息並顯示模型回覆，會消耗帳戶的 Workers AI 用量（每天 1 萬 Neuron 免費額度）。</string>
+    <string name="dev_ai_needs_write">試運行文字生成模型需要 Workers AI 寫入權限（ai.write）。請登出後重新授權並勾選該權限。</string>
+    <string name="dev_ai_unsupported">此模型的輸入/輸出格式與文字生成不同，暫不支援在 App 內試運行。</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI 體驗升級</string>
+    <string name="whatsnew_1_4_2_0_detail">現在可按任務類型分組瀏覽模型、查看模型詳情，並修復了文字生成模型的試運行。</string>
     <string name="whatsnew_1_4_0_title">全新「開發者平台」</string>
     <string name="whatsnew_1_4_0_detail">把 Workers 與 Workers AI、AI Gateway、佇列、Hyperdrive、Durable Objects、Pages 收進統一的「開發者平台」中樞，一處直達。</string>
     <string name="whatsnew_1_4_1_title">緩存規則、速率限制與電子郵件路由</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -1027,4 +1027,11 @@
     <string name="pages_deployed">已部署</string>
     <string name="pages_deploy_empty">未找到可部署的檔案</string>
     <string name="pages_deploy_too_big">檔案 %1$s 超過 25 MB 上限</string>
+    <string name="dev_ai_task_other">其他</string>
+    <string name="dev_ai_info_task">任務</string>
+    <string name="dev_ai_info_model">模型</string>
+    <string name="dev_ai_playground">試執行</string>
+    <string name="dev_ai_run_note">傳送一則使用者訊息並顯示模型回覆，會消耗帳戶的 Workers AI 用量（每天 1 萬 Neuron 免費額度）。</string>
+    <string name="dev_ai_needs_write">試執行文字生成模型需要 Workers AI 寫入權限（ai.write）。請登出後重新授權並勾選該權限。</string>
+    <string name="dev_ai_unsupported">此模型的輸入/輸出格式與文字生成不同，暫不支援在 App 內試執行。</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI 體驗升級</string>
+    <string name="whatsnew_1_4_2_0_detail">現在可按任務類型分組瀏覽模型、檢視模型詳情，並修復了文字生成模型的試執行。</string>
     <string name="whatsnew_1_4_0_title">全新「開發者平台」</string>
     <string name="whatsnew_1_4_0_detail">把 Workers 與 Workers AI、AI Gateway、佇列、Hyperdrive、Durable Objects、Pages 收進統一的「開發者平台」中樞，一處直達。</string>
     <string name="whatsnew_1_4_1_title">快取規則、速率限制與電子郵件路由</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1016,6 +1016,13 @@
     <string name="dev_gateway_sub">缓存 TTL %1$d 秒</string>
     <string name="dev_ai_prompt">输入提示词</string>
     <string name="dev_ai_run">运行</string>
+    <string name="dev_ai_task_other">其它</string>
+    <string name="dev_ai_info_task">任务</string>
+    <string name="dev_ai_info_model">模型</string>
+    <string name="dev_ai_playground">试运行</string>
+    <string name="dev_ai_run_note">发送一条用户消息并显示模型回复，会消耗账号的 Workers AI 用量（每天 1 万 Neuron 免费额度）。</string>
+    <string name="dev_ai_needs_write">试运行文本生成模型需要 Workers AI 写权限（ai.write）。请退出登录后重新授权并勾选该权限。</string>
+    <string name="dev_ai_unsupported">该模型的输入/输出格式与文本生成不同，暂不支持在 App 内试运行。</string>
     <!-- 开发者平台 写操作 -->
     <string name="dev_action_do">执行</string>
     <string name="dev_delete_confirm">确认删除？</string>

--- a/apps/android/app/src/main/res/values/whatsnew.xml
+++ b/apps/android/app/src/main/res/values/whatsnew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_4_2_0_title">Workers AI 体验升级</string>
+    <string name="whatsnew_1_4_2_0_detail">现在可按任务类型分组浏览模型、查看模型详情，并修复了文本生成模型的试运行。</string>
     <string name="whatsnew_1_4_0_title">全新「开发者平台」</string>
     <string name="whatsnew_1_4_0_detail">把 Workers 与 Workers AI、AI Gateway、队列、Hyperdrive、Durable Objects、Pages 收进统一的「开发者平台」中枢，一处直达。</string>
     <string name="whatsnew_1_4_1_title">缓存规则、速率限制与电子邮件路由</string>

--- a/apps/web/public/android/latest.json
+++ b/apps/web/public/android/latest.json
@@ -1,7 +1,7 @@
 {
-  "versionCode": 5,
-  "versionName": "1.4",
+  "versionCode": 7,
+  "versionName": "1.4.2",
   "minVersionCode": 1,
-  "url": "https://orange-cloud.chatiro.app/orange-cloud.apk",
-  "note": "全新「开发者平台」中枢：Workers 与 Workers AI、AI Gateway、队列、Hyperdrive、Durable Objects、Pages 一处直达，新增 Worker 创建与 Pages 一键部署。域名侧补齐缓存规则、速率限制、邮件路由、批量重定向、负载均衡、Zero Trust、审计日志；R2 接入系统「文件」，并新增全球流量地图、AI 助手与可视化/自然语言 WAF 构建器。"
+  "url": "https://o-c.do/orange-cloud.apk",
+  "note": "Workers AI 体验升级：现在可按任务类型分组浏览模型、查看模型详情，并修复了文本生成模型的试运行。"
 }

--- a/packages/changelog/android.json
+++ b/packages/changelog/android.json
@@ -1,5 +1,44 @@
 [
   {
+    "version": "1.4.2",
+    "date": "2026.06.29",
+    "channel": "Google Play",
+    "items": [
+      {
+        "title": {
+          "zh-Hans": "Workers AI 体验升级",
+          "en": "Workers AI improvements",
+          "zh-Hant": "Workers AI 體驗升級",
+          "zh-HK": "Workers AI 體驗升級",
+          "ja": "Workers AI の改善",
+          "es-MX": "Mejoras en Workers AI",
+          "ko": "Workers AI 개선",
+          "pt-BR": "Melhorias no Workers AI",
+          "pt-PT": "Melhorias no Workers AI",
+          "de": "Workers-AI-Verbesserungen",
+          "fr": "Améliorations de Workers AI",
+          "ar": "تحسينات Workers AI",
+          "tr": "Workers AI iyileştirmeleri"
+        },
+        "detail": {
+          "zh-Hans": "现在可按任务类型分组浏览模型、查看模型详情，并修复了文本生成模型的试运行。",
+          "en": "Browse models grouped by task type, view model details, and the text-generation test run is fixed.",
+          "zh-Hant": "現在可按任務類型分組瀏覽模型、檢視模型詳情，並修復了文字生成模型的試執行。",
+          "zh-HK": "現在可按任務類型分組瀏覽模型、查看模型詳情，並修復了文字生成模型的試運行。",
+          "ja": "モデルをタスク種別ごとに分類して閲覧でき、モデルの詳細表示と、テキスト生成モデルの試し実行の不具合を修正しました。",
+          "es-MX": "Explora los modelos agrupados por tipo de tarea, consulta sus detalles y se corrigió la prueba de los modelos de generación de texto.",
+          "ko": "모델을 작업 유형별로 묶어 살펴보고 모델 상세 정보를 확인할 수 있으며, 텍스트 생성 모델의 시험 실행 오류를 수정했습니다.",
+          "pt-BR": "Navegue pelos modelos agrupados por tipo de tarefa, veja os detalhes do modelo e corrigimos o teste dos modelos de geração de texto.",
+          "pt-PT": "Navegue pelos modelos agrupados por tipo de tarefa, veja os detalhes do modelo e corrigimos o teste dos modelos de geração de texto.",
+          "de": "Modelle nach Aufgabentyp gruppiert durchsuchen, Modelldetails ansehen – und der Testlauf für Textgenerierungsmodelle wurde behoben.",
+          "fr": "Parcourez les modèles regroupés par type de tâche, consultez leurs détails et l'essai des modèles de génération de texte est corrigé.",
+          "ar": "تصفّح النماذج مجمّعة حسب نوع المهمة، واعرض تفاصيل النموذج، وأصلحنا التشغيل التجريبي لنماذج توليد النص.",
+          "tr": "Modelleri görev türüne göre gruplandırarak inceleyin, model ayrıntılarını görün; metin oluşturma modellerinin deneme çalıştırması düzeltildi."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.4",
     "date": "2026.06.28",
     "channel": "Google Play",


### PR DESCRIPTION
## Android 1.4.2

接在 1.4.1（域名迁移 o-c.do）之后的小版本（**versionCode 7 / versionName 1.4.2**）。

### Workers AI
- 模型按任务类型分组浏览（新增可复用 `StorageGroupedListBody`，Text Generation 置顶）。
- 新增模型详情页：说明 / 任务 / 模型 ID（等宽可选中）；文本生成模型在有 `ai.write` 时内嵌试运行 playground。
- 修复试运行报「no route for that uri」：此前误把模型 UUID 拼进 `ai/run/{model}`，应传 `@cf/...` 模型名。

### 开发者平台 Pro 门控（对齐 iOS）
此前 Android hub 只有 Pages 包了 `ProGate`，其余免费可进。补齐 **Workers AI / AI Gateway / Queues / Hyperdrive / Durable Objects**（+ Workers AI 试运行子路由）的 `ProGate`；**Workers 与 AI 助手保持免费**。

### 发布
- changelog android.json 加 1.4.2（13 语）+ 重新生成 13× whatsnew、生成物 kt。
- direct 渠道签名 APK（v2，同历史密钥可原地更新）投放官网下载区 + `latest.json` vc7/1.4.2（保留 `o-c.do`）。
- Play AAB 已构建，待手动上传 Play Console。

---
**English:** Patch release 1.4.2 on top of 1.4.1 (the o-c.do domain migration). Workers AI now browses models grouped by task type, adds a model-detail page (description / task / model id) with an inline test-run playground for text-generation models when `ai.write` is granted, and fixes the test-run "no route for that uri" error (it was sending the model UUID instead of the `@cf/...` model name). Developer Platform Pro gating now matches iOS — Workers AI, AI Gateway, Queues, Hyperdrive and Durable Objects get `ProGate` (previously only Pages had it); Workers and the AI assistant stay free. Bundles the 13-language 1.4.2 changelog + regenerated whatsnew, the signed direct-channel APK + `latest.json` (vc7, keeping `o-c.do`), and the Play AAB (awaiting manual upload).
