### PR TITLE
fix(ios): 1.8.1 — Access 多主机名 / 令牌卡死 / 文件挂载重复 / 减少动画 / 用量缓存

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud File/R2FileProviderClient.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud File/R2FileProviderClient.swift
@@ -262,8 +262,18 @@ actor R2FileProviderClient {
 
     private func refresh(stored: StoredToken) async throws -> String {
         if let task = refreshTask { return try await task.value }
-        guard let refreshToken = stored.refreshToken else { throw ClientError.notAuthenticated }
+        let sessionId = credentials.sessionId.uuidString
         let task = Task<String, Error> {
+            // 跨进程独占锁：避免与主 App 并发刷新同一个轮转 refresh token——Cloudflare 单次有效令牌
+            // 被两进程同时用会触发复用检测吊销整条令牌链，主 App 随后卡死登录态。best-effort，拿不到也照常刷。
+            let lock = await RefreshGate.acquire(sessionId: sessionId)
+            defer { RefreshGate.release(lock) }
+
+            // 等锁期间主 App 可能已把令牌轮换掉：重读共享钥匙串，用最新一份去刷新
+            // （而非调用时手里那份陈旧令牌），避免拿旧令牌刷新触发复用检测。
+            let current = loadToken() ?? stored
+            guard let refreshToken = current.refreshToken else { throw ClientError.notAuthenticated }
+
             var request = URLRequest(url: Self.oauthTokenURL)
             request.httpMethod = "POST"
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
@@ -281,7 +291,7 @@ actor R2FileProviderClient {
                 accessToken: tr.access_token,
                 refreshToken: tr.refresh_token ?? refreshToken,
                 expiresAt: Date().addingTimeInterval(TimeInterval(tr.expires_in)),
-                scope: tr.scope ?? stored.scope
+                scope: tr.scope ?? current.scope
             )
             saveToken(newToken)
             return newToken.accessToken

--- a/apps/ios/Orange Cloud/Orange Cloud File/RefreshGate.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud File/RefreshGate.swift
@@ -1,0 +1,51 @@
+//
+//  RefreshGate.swift
+//  Orange Cloud File
+//
+//  跨进程 token 刷新串行化（扩展进程侧）。与主 App 的 Core/Auth/RefreshGate.swift 是等价实现——
+//  两 target 不共享源码，按本扩展「自包含、零跨 target 依赖」的既有约定复制一份；改一处务必同步另一处。
+//
+//  动机：主 App 与本扩展共享同一个 Cloudflare OAuth refresh token，而该令牌单次有效、轮转式。
+//  两进程并发刷新会触发服务端复用检测吊销整条令牌链，主 App 随后卡死登录态。用共享 App Group 容器
+//  里的 fcntl 文件记录锁让同一身份的刷新任一时刻只有一个进程在跑。best-effort：拿不到锁就降级直刷。
+//
+
+import Foundation
+
+enum RefreshGate {
+
+    /// 与 entitlements 的 application-groups 对齐
+    private static let appGroupID = "group.jiamin.chen.Orange-Cloud"
+
+    /// 取得「该身份刷新」的跨进程独占锁。非 nil = 已持锁（调用方必须 release）；nil = 降级（照常刷）。
+    static func acquire(sessionId: String) async -> Int32? {
+        guard let dir = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) else {
+            return nil
+        }
+        let lockURL = dir.appendingPathComponent("token-refresh-\(sessionId).lock")
+        let fd = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
+        guard fd >= 0 else { return nil }
+        for _ in 0..<120 {                                   // 120 × 50ms ≈ 6s 上限
+            if lock(fd, type: Int16(F_WRLCK)) { return fd }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        close(fd)
+        return nil
+    }
+
+    static func release(_ token: Int32?) {
+        guard let fd = token else { return }
+        _ = lock(fd, type: Int16(F_UNLCK))
+        close(fd)
+    }
+
+    /// 对整个文件加 / 解非阻塞记录锁（fcntl + struct flock，避开 flock() 函数与同名结构体的歧义）
+    private static func lock(_ fd: Int32, type: Int16) -> Bool {
+        var fl = flock()
+        fl.l_start = 0
+        fl.l_len = 0
+        fl.l_type = type
+        fl.l_whence = Int16(SEEK_SET)
+        return fcntl(fd, F_SETLK, &fl) != -1
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -653,7 +653,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -673,7 +673,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -685,7 +685,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -706,7 +706,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -717,7 +717,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -740,7 +740,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -751,7 +751,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -774,7 +774,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -786,7 +786,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -808,7 +808,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -820,7 +820,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -840,7 +840,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -852,7 +852,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -870,7 +870,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -882,7 +882,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -900,7 +900,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -912,7 +912,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -930,7 +930,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -942,7 +942,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -963,7 +963,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -982,7 +982,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1006,7 +1006,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1025,7 +1025,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/ContentView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ContentView.swift
@@ -11,6 +11,7 @@ import SwiftData
 struct ContentView: View {
 
     @Environment(AuthManager.self) private var auth
+    @AppStorage(AppMotion.storageKey) private var reduceAnimations = false
 
     var body: some View {
         @Bindable var router = AppRouter.shared
@@ -24,10 +25,19 @@ struct ContentView: View {
             }
         }
         .animation(.smooth, value: auth.isLoggedIn)
+        // App「减少动画」开关下注全树：Zoom 导航转场 / 玻璃岛浮现 / 骨架闪烁统一读它
+        .environment(\.appReduceMotion, reduceAnimations)
         // 「免登录工具箱」挂在 auth 闸门之上（不随 .id 会话重建销毁），
         // 登录前后、通知点按统一从这里弹出。
         .fullScreenCover(isPresented: $router.presentToolbox) {
             ToolboxHubView()
+        }
+        // 启动自愈：清掉「文件」App 里不属于当前存活身份的孤儿挂载 domain（重装/登出残留，
+        // 表现为侧边栏同名重复且删不掉、每重装一次多一个）。一次性，登录态与否都跑。
+        .task {
+            await FileProviderMountManager.reconcile(
+                liveSessionIds: Set(auth.sessions.map(\.id.uuidString))
+            )
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/AuthManager.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/AuthManager.swift
@@ -388,10 +388,20 @@ final class AuthManager {
         return try await task.value
     }
 
-    /// 实际刷新逻辑：仅在刷新令牌确已失效（token 端点 400）时移除该身份；
-    /// 网络中断 / 超时 / 5xx / 429 等瞬时失败保留身份并原样抛出，交由调用方稍后重试，
-    /// 避免一次网络抖动就把用户登出（其他身份始终不受影响）。
+    /// 实际刷新逻辑。三条铁律：
+    /// ① **跨进程串行化**：先抢共享 App Group 文件锁（[[RefreshGate]]），避免与「文件」扩展并发刷新
+    ///    同一个轮转 refresh token——并发会触发 Cloudflare 复用检测吊销整条令牌链（卡死登录态的根因）。
+    /// ② **服务端明确拒绝（token 端点 4xx）才登出**：400/401/403 = 刷新令牌失效/被撤销/被复用吊销，
+    ///    登出该身份回登录页（一键重授权恢复），不再卡死；网络/超时/5xx/429 等瞬时失败保留身份原样抛出。
+    /// ③ **轮换自愈**：拿锁后才读 token（用钥匙串里最新一份去刷新，而非调用时手里的陈旧令牌）；被拒时
+    ///    若发现 refresh token 已被别的进程轮换走，用新令牌重试一次再判定，避免良性竞态误登出。
     private func performTokenRefresh(sessionId: UUID) async throws -> String {
+        // 跨进程独占锁（best-effort，拿不到也照常刷）
+        let lock = await RefreshGate.acquire(sessionId: sessionId.uuidString)
+        defer { RefreshGate.release(lock) }
+
+        // 拿到锁后才读 token：等锁期间另一进程可能已把令牌轮换掉，这里读到的是最新一份，
+        // 用它去刷新（而非调用时手里那份陈旧令牌），避免拿着旧令牌去刷触发复用检测。
         guard let stored = TokenStore.load(sessionId: sessionId) else {
             // 钥匙串读不到该身份 token：多半是切账号竞态下的陈旧请求，或确已被清。
             // 保留身份、抛出由调用方当未授权处理——绝不在此删身份（曾导致多账号雪崩登出）。
@@ -406,7 +416,7 @@ final class AuthManager {
         }
 
         // 诊断（issue #5 历史）：对比当前刷新令牌指纹与「我们最后写入」的基线。
-        // 移除 iCloud 同步后正常应恒等；不一致说明令牌被本进程之外改写过。usedFP/baselineFP 提到 do 外，catch 也能引用。
+        // 移除 iCloud 同步后正常应恒等；不一致说明令牌被本进程之外改写过。
         let usedFP = AuthDiagnostics.fingerprint(refreshToken)
         let baselineFP = AuthDiagnostics.lastWrittenFingerprint(sessionId)
         AppLog.auth.info("refresh attempt session=\(sessionId.uuidString) usedRefreshFP=\(usedFP) lastWrittenFP=\(baselineFP ?? "nil") accessExpiresInSec=\(Int(stored.expiresAt.timeIntervalSinceNow))")
@@ -415,28 +425,41 @@ final class AuthManager {
         }
 
         do {
-            let response = try await requestToken(parameters: [
-                "grant_type":    "refresh_token",
-                "client_id":     OAuthConfig.clientID,
-                "refresh_token": refreshToken,
-            ])
-            let newToken = TokenStore.StoredToken(
-                accessToken:  response.accessToken,
-                refreshToken: response.refreshToken ?? refreshToken,
-                expiresAt:    Date().addingTimeInterval(TimeInterval(response.expiresIn)),
-                scope:        response.scope ?? stored.scope
-            )
-            TokenStore.save(newToken, sessionId: sessionId)
-            AuthDiagnostics.recordWrite(refreshToken: newToken.refreshToken, sessionId: sessionId)
-            AppLog.auth.info("refresh ok session=\(sessionId.uuidString) newRefreshFP=\(AuthDiagnostics.fingerprint(newToken.refreshToken))")
-            return newToken.accessToken
-        } catch let AuthError.tokenEndpointError(status, _) where status == 400 {
-            // OAuth 标准：刷新令牌失效 / 被撤销 / 过期返回 400，确需重新授权
-            AppLog.auth.error("refresh rejected 400 (invalid_grant) → logout. usedRefreshFP=\(usedFP) lastWrittenFP=\(baselineFP ?? "nil")")
+            return try await requestAndStoreRefresh(sessionId: sessionId, refreshToken: refreshToken, previousScope: stored.scope)
+        } catch let AuthError.tokenEndpointError(status, _) where (400...403).contains(status) {
+            // token 端点 4xx = 服务端明确拒绝该刷新令牌。先看是否被别的进程轮换走了：
+            // 钥匙串里若已出现不同的 refresh token，用它重试一次（多账号 / 扩展并发下的良性竞态）。
+            if let latest = TokenStore.load(sessionId: sessionId),
+               let rotated = latest.refreshToken, rotated != refreshToken,
+               let token = try? await requestAndStoreRefresh(sessionId: sessionId, refreshToken: rotated, previousScope: latest.scope) {
+                AppLog.auth.notice("refresh rejected \(status) but keychain rotated by another process → recovered with fresh token. session=\(sessionId.uuidString)")
+                return token
+            }
+            // 确属失效：登出该身份（回登录页，一键重授权恢复），不再卡死登录态
+            AppLog.auth.error("refresh rejected \(status) (invalid_grant) → logout. usedRefreshFP=\(usedFP) lastWrittenFP=\(baselineFP ?? "nil")")
             removeSession(sessionId)
             throw AuthError.notLoggedIn
         }
         // 其它错误（网络 / 超时 / 5xx / 429）：保留身份，原样向上抛出
+    }
+
+    /// 用给定 refresh token 向 token 端点换新令牌、写回钥匙串并返回新 access token。
+    private func requestAndStoreRefresh(sessionId: UUID, refreshToken: String, previousScope: String) async throws -> String {
+        let response = try await requestToken(parameters: [
+            "grant_type":    "refresh_token",
+            "client_id":     OAuthConfig.clientID,
+            "refresh_token": refreshToken,
+        ])
+        let newToken = TokenStore.StoredToken(
+            accessToken:  response.accessToken,
+            refreshToken: response.refreshToken ?? refreshToken,
+            expiresAt:    Date().addingTimeInterval(TimeInterval(response.expiresIn)),
+            scope:        response.scope ?? previousScope
+        )
+        TokenStore.save(newToken, sessionId: sessionId)
+        AuthDiagnostics.recordWrite(refreshToken: newToken.refreshToken, sessionId: sessionId)
+        AppLog.auth.info("refresh ok session=\(sessionId.uuidString) newRefreshFP=\(AuthDiagnostics.fingerprint(newToken.refreshToken))")
+        return newToken.accessToken
     }
 
     private func requestToken(parameters: [String: String]) async throws -> TokenResponse {

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/RefreshGate.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/RefreshGate.swift
@@ -1,0 +1,61 @@
+//
+//  RefreshGate.swift
+//  Orange Cloud
+//
+//  跨进程 token 刷新串行化。主 App（AuthManager）与「文件」扩展（R2FileProviderClient）是两个
+//  独立进程，却共享同一个 Cloudflare OAuth refresh token——而 Cloudflare 的 refresh token 是
+//  **单次有效、轮转式**的：两个进程并发刷新会触发服务端的「复用检测」，把整条令牌链一起吊销，
+//  主 App 随后再也刷不出 token、卡死在登录态（数据全空白、下拉无反应）。
+//
+//  这里在共享 App Group 容器里用 fcntl 文件记录锁做跨进程互斥：同一身份的刷新任一时刻只有一个
+//  进程在跑（进程崩溃 / 退出时内核自动释放锁，不会留死锁）。**best-effort**：拿不到锁（超时）或
+//  容器不可用时就降级为不持锁直接刷，绝不死等、绝不比现状更糟。
+//
+//  扩展进程里有一份等价实现（Orange Cloud File/RefreshGate.swift）——两 target 不共享源码，
+//  与既有 token 读写一样按「自包含、零跨 target 依赖」复制；改一处务必同步另一处。
+//
+//  注：用 fcntl(F_SETLK) 而非 flock()，因为 BSD 的 flock() 函数与 `struct flock` 同名，Swift 里
+//  无法干净地引用到函数；fcntl + struct flock 无歧义。
+//
+
+import Foundation
+
+nonisolated enum RefreshGate {
+
+    /// 与 entitlements / WidgetSnapshot.appGroupID 对齐
+    private static let appGroupID = "group.jiamin.chen.Orange-Cloud"
+
+    /// 取得「该身份刷新」的跨进程独占锁。返回非 nil 句柄表示已持锁——调用方**必须**用 `release` 释放；
+    /// 返回 nil 表示降级（无共享容器 / 打不开 / 约 6s 内没抢到），调用方照常往下刷即可。
+    static func acquire(sessionId: String) async -> Int32? {
+        guard let dir = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) else {
+            return nil
+        }
+        let lockURL = dir.appendingPathComponent("token-refresh-\(sessionId).lock")
+        let fd = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
+        guard fd >= 0 else { return nil }
+        for _ in 0..<120 {                                   // 120 × 50ms ≈ 6s 上限
+            if lock(fd, type: Int16(F_WRLCK)) { return fd }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        close(fd)                                            // 超时没抢到：关掉句柄，降级
+        return nil
+    }
+
+    /// 释放 `acquire` 取得的锁（nil 为降级态，无操作）
+    static func release(_ token: Int32?) {
+        guard let fd = token else { return }
+        _ = lock(fd, type: Int16(F_UNLCK))
+        close(fd)
+    }
+
+    /// 对整个文件加 / 解非阻塞记录锁。成功返回 true（解锁恒为 true）。
+    private static func lock(_ fd: Int32, type: Int16) -> Bool {
+        var fl = flock()
+        fl.l_start = 0
+        fl.l_len = 0
+        fl.l_type = type
+        fl.l_whence = Int16(SEEK_SET)
+        return fcntl(fd, F_SETLK, &fl) != -1
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/FileProviderMountManager.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/FileProviderMountManager.swift
@@ -22,19 +22,27 @@ enum FileProviderMountManager {
         return domains.contains { $0.identifier.rawValue == target }
     }
 
-    /// 挂载：新增一个 domain（已存在则幂等返回）
+    /// 挂载：新增一个 domain（已存在则幂等返回）。
+    /// 不变式：同一 (account, bucket) 在「文件」里只允许一个 domain。挂载前先清掉任何旧身份
+    /// 残留的同桶 domain（sessionId 不同但 account+bucket 相同）——否则会在侧边栏出现同名、
+    /// App 又触达不到的重复挂载目录（重装后 sessionId 重置 + 系统保留旧 domain 的典型表现）。
     static func mount(sessionId: UUID, accountId: String, bucketName: String) async throws {
         let id = FileProviderDomainID.make(sessionId: sessionId, accountId: accountId, bucketName: bucketName)
-        if await isMounted(sessionId: sessionId, accountId: accountId, bucketName: bucketName) { return }
+        let domains = (try? await allDomains()) ?? []
+
+        for existing in domains {
+            guard existing.identifier.rawValue != id,
+                  let parsed = FileProviderDomainID.parse(existing.identifier.rawValue),
+                  parsed.accountId == accountId, parsed.bucketName == bucketName else { continue }
+            try? await remove(existing)   // 清掉同桶的孤儿 domain，best-effort
+        }
+
+        if domains.contains(where: { $0.identifier.rawValue == id }) { return }   // 已挂载，幂等
         let domain = NSFileProviderDomain(
             identifier: NSFileProviderDomainIdentifier(rawValue: id),
             displayName: bucketName
         )
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            NSFileProviderManager.add(domain) { error in
-                if let error { cont.resume(throwing: error) } else { cont.resume() }
-            }
-        }
+        try await add(domain)
     }
 
     /// 卸载：移除该 domain（连同系统侧已下载的副本）
@@ -42,6 +50,37 @@ enum FileProviderMountManager {
         let id = FileProviderDomainID.make(sessionId: sessionId, accountId: accountId, bucketName: bucketName)
         let domains = try await allDomains()
         guard let domain = domains.first(where: { $0.identifier.rawValue == id }) else { return }
+        try await remove(domain)
+    }
+
+    /// 启动自愈：移除「文件」里所有不属于当前存活登录身份的挂载 domain。
+    /// domain identifier 编码了 sessionId，而 sessionId 存在 UserDefaults——卸载即清空、重装重置，
+    /// 但系统会保留（甚至在重装后复活）旧的 domain 注册。这些旧 domain 的 sessionId 已不在存活集合里，
+    /// App 的挂载/卸载只认当前身份，永远触达不到它们 → 侧边栏同名重复且删不掉、每重装一次多一个。
+    /// 这里按存活 sessionId 把这类孤儿一并清掉（无法解析的历史 domain 也清）。登出态（空集合）下
+    /// 不存在合法挂载，会清掉全部残留 domain，符合预期。
+    static func reconcile(liveSessionIds: Set<String>) async {
+        let domains = (try? await allDomains()) ?? []
+        for domain in domains {
+            if let parsed = FileProviderDomainID.parse(domain.identifier.rawValue),
+               liveSessionIds.contains(parsed.sessionId.uuidString) {
+                continue   // 属于当前存活身份的合法挂载，保留
+            }
+            try? await remove(domain)
+        }
+    }
+
+    // MARK: - NSFileProviderManager 封装
+
+    private static func add(_ domain: NSFileProviderDomain) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            NSFileProviderManager.add(domain) { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            }
+        }
+    }
+
+    private static func remove(_ domain: NSFileProviderDomain) async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             NSFileProviderManager.remove(domain) { error in
                 if let error { cont.resume(throwing: error) } else { cont.resume() }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/UI/AvailabilityCompat.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/UI/AvailabilityCompat.swift
@@ -35,15 +35,26 @@ extension View {
     }
 }
 
+// MARK: - 统一动效信号
+
+private struct AppReduceMotionKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    /// App 设置里「减少动画」开关的值（独立于系统辅助功能「减弱动态效果」）。在根视图注入，
+    /// 让系统级转场（Zoom 导航转场）与自定义动画（玻璃岛浮现 / 骨架闪烁）都能跟着这个开关走——
+    /// 否则开关只接了全局 .transaction，盖不住导航转场与只读系统设置的浮现动画，用户感觉「开了没用」。
+    var appReduceMotion: Bool {
+        get { self[AppReduceMotionKey.self] }
+        set { self[AppReduceMotionKey.self] = newValue }
+    }
+}
+
 extension View {
-    /// 详情页：iOS 18+ 应用 Zoom 导航转场；iOS 17 原样返回（标准 push）。
-    @ViewBuilder
-    func zoomNavigationTransition(sourceID: some Hashable, in namespace: Namespace.ID) -> some View {
-        if #available(iOS 18.0, *) {
-            navigationTransition(.zoom(sourceID: sourceID, in: namespace))
-        } else {
-            self
-        }
+    /// 详情页：iOS 18+ 应用 Zoom 导航转场；iOS 17 或开启「减少动画」时原样返回（标准 push）。
+    func zoomNavigationTransition<ID: Hashable>(sourceID: ID, in namespace: Namespace.ID) -> some View {
+        modifier(ZoomNavigationTransition(sourceID: sourceID, namespace: namespace))
     }
 
     /// 源视图（列表行）：iOS 18+ 标记 Zoom 转场源；iOS 17 无操作。
@@ -75,6 +86,23 @@ extension View {
             symbolEffect(.bounce, options: .nonRepeating)
         } else {
             self
+        }
+    }
+}
+
+/// Zoom 导航转场（iOS 18+），开启「减少动画」时降级为标准 push。
+/// 读环境注入的 appReduceMotion——系统「减弱动态效果」由系统自动让 .zoom 回退，这里只额外接 App 开关。
+private struct ZoomNavigationTransition<ID: Hashable>: ViewModifier {
+    @Environment(\.appReduceMotion) private var appReduceMotion
+    let sourceID: ID
+    let namespace: Namespace.ID
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *), !appReduceMotion {
+            content.navigationTransition(.zoom(sourceID: sourceID, in: namespace))
+        } else {
+            content
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -1,6 +1,158 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "添加主机名" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة اسم مضيف"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hostname hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Hostname"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar nombre de host"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un nom d’hôte"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト名を追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스트 이름 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar nome de host"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar nome de anfitrião"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ana makine adı ekle"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增主機名稱"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增主機名稱"
+          }
+        }
+      }
+    },
+    "自托管应用可保护多个公共主机名（及路径），第一个为主域名。左滑删除。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكن للتطبيقات المُستضافة ذاتيًا حماية عدة أسماء مضيفين عامة (ومسارات). الأول هو النطاق الأساسي. اسحب للحذف."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selbst gehostete Apps können mehrere öffentliche Hostnamen (und Pfade) schützen. Der erste ist die primäre Domain. Wischen zum Löschen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-hosted apps can protect multiple public hostnames (and paths). The first is the primary domain. Swipe to delete."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las apps autoalojadas pueden proteger varios nombres de host públicos (y rutas). El primero es el dominio principal. Desliza para eliminar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les apps auto-hébergées peuvent protéger plusieurs noms d’hôte publics (et chemins). Le premier est le domaine principal. Glissez pour supprimer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セルフホストのアプリは複数のパブリックホスト名（とパス）を保護できます。最初のものがメインのドメインです。スワイプで削除。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자체 호스팅 앱은 여러 공개 호스트 이름(및 경로)을 보호할 수 있습니다. 첫 번째가 기본 도메인입니다. 밀어서 삭제."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apps auto-hospedados podem proteger vários nomes de host públicos (e caminhos). O primeiro é o domínio principal. Deslize para excluir."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As apps auto-alojadas podem proteger vários nomes de anfitrião públicos (e caminhos). O primeiro é o domínio principal. Deslize para eliminar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kendi sunucunuzda barındırılan uygulamalar birden çok genel ana makine adını (ve yolları) koruyabilir. İlki birincil etki alanıdır. Silmek için kaydırın."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自架應用程式可保護多個公開主機名稱（及路徑），第一個為主域名。左滑刪除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自架應用程式可保護多個公開主機名稱（及路徑），第一個為主網域。左滑刪除。"
+          }
+        }
+      }
+    },
     "端点推送" : {
       "localizations" : {
         "ar" : {

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/AccountUsageModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/AccountUsageModels.swift
@@ -254,7 +254,7 @@ nonisolated struct D1UsageSum: Codable, Sendable {
 }
 
 /// D1 用量聚合
-nonisolated struct D1Usage: Sendable {
+nonisolated struct D1Usage: Codable, Sendable {
     let rowsReadToday:     Int
     let rowsWrittenToday:  Int
     let rowsReadPeriod:    Int
@@ -381,7 +381,7 @@ nonisolated struct KVStorageMax: Codable, Sendable {
 }
 
 /// KV 用量聚合
-nonisolated struct KVUsage: Sendable {
+nonisolated struct KVUsage: Codable, Sendable {
     let readsToday:   Int
     let writesToday:  Int
     let readsPeriod:  Int
@@ -390,7 +390,7 @@ nonisolated struct KVUsage: Sendable {
 
 // MARK: - 聚合结果
 
-nonisolated struct AccountUsage: Sendable {
+nonisolated struct AccountUsage: Codable, Sendable {
     let workersRequestsToday: Int
     let workersRequestsMonth: Int
     let workersErrorsMonth:   Int

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/ZeroTrustModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/ZeroTrustModels.swift
@@ -9,17 +9,43 @@
 import Foundation
 
 /// Access 应用。列表只给概要；编辑前用 getApp 取详情（含 policies 的完整 include 规则）。
+/// 自托管应用可绑**多个**公共主机名：现行字段是 `destinations`（含 public/private 目标），
+/// 旧字段 `self_hosted_domains` 已弃用但 API 仍返回（含全部 public 目标的 URI）；只读 `domain`
+/// 只是其中第一个，**不能只取它**否则多主机名只显示第一个（issue：网页端绑 3 个子域，客户端只显示 1 个）。
 nonisolated struct AccessApp: Codable, Identifiable, Sendable {
-    let id:              String
-    let name:            String?
-    let domain:          String?
-    let type:            String?
-    let sessionDuration: String?
-    let policies:        [AccessPolicy]?
+    let id:                String
+    let name:              String?
+    let domain:            String?
+    let selfHostedDomains: [String]?
+    let destinations:      [AccessDestination]?
+    let type:              String?
+    let sessionDuration:   String?
+    let policies:          [AccessPolicy]?
 
     enum CodingKeys: String, CodingKey {
-        case id, name, domain, type, policies
+        case id, name, domain, type, policies, destinations
+        case selfHostedDomains = "self_hosted_domains"
         case sessionDuration = "session_duration"
+    }
+
+    /// 全部公共主机名（保序去重，domain 优先）。destinations 的 public 目标 ∪ self_hosted_domains ∪ domain，
+    /// 三处取并集兼容新老应用形态；只要其一有值就能拿全。
+    var publicHostnames: [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        func add(_ value: String?) {
+            guard let value, !value.isEmpty, seen.insert(value).inserted else { return }
+            out.append(value)
+        }
+        add(domain)
+        for dest in destinations ?? [] where (dest.type ?? "public") == "public" { add(dest.uri) }
+        for host in selfHostedDomains ?? [] { add(host) }
+        return out
+    }
+
+    /// 写回时需原样保留的非 public 目标（如私有网络目标），避免编辑公共主机名时把它们误删
+    var nonPublicDestinations: [AccessDestination] {
+        (destinations ?? []).filter { ($0.type ?? "public") != "public" }
     }
 
     /// 应用类型可读名
@@ -37,6 +63,13 @@ nonisolated struct AccessApp: Codable, Identifiable, Sendable {
         case let other:      other
         }
     }
+}
+
+/// Access 应用的目标（`destinations` 取代 `self_hosted_domains`）：
+/// type=public 是公共主机名，type=private 是私有网络目标（IP/私有主机名）。
+nonisolated struct AccessDestination: Codable, Sendable {
+    let type: String?
+    let uri:  String?
 }
 
 /// Access 策略（可复用资源；应用通过 id 引用）
@@ -152,15 +185,23 @@ nonisolated struct AccessPolicyInput: Codable, Sendable {
 
 nonisolated struct AccessAppInput: Codable, Sendable {
     let name:            String
-    let domain:          String
+    let domain:          String                       // 主主机名（第一个），保留兼容
+    let destinations:    [AccessDestinationInput]?    // 全部目标（多公共主机名 + 保留的私有目标）
     let type:            String
     let sessionDuration: String?
     let policies:        [String]      // 引用的策略 ID
 
     enum CodingKeys: String, CodingKey {
-        case name, domain, type, policies
+        case name, domain, type, policies, destinations
         case sessionDuration = "session_duration"
     }
+}
+
+/// 写回用的单个目标。PUT 是全量替换：编辑公共主机名时必须把**全部**主机名（及原有私有目标）一起回写，
+/// 否则会把未提交的主机名删掉（此前只回写 domain 单值 → 多主机名应用一保存就被删到只剩一个）。
+nonisolated struct AccessDestinationInput: Codable, Sendable {
+    let type: String
+    let uri:  String
 }
 
 /// Access 会话时长预设

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
@@ -156,6 +156,10 @@ final class DashboardViewModel {
     /// 账号用量（Workers/R2）。同一账号只拉一次，下拉刷新强制重拉。
     /// 周期起点优先级：订阅接口（best-effort）→ 手动账单日（fallbackPeriodStart）→ 自然月。
     func loadUsage(accountId: String, fallbackPeriodStart: Date? = nil, force: Bool = false) async {
+        // 先用上次缓存即时填充（VM 被重建后切回概览不再空白重载），随后照常后台静默刷新
+        if usage == nil, let cached = UsageCache.load(accountId: accountId) {
+            usage = cached
+        }
         guard force || usageLoadedForAccount != accountId else { return }
         if let usageTask {
             await usageTask.value
@@ -273,6 +277,7 @@ final class DashboardViewModel {
             self.usage = usage
             usageLoadFailed = false
             usageLoadedForAccount = accountId
+            UsageCache.save(usage, accountId: accountId)   // 落盘供下次切回即时显示
             persistAnalyticsAvailability(true)
         } else {
             // 账号级分析全部失败（多为 GraphQL 数据集权限问题，见网络日志 "graphQL error"）。
@@ -352,5 +357,30 @@ final class DashboardViewModel {
         WidgetCenter.shared.reloadTimelines(ofKind: "ZoneStatusWidget")
         // 数据刷新后把最新快照推给 Apple Watch
         WatchSessionManager.shared.pushCurrentState()
+    }
+}
+
+/// 概览用量的本地缓存（按账号）。VM 在 iPad 侧栏返回概览时会被重建，内存里的 usage 随之丢失 →
+/// 每次切回都空白重载。缓存让「先显示上次数据、后台静默刷新」成立，切回即有数。
+nonisolated enum UsageCache {
+
+    private static let key = "dashboardUsageByAccount"
+
+    private static func loadMap() -> [String: AccountUsage] {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let map = try? JSONDecoder().decode([String: AccountUsage].self, from: data) else { return [:] }
+        return map
+    }
+
+    static func load(accountId: String) -> AccountUsage? {
+        loadMap()[accountId]
+    }
+
+    static func save(_ usage: AccountUsage, accountId: String) {
+        var map = loadMap()
+        map[accountId] = usage
+        if let data = try? JSONEncoder().encode(map) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZeroTrustViewModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZeroTrustViewModels.swift
@@ -51,8 +51,8 @@ final class AccessAppsViewModel {
         }
     }
 
-    /// 新建：先建可复用策略，再建应用引用它
-    func create(name: String, domain: String, sessionDuration: String, decision: String, include: [AccessRule]) async -> Bool {
+    /// 新建：先建可复用策略，再建应用引用它。hostnames 为全部公共主机名（保序，第一个作主 domain）。
+    func create(name: String, hostnames: [String], sessionDuration: String, decision: String, include: [AccessRule]) async -> Bool {
         guard let accountId, !isSaving else { return false }
         isSaving = true
         error = nil
@@ -69,7 +69,12 @@ final class AccessAppsViewModel {
             do {
                 _ = try await service.createAccessApp(
                     accountId: accountId,
-                    body: AccessAppInput(name: name, domain: domain, type: "self_hosted", sessionDuration: sessionDuration, policies: [policyId])
+                    body: AccessAppInput(
+                        name: name,
+                        domain: hostnames.first ?? "",
+                        destinations: hostnames.map { AccessDestinationInput(type: "public", uri: $0) },
+                        type: "self_hosted", sessionDuration: sessionDuration, policies: [policyId]
+                    )
                 )
             } catch {
                 // 应用创建失败：补偿删掉刚建的可复用策略，避免账号里堆积孤儿策略
@@ -85,12 +90,15 @@ final class AccessAppsViewModel {
         }
     }
 
-    /// 编辑：可选先 PATCH 策略规则，再 PUT 应用（policyIds 为现有引用，保持不变）
+    /// 编辑：可选先 PATCH 策略规则，再 PUT 应用（policyIds 为现有引用，保持不变）。
+    /// hostnames 为编辑后的全部公共主机名；preserved 为原应用的非 public 目标，原样回写避免误删。
+    /// PUT 全量替换——必须把全部主机名一起回写，否则会把没提交的主机名删掉。
     func update(
         appId: String,
         policyIds: [String],
         name: String,
-        domain: String,
+        hostnames: [String],
+        preservedDestinations: [AccessDestination],
         sessionDuration: String,
         policyPatch: (id: String, decision: String, include: [AccessRule])?
     ) async -> Bool {
@@ -105,9 +113,17 @@ final class AccessAppsViewModel {
                     body: AccessPolicyInput(name: String(localized: "\(name) 策略"), decision: patch.decision, include: patch.include)
                 )
             }
+            let destinations = hostnames.map { AccessDestinationInput(type: "public", uri: $0) }
+                + preservedDestinations.compactMap { dest in
+                    dest.uri.map { AccessDestinationInput(type: dest.type ?? "private", uri: $0) }
+                }
             _ = try await service.updateAccessApp(
                 accountId: accountId, appId: appId,
-                body: AccessAppInput(name: name, domain: domain, type: "self_hosted", sessionDuration: sessionDuration, policies: policyIds)
+                body: AccessAppInput(
+                    name: name, domain: hostnames.first ?? "",
+                    destinations: destinations,
+                    type: "self_hosted", sessionDuration: sessionDuration, policies: policyIds
+                )
             )
             await load()
             didChange.toggle()

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Components/Daybreak.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Components/Daybreak.swift
@@ -172,9 +172,13 @@ struct HorizonArc: View {
 /// 岛屿按序浮现（开启「减弱动态效果」时直接显示）
 private struct IslandReveal: ViewModifier {
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.appReduceMotion) private var appReduceMotion
+    @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     let index: Int
     @State private var shown = false
+
+    /// App 开关 ∨ 系统「减弱动态效果」，任一开启即跳过浮现动画
+    private var reduceMotion: Bool { appReduceMotion || systemReduceMotion }
 
     func body(content: Content) -> some View {
         content

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Components/Skeleton.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Components/Skeleton.swift
@@ -13,8 +13,12 @@ import SwiftUI
 
 private struct SkeletonPulse: ViewModifier {
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.appReduceMotion) private var appReduceMotion
+    @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @State private var dimmed = false
+
+    /// App 开关 ∨ 系统「减弱动态效果」，任一开启即静止
+    private var reduceMotion: Bool { appReduceMotion || systemReduceMotion }
 
     func body(content: Content) -> some View {
         content

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/ZeroTrust/AccessAppEditorView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/ZeroTrust/AccessAppEditorView.swift
@@ -29,8 +29,15 @@ struct AccessAppEditorView: View {
         var value: String
     }
 
+    private struct HostnameRow: Identifiable {
+        let id = UUID()
+        var value: String
+    }
+
     @State private var name = ""
-    @State private var domain = ""
+    @State private var hostnames: [HostnameRow] = [HostnameRow(value: "")]
+    /// 原应用的非 public 目标（私有网络目标），编辑公共主机名时原样保留回写，避免误删
+    @State private var preservedDestinations: [AccessDestination] = []
     @State private var sessionDuration = AccessSessionDuration.h24.rawValue
     @State private var decision = AccessDecision.allow
     @State private var rules: [RuleRow] = [RuleRow(kind: .everyone, value: "")]
@@ -45,7 +52,13 @@ struct AccessAppEditorView: View {
     private var isCreate: Bool { mode == .create }
 
     private var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
-    private var trimmedDomain: String { domain.trimmingCharacters(in: .whitespacesAndNewlines) }
+    /// 去空白、去空值、保序去重后的全部公共主机名
+    private var trimmedHostnames: [String] {
+        var seen = Set<String>()
+        return hostnames
+            .map { $0.value.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
 
     /// 规则有效：所有人无需值；其余需非空值
     private var rulesValid: Bool {
@@ -55,7 +68,7 @@ struct AccessAppEditorView: View {
     private var canEditRules: Bool { isCreate || editablePolicyId != nil }
 
     private var canSave: Bool {
-        guard !trimmedName.isEmpty, !trimmedDomain.isEmpty, !viewModel.isSaving else { return false }
+        guard !trimmedName.isEmpty, !trimmedHostnames.isEmpty, !viewModel.isSaving else { return false }
         return canEditRules ? rulesValid : true
     }
 
@@ -98,13 +111,26 @@ struct AccessAppEditorView: View {
         Group {
             Section {
                 TextField("名称", text: $name).disabled(viewModel.isSaving)
-                TextField("应用域名（如 app.example.com）", text: $domain)
-                    .textInputAutocapitalization(.never).autocorrectionDisabled()
-                    .keyboardType(.URL).disabled(viewModel.isSaving)
             } header: {
                 Text("应用")
+            }
+            Section {
+                ForEach($hostnames) { $row in
+                    TextField("应用域名（如 app.example.com）", text: $row.value)
+                        .textInputAutocapitalization(.never).autocorrectionDisabled()
+                        .keyboardType(.URL).disabled(viewModel.isSaving)
+                }
+                .onDelete { hostnames.remove(atOffsets: $0) }
+                Button {
+                    hostnames.append(HostnameRow(value: ""))
+                } label: {
+                    Label("添加主机名", systemImage: "plus")
+                }
+                .disabled(viewModel.isSaving)
+            } header: {
+                Text("公共主机名")
             } footer: {
-                Text("自托管应用：Access 会保护该域名（及路径）。")
+                Text("自托管应用可保护多个公共主机名（及路径），第一个为主域名。左滑删除。")
             }
             Section {
                 Picker("会话时长", selection: $sessionDuration) {
@@ -177,7 +203,9 @@ struct AccessAppEditorView: View {
         defer { loadingDetail = false }
         guard let app = await viewModel.detail(appId: appId) else { prefilled = true; return }
         name = app.name ?? ""
-        domain = app.domain ?? ""
+        let hosts = app.publicHostnames
+        hostnames = hosts.isEmpty ? [HostnameRow(value: "")] : hosts.map { HostnameRow(value: $0) }
+        preservedDestinations = app.nonPublicDestinations
         if let sd = app.sessionDuration, !sd.isEmpty { sessionDuration = sd }
         policyIds = (app.policies ?? []).compactMap(\.id)
 
@@ -206,7 +234,7 @@ struct AccessAppEditorView: View {
         switch mode {
         case .create:
             ok = await viewModel.create(
-                name: trimmedName, domain: trimmedDomain,
+                name: trimmedName, hostnames: trimmedHostnames,
                 sessionDuration: sessionDuration, decision: decision.rawValue, include: buildInclude()
             )
         case .edit(let appId):
@@ -214,8 +242,9 @@ struct AccessAppEditorView: View {
                 editablePolicyId.map { ($0, decision.rawValue, buildInclude()) }
             ok = await viewModel.update(
                 appId: appId, policyIds: policyIds,
-                name: trimmedName, domain: trimmedDomain, sessionDuration: sessionDuration,
-                policyPatch: patch
+                name: trimmedName, hostnames: trimmedHostnames,
+                preservedDestinations: preservedDestinations,
+                sessionDuration: sessionDuration, policyPatch: patch
             )
         }
         if ok { onSuccess(); dismiss() }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/ZeroTrust/AccessAppsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/ZeroTrust/AccessAppsView.swift
@@ -56,7 +56,7 @@ struct AccessAppsView: View {
             Text("当前授权未包含 Access 写权限（access.write）。\n请在设置中退出登录后重新授权以启用此功能。")
         }
         .confirmationDialog(
-            deleteTarget.map { String(localized: "删除应用「\($0.name ?? $0.domain ?? "")」？") } ?? "",
+            deleteTarget.map { String(localized: "删除应用「\($0.name ?? $0.publicHostnames.first ?? "")」？") } ?? "",
             isPresented: Binding(get: { deleteTarget != nil }, set: { if !$0 { deleteTarget = nil } }),
             titleVisibility: .visible
         ) {
@@ -125,10 +125,13 @@ struct AccessAppsView: View {
         HStack(spacing: 12) {
             TintIcon(systemImage: "lock.shield", color: .ocOrange)
             VStack(alignment: .leading, spacing: 3) {
-                Text(app.name?.isEmpty == false ? app.name! : (app.domain ?? "—"))
+                Text(app.name?.isEmpty == false ? app.name! : (app.publicHostnames.first ?? "—"))
                     .font(.callout).foregroundStyle(.primary).lineLimit(1)
-                if let domain = app.domain, !domain.isEmpty {
-                    Text(domain).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                if let first = app.publicHostnames.first {
+                    // 多主机名时主机名后缀「+N」，提示这个应用绑了不止一个公共主机名
+                    let extra = app.publicHostnames.count - 1
+                    Text(extra > 0 ? "\(first) +\(extra)" : first)
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
                 }
             }
             Spacer(minLength: 8)

--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,5 +1,46 @@
 [
   {
+    "version": "1.8.1",
+    "date": "2026.06.30",
+    "channel": "App Store",
+    "inApp": false,
+    "items": [
+      {
+        "icon": "wrench.and.screwdriver.fill",
+        "title": {
+          "zh-Hans": "稳定性与体验修复",
+          "en": "Stability & experience fixes",
+          "zh-Hant": "穩定性與體驗修復",
+          "zh-HK": "穩定性與體驗修復",
+          "ja": "安定性と使い勝手の修正",
+          "es-MX": "Correcciones de estabilidad y experiencia",
+          "ko": "안정성 및 사용성 개선",
+          "pt-BR": "Correções de estabilidade e experiência",
+          "pt-PT": "Correções de estabilidade e experiência",
+          "de": "Stabilitäts- und Erlebnisverbesserungen",
+          "fr": "Corrections de stabilité et d’expérience",
+          "ar": "تحسينات الاستقرار والتجربة",
+          "tr": "Kararlılık ve deneyim düzeltmeleri"
+        },
+        "detail": {
+          "zh-Hans": "修复 Access 应用多个公共主机名只显示第一个、长时间使用后保持登录却刷新不出数据、重装后存储桶在「文件」App 重复挂载等问题，并优化「减少动画」开关与概览用量加载。",
+          "en": "Fixes an Access app showing only the first of multiple public hostnames, a rare “stays signed in but won’t refresh data” after long use, and duplicate R2 bucket mounts in Files after reinstalling; also improves the Reduce Animations toggle and Overview usage loading.",
+          "zh-Hant": "修復 Access 應用程式多個公開主機名稱只顯示第一個、長時間使用後保持登入卻無法重新整理資料、重新安裝後儲存桶在「檔案」App 重複掛載等問題，並優化「減少動畫」開關與總覽用量載入。",
+          "zh-HK": "修復 Access 應用程式多個公開主機名稱只顯示第一個、長時間使用後保持登入卻無法重新整理資料、重新安裝後儲存桶在「檔案」App 重複掛載等問題，並優化「減少動畫」開關與概覽用量載入。",
+          "ja": "Access の複数の公開ホスト名が最初の1つしか表示されない問題、長時間使用後にログイン状態のままデータを更新できない問題、再インストール後に「ファイル」で R2 バケットが重複マウントされる問題を修正し、「アニメーションを減らす」スイッチと概要の使用状況の読み込みを改善しました。",
+          "es-MX": "Corrige que una app de Access muestre solo el primero de varios nombres de host públicos, un raro “sesión iniciada pero sin actualizar datos” tras un uso prolongado y los montajes duplicados de buckets R2 en Archivos tras reinstalar; también mejora Reducir animaciones y la carga de uso en Resumen.",
+          "ko": "Access 앱에서 여러 공개 호스트 이름 중 첫 번째만 표시되던 문제, 장시간 사용 후 로그인 상태가 유지되지만 데이터가 새로 고쳐지지 않던 문제, 재설치 후 '파일'에서 R2 버킷이 중복 마운트되던 문제를 수정하고 '애니메이션 줄이기' 스위치와 개요 사용량 로딩을 개선했습니다.",
+          "pt-BR": "Corrige um app do Access que mostrava apenas o primeiro de vários nomes de host públicos, um raro “continua conectado mas não atualiza os dados” após uso prolongado e montagens duplicadas de buckets R2 em Arquivos após reinstalar; também melhora Reduzir animações e o carregamento de uso na Visão geral.",
+          "pt-PT": "Corrige uma app do Access que mostrava apenas o primeiro de vários nomes de anfitrião públicos, um raro “mantém a sessão iniciada mas não atualiza os dados” após uso prolongado e montagens duplicadas de buckets R2 em Ficheiros após reinstalar; também melhora Reduzir animações e o carregamento de utilização na Vista geral.",
+          "de": "Behebt, dass eine Access-App nur den ersten von mehreren öffentlichen Hostnamen anzeigte, ein seltenes „bleibt angemeldet, aktualisiert aber keine Daten“ nach langer Nutzung und doppelte R2-Bucket-Einbindungen in „Dateien“ nach einer Neuinstallation; verbessert außerdem „Animationen reduzieren“ und das Laden der Nutzung in der Übersicht.",
+          "fr": "Corrige une app Access n’affichant que le premier de plusieurs noms d’hôte publics, un rare « reste connecté mais n’actualise pas les données » après une utilisation prolongée et les montages en double de buckets R2 dans Fichiers après une réinstallation ; améliore aussi Réduire les animations et le chargement de l’utilisation dans l’aperçu.",
+          "ar": "يُصلح ظهور أول اسم فقط من بين عدة أسماء مضيفين عامة في تطبيق Access، ومشكلة نادرة وهي «يبقى تسجيل الدخول لكن لا تتحدّث البيانات» بعد الاستخدام الطويل، وتكرار تحميل حاويات R2 في «الملفات» بعد إعادة التثبيت؛ كما يحسّن مفتاح «تقليل الحركة» وتحميل الاستخدام في النظرة العامة.",
+          "tr": "Bir Access uygulamasının birden çok genel ana makine adından yalnızca ilkini göstermesini, uzun kullanımdan sonra nadiren görülen “oturum açık kalır ama veriler yenilenmez” sorununu ve yeniden yükleme sonrası Dosyalar’da yinelenen R2 paketi bağlamalarını giderir; ayrıca Animasyonları Azalt anahtarını ve Genel Bakış kullanım yüklemesini iyileştirir."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.8.0",
     "date": "2026.06.29",
     "channel": "App Store",


### PR DESCRIPTION
## Orange Cloud iOS 1.8.1（build 22）

修复一批用户反馈的问题，并完成发版 prep。

### 修复

| 问题 | 根因 | 修复 |
|---|---|---|
| **Access 多公共主机名只显示第一个** | 模型只解码单个 `domain`，多主机名实际在 `destinations`/`self_hosted_domains` | 读/显示/编辑/回写全部公共主机名；编辑器改多主机名列表 |
| **（连带）编辑保存删掉其余主机名** | PUT 全量替换只回写单个 `domain` | 回写 `destinations`（含全部公共主机名 + 保留私有目标） |
| **长时间使用后保持登录却刷不出数据** | 主 App 与「文件」扩展两进程并发刷新同一轮转 refresh token → CF 复用检测吊销令牌链（非 400，旧逻辑只在 400 登出 → 卡死） | 跨进程 `fcntl` 刷新锁串行化 + 登出判定放宽到 token 端点 4xx + 轮换自愈 |
| **重装后「文件」App 存储桶重复挂载、删不掉** | domain identifier 含易变 `sessionId`，旧 domain 成孤儿、每重装多一个 | 挂载同桶去重 + 启动 reconcile 清非存活身份 domain |
| **「减少动画」开关无效** | 只接全局 `.transaction`，盖不住 Zoom 转场与浮现 | 根视图注入 `appReduceMotion`，统一驱动转场/浮现/骨架 |
| **概览用量每次切回空白重载** | `usage` 只在内存，VM 重建即丢 | 按账号落盘缓存，先显示上次数据再后台静默刷新 |

### 发版 prep
- 版本号 **1.8.1 / build 22**，pbxproj 12 处全同步（无 must-match 警告）。
- changelog 加 1.8.1：**静默**（`inApp:false`，仅进官网历史，App 内不弹窗），13 语；`changelog:gen` + `check` 绿，in-app 生成物未变。
- 新增 2 条 Access 文案 × 12 语本地化（`公共主机名` 复用既有翻译）。

### 验证
- ✅ Xcode-beta 全 target `BUILD SUCCEEDED`，0 error。
- ⚠️ 真机/账号相关未跑（环境无 CF 账号/真机）。**Access 那条建议真机复验**：绑 3 个公共主机名的自托管应用 → 三个都显示、编辑保存后网页端三个仍在。

### 说明
- 本 PR **只含 iOS + changelog**；工作区里的 `apps/web`（hicyou 徽章 / blog 目录）是并行改动，已**有意排除**。
- 二进制 archive / TestFlight 上传 / ASC release notes / 送审仍需手动。
