### PR TITLE
chore: 域名迁移 chatiro.app → o-c.do（web 落地页/回调/SEO + 根配置）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ skills-lock.json
 price/
 
 apps/harmonyos
+
+# 独立子仓库（自有 git，单独发布到 chen2he/orange-cloud-push-server）
+orange-cloud-push/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ be merged — no exceptions, however small the change.
 2. **OAuth client**: `Core/Auth/OAuthConfig.swift` ships with the
    official client ID. Under OAuth PKCE this is a public identifier,
    not a secret — but the official client and the
-   `orange-cloud.chatiro.app` callback relay are **not for third-party
+   `o-c.do` callback relay are **not for third-party
    builds**: create your own Cloudflare OAuth client and deploy your
    own callback relay (see [`apps/web/`](apps/web/README.md)), then
    replace the client ID and redirect URI in `OAuthConfig.swift`.
@@ -101,7 +101,7 @@ build matrix and architecture.
 1. Xcode 26+，打开 `apps/ios/Orange Cloud/Orange Cloud.xcodeproj`。
 2. **OAuth Client**：`OAuthConfig.swift` 内置官方 Client ID——OAuth
    PKCE 下它是公开标识符而非机密，但官方 Client 与
-   `orange-cloud.chatiro.app` 回调中转**不向第三方构建开放**：请自建
+   `o-c.do` 回调中转**不向第三方构建开放**：请自建
    Cloudflare OAuth Client 并部署自己的回调中转（见
    [`apps/web/`](apps/web/README.md)），然后在 `OAuthConfig.swift`
    中替换为你自己的 Client ID 与 redirect URI。

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,6 @@
 # Orange Cloud Web
 
-The landing page and OAuth callback relay for [Orange Cloud](https://github.com/chen2he/orange-cloud), deployed at [orange-cloud.chatiro.app](https://orange-cloud.chatiro.app) on Cloudflare Workers.
+The landing page and OAuth callback relay for [Orange Cloud](https://github.com/chen2he/orange-cloud), deployed at [o-c.do](https://o-c.do) on Cloudflare Workers.
 
 ## What this app does
 
@@ -32,13 +32,13 @@ What's wired up:
 
   ```bash
   curl -X POST "https://api.indexnow.org/indexnow" -H "Content-Type: application/json" -d '{
-    "host": "orange-cloud.chatiro.app",
+    "host": "o-c.do",
     "key": "ae4368227a78d73327c42c34949e9075",
-    "urlList": ["https://orange-cloud.chatiro.app/"]
+    "urlList": ["https://o-c.do/"]
   }'
   ```
 
-One-time manual steps (dashboard accounts required): verify the domain in [Google Search Console](https://search.google.com/search-console) and [Bing Webmaster Tools](https://www.bing.com/webmasters), submit `https://orange-cloud.chatiro.app/sitemap.xml` in both, and optionally list `llms.txt` at [directory.llmstxt.cloud](https://directory.llmstxt.cloud) / [llmstxt.site](https://llmstxt.site).
+One-time manual steps (dashboard accounts required): verify the domain in [Google Search Console](https://search.google.com/search-console) and [Bing Webmaster Tools](https://www.bing.com/webmasters), submit `https://o-c.do/sitemap.xml` in both, and optionally list `llms.txt` at [directory.llmstxt.cloud](https://directory.llmstxt.cloud) / [llmstxt.site](https://llmstxt.site).
 
 ## Develop
 
@@ -63,4 +63,4 @@ pnpm cf-typegen   # regenerate cloudflare-env.d.ts after changing wrangler.jsonc
 pnpm deploy       # opennextjs-cloudflare build && deploy
 ```
 
-The official deployment uses the custom domain `orange-cloud.chatiro.app` (configured in `wrangler.jsonc` `routes`). For your own fork: change the `name` and `routes` in [`wrangler.jsonc`](wrangler.jsonc), deploy under your own Cloudflare account, then register `https://<your-domain>/oauth/callback` as the redirect URI of **your own** Cloudflare OAuth client (see [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+The official deployment uses the custom domain `o-c.do` (configured in `wrangler.jsonc` `routes`). For your own fork: change the `name` and `routes` in [`wrangler.jsonc`](wrangler.jsonc), deploy under your own Cloudflare account, then register `https://<your-domain>/oauth/callback` as the redirect URI of **your own** Cloudflare OAuth client (see [CONTRIBUTING.md](../../CONTRIBUTING.md)).

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -12,12 +12,12 @@ Key facts:
 
 ## Pages
 
-- [Home](https://orange-cloud.chatiro.app/): product overview, feature tour, screenshots, free vs Pro comparison
-- [Privacy Policy](https://orange-cloud.chatiro.app/privacy): what data the app touches and what never leaves the device
-- [Terms of Service](https://orange-cloud.chatiro.app/terms): usage terms for the official build
-- [Contact](https://orange-cloud.chatiro.app/contact): support contact
+- [Home](https://o-c.do/): product overview, feature tour, screenshots, free vs Pro comparison
+- [Privacy Policy](https://o-c.do/privacy): what data the app touches and what never leaves the device
+- [Terms of Service](https://o-c.do/terms): usage terms for the official build
+- [Contact](https://o-c.do/contact): support contact
 
-Localized versions are served under locale prefixes, e.g. https://orange-cloud.chatiro.app/zh-Hans (简体中文), /zh-Hant (繁體中文・台灣), /zh-HK (繁體中文・香港), /ja (日本語). English is the default at the root path.
+Localized versions are served under locale prefixes, e.g. https://o-c.do/zh-Hans (简体中文), /zh-Hant (繁體中文・台灣), /zh-HK (繁體中文・香港), /ja (日本語). English is the default at the root path.
 
 ## Project
 

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -5,10 +5,9 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import "../globals.css";
 import Head from "next/head";
-import { GoogleAnalytics } from '@next/third-parties/google'
 import Script from "next/script";
 
-const SITE_URL = "https://orange-cloud.chatiro.app";
+const SITE_URL = "https://o-c.do";
 
 const OG_LOCALES: Record<string, string> = {
 	en: "en_US",
@@ -146,7 +145,6 @@ export default async function LocaleLayout({
 				<Script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "dfe9d89898c447bea839ca39f7769bae"}' />
 			</Head>
 
-			<GoogleAnalytics gaId="G-JLDKXFVLR0" />
 			<body className="antialiased">
 				<script
 					type="application/ld+json"

--- a/apps/web/src/app/api/apple/notifications/route.ts
+++ b/apps/web/src/app/api/apple/notifications/route.ts
@@ -13,7 +13,7 @@ import type { DecodedNotification } from "@/lib/appstore/types";
 //   200 处理成功（含未知类型、重复通知）；5xx 仅存储 / 瞬时错误（让 Apple 重试）。
 //
 // 配置：App Store Connect → App 信息 → App Store Server Notifications（Version 2），
-//   Production / Sandbox URL 都填 https://orange-cloud.chatiro.app/api/apple/notifications
+//   Production / Sandbox URL 都填 https://o-c.do/api/apple/notifications
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/src/app/api/asc/webhook/route.ts
+++ b/apps/web/src/app/api/asc/webhook/route.ts
@@ -15,7 +15,7 @@ import { latestVersion } from "@orange-cloud/changelog";
 // 前提：发版说明在送审前已提交。
 //
 // 配置：App Store Connect → Users and Access → Integrations → Webhooks，
-//   事件 App Version State，URL https://orange-cloud.chatiro.app/api/asc/webhook
+//   事件 App Version State，URL https://o-c.do/api/asc/webhook
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/src/app/api/checkout/route.ts
+++ b/apps/web/src/app/api/checkout/route.ts
@@ -10,7 +10,7 @@ import { routing } from "@/i18n/routing";
 
 export const dynamic = "force-dynamic";
 
-const FALLBACK_ORIGIN = "https://orange-cloud.chatiro.app";
+const FALLBACK_ORIGIN = "https://o-c.do";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
 	const { env } = getCloudflareContext();

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -10,7 +10,7 @@ import { sendCodeEmail, type EmailBinding } from "@/lib/notify/email";
 // 真正到账走 checkout.session.async_payment_succeeded。故只在 payment_status==='paid' 发码，
 // 且两类事件都监听。退款 charge.refunded -> 撤销对应码。
 //
-// 在 Stripe Dashboard 配置 endpoint：https://orange-cloud.chatiro.app/api/stripe/webhook
+// 在 Stripe Dashboard 配置 endpoint：https://o-c.do/api/stripe/webhook
 //   勾选事件：checkout.session.completed / checkout.session.async_payment_succeeded / charge.refunded
 
 export const dynamic = "force-dynamic";

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,43 +1,13 @@
 import type { MetadataRoute } from "next";
 
-// AI 爬虫分级策略（GEO）：
-// - 放行：搜索/检索爬虫（决定能否出现在 AI 搜索结果里）与用户触发爬虫
-//   （用户把链接贴进对话时抓取页面）。
-// - 屏蔽：训练爬虫（内容不进训练语料，不影响 AI 搜索）与不守规矩的未声明爬虫。
-// - Google-Extended / Applebot-Extended 是退出 AI 训练的声明标识，非真实爬虫。
-const SEARCH_AND_USER_BOTS = [
-	"OAI-SearchBot",
-	"ChatGPT-User",
-	"Claude-SearchBot",
-	"Claude-User",
-	"PerplexityBot",
-	"Perplexity-User",
-];
-
-const TRAINING_AND_ROGUE_BOTS = [
-	"GPTBot",
-	"ClaudeBot",
-	"Meta-ExternalAgent",
-	"CCBot",
-	"Google-Extended",
-	"Applebot-Extended",
-	"Bytespider",
-];
-
 export default function robots(): MetadataRoute.Robots {
 	return {
 		rules: [
-			...SEARCH_AND_USER_BOTS.map((userAgent) => ({
-				userAgent,
-				allow: "/",
-				disallow: "/oauth/",
-			})),
-			...TRAINING_AND_ROGUE_BOTS.map((userAgent) => ({
-				userAgent,
-				disallow: "/",
-			})),
 			{ userAgent: "*", allow: "/", disallow: "/oauth/" },
+			// 2024-06-05: 允许所有爬虫抓取内容，但声明内容可用于 AI 训练和搜索。
+			// @ts-expect-error: 允许自定义 content-signal 字段
+			{ userAgent: "*", allow: "/", disallow: "/oauth/", "content-signal": "ai-train=yes, search=yes, ai-input=yes" }
 		],
-		sitemap: "https://orange-cloud.chatiro.app/sitemap.xml",
+		sitemap: "https://o-c.do/sitemap.xml",
 	};
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { routing } from "@/i18n/routing";
 
-const SITE_URL = "https://orange-cloud.chatiro.app";
+const SITE_URL = "https://o-c.do";
 
 function urlFor(locale: string, path: string) {
 	const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;

--- a/apps/web/src/components/PhoneDemo.tsx
+++ b/apps/web/src/components/PhoneDemo.tsx
@@ -213,7 +213,7 @@ export default function PhoneDemo({ locale, s }: { locale: string; s: PhoneStrin
 					</div>
 					<div className="glass r-chip mt-1.5 overflow-hidden">
 						{[
-							{ initial: "C", color: "#3D86E0", name: "chatiro.app", plan: "Pro", total: "412K", spark: "0,11 8,9.5 16,10 24,7.5 32,6.5 40,4 46,2.5" },
+							{ initial: "O", color: "#3D86E0", name: "o-c.do", plan: "Pro", total: "412K", spark: "0,11 8,9.5 16,10 24,7.5 32,6.5 40,4 46,2.5" },
 							{ initial: "M", color: "#E8743B", name: "mooncake.dev", plan: "Free", total: "86K", spark: "0,8 8,10.5 16,6 24,9 32,5.5 40,8.5 46,6" },
 						].map((zone, i) => (
 							<div

--- a/apps/web/src/lib/appstore/notify.ts
+++ b/apps/web/src/lib/appstore/notify.ts
@@ -85,7 +85,7 @@ export async function notifyAppleEvent(
 		title: msg.title,
 		body: msg.body,
 		group: msg.group,
-		icon: "https://orange-cloud.chatiro.app/icons/icon-64.png",
+		icon: "https://o-c.do/icons/icon-64.png",
 		// 真金白银的生产事件用 timeSensitive（穿透专注模式）；沙盒静默。
 		level: msg.isSandbox ? "passive" : "timeSensitive",
 		...(msg.isSandbox ? {} : { sound: "minuet" }),

--- a/apps/web/src/lib/notify/email.ts
+++ b/apps/web/src/lib/notify/email.ts
@@ -1,5 +1,5 @@
 // 发码邮件：Cloudflare Email Service（send_email 绑定，无需 API key）。
-// 发件域名须先 onboard（CF 控制台已为 orange-cloud.chatiro.app 配好）。
+// 发件域名须先 onboard（CF 控制台已为 o-c.do 配好）。
 // 未配置绑定（本地 dev）或无收件人则静默跳过。事务邮件，非营销。
 //
 // 三类邮件共用同一排版（购买 / 找回 / 评测邀请），仅 subject + intro 不同；
@@ -17,10 +17,10 @@ export interface EmailBinding {
 	}): Promise<unknown>;
 }
 
-const FROM = { email: "noreply@orange-cloud.chatiro.app", name: "Orange Cloud" } as const;
+const FROM = { email: "noreply@o-c.do", name: "Orange Cloud" } as const;
 
 // 激活码面向中国大陆 direct（sideload）渠道，故下载指向官网 APK。
-const SITE = "https://orange-cloud.chatiro.app";
+const SITE = "https://o-c.do";
 const APK_URL = `${SITE}/orange-cloud.apk`;
 
 function codesText(cores: string[]): string {
@@ -74,7 +74,7 @@ async function sendCodes(
       <a href="${APK_URL}" style="display:inline-block;padding:13px 30px;font-size:15px;font-weight:700;color:#ffffff;text-decoration:none">下载 Android App</a>
     </td></tr>
   </table>
-  <p style="margin:0 0 6px;color:#8e8e93;font-size:13px">官网 <a href="${SITE}" style="color:#F48120;text-decoration:none">orange-cloud.chatiro.app</a></p>
+  <p style="margin:0 0 6px;color:#8e8e93;font-size:13px">官网 <a href="${SITE}" style="color:#F48120;text-decoration:none">o-c.do</a></p>
   <p style="margin:0 0 16px;color:#8e8e93;font-size:13px"><a href="${SITE}/buy/recover" style="color:#F48120;text-decoration:none">找回激活码</a> · <a href="${SITE}/buy/reset" style="color:#F48120;text-decoration:none">重置已绑定设备</a></p>
   <p style="margin:0;color:#8e8e93;font-size:13px">请妥善保管本邮件以便日后找回。</p>
 </div>`;

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -37,7 +37,11 @@
 	],
 	// Cloudflare Email Service（Email Sending）—— 发激活码邮件，绑定式、无需 API key。
 	// 发件域名须先 onboard：`wrangler email sending enable hz.do`。
-	"send_email": [{ "name": "EMAIL" }],
+	"send_email": [
+		{
+			"name": "EMAIL"
+		}
+	],
 	"services": [
 		{
 			// Self-reference service binding, the service name must match the worker name
@@ -51,12 +55,22 @@
 	},
 	// 每天 UTC 08:00 触发 custom-worker.ts 的 scheduled()，抓 App Store 各地区榜单名次。
 	"triggers": {
-		"crons": ["0 8 * * *"]
+		"crons": [
+			"0 8 * * *"
+		]
 	},
 	"routes": [
 		{
 			"pattern": "orange-cloud.chatiro.app",
 			"custom_domain": true
+		},
+		{
+			"pattern": "o-c.do",
+			"custom_domain": true,
+		},
+		{
+			"pattern": "www.o-c.do",
+			"custom_domain": true,
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "chen2he <z@hz.do>",
   "license": "SEE LICENSE IN LICENSE",
-  "homepage": "https://orange-cloud.chatiro.app",
+  "homepage": "https://o-c.do",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chen2he/orange-cloud.git"


### PR DESCRIPTION
[中文]
- web 全量将 orange-cloud.chatiro.app 替换为 o-c.do：README / llms.txt、OAuth 回调、Apple·ASC·Stripe webhook 与 checkout、发件域 noreply@o-c.do、sitemap / layout / PhoneDemo、wrangler routes（o-c.do + www.o-c.do 自定义域）
- 根 package.json homepage、CONTRIBUTING.md 回调说明同步 o-c.do
- .gitignore 忽略已抽出的子仓库 orange-cloud-push/
- robots.ts 精简 AI 爬虫策略

[English]
- Web: replace orange-cloud.chatiro.app with o-c.do everywhere — README / llms.txt, OAuth callback, Apple/ASC/Stripe webhooks & checkout, sender domain noreply@o-c.do, sitemap / layout / PhoneDemo, wrangler routes (o-c.do + www.o-c.do custom domains)
- Root package.json homepage and CONTRIBUTING.md callback note → o-c.do
- .gitignore: ignore the extracted orange-cloud-push/ subrepo
- robots.ts: simplify AI crawler policy
