### PR TITLE
release(ios): 1.8.2 (23) — iOS 17.0 概览页闪退根治 / 滑动掉帧 / 授权失效重授权引导

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -653,7 +653,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -673,7 +673,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -685,7 +685,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -706,7 +706,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -717,7 +717,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -740,7 +740,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -751,7 +751,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -774,7 +774,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -786,7 +786,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -808,7 +808,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -820,7 +820,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -840,7 +840,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -852,7 +852,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -870,7 +870,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -882,7 +882,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -900,7 +900,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -912,7 +912,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -930,7 +930,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -942,7 +942,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -963,7 +963,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -982,7 +982,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1006,7 +1006,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1025,7 +1025,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/AuthManager.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/AuthManager.swift
@@ -51,6 +51,11 @@ final class AuthManager {
     var isLoading = false
     var errorMessage: String?
 
+    /// 存储的 token 缺少 refresh token 的身份（token 端点当次未发 refresh_token，
+    /// access token 到期后无从续期）。UI 据此把泛化的「刷新失败」升级为「重新授权」引导；
+    /// 重新授权拿到带 refresh token 的新令牌后自动摘除。
+    private(set) var sessionsNeedingReauth: Set<UUID> = []
+
     var isLoggedIn: Bool { currentSessionId != nil }
 
     var currentSession: AuthSessionMeta? {
@@ -96,6 +101,14 @@ final class AuthManager {
         // 看 workers-observability.read 等是否真在 token 里）。重启即可见，无需重新登录。
         if let current = currentSession {
             AppLog.auth.info("active session scopes (\(current.scopes.count))=[\(current.scopes.joined(separator: " "))]")
+        }
+        // 启动即标记「缺 refresh token」的身份（不等到 access token 过期刷新失败才发现），
+        // Dashboard 能在第一时间给出「重新授权」引导而非泛化的刷新失败。
+        for meta in sessions {
+            if let token = TokenStore.load(sessionId: meta.id), token.refreshToken == nil {
+                sessionsNeedingReauth.insert(meta.id)
+                AppLog.auth.error("stored token has no refresh token at launch. session=\(meta.id.uuidString)")
+            }
         }
         // 自愈：清掉 App Group 里已不再登录的身份残留的 Widget 数据（历史登出未清等）
         WidgetDataStore.reconcile(liveSessionIds: Set(sessions.map { $0.id.uuidString }))
@@ -188,6 +201,7 @@ final class AuthManager {
             let id = UUID()
             TokenStore.save(token, sessionId: id)
             AuthDiagnostics.recordWrite(refreshToken: token.refreshToken, sessionId: id)
+            noteRefreshTokenPresence(token, sessionId: id, phase: "login")
             let scopes = token.scope.components(separatedBy: " ").filter { !$0.isEmpty }.sorted()
             AppLog.auth.info("login stored session=\(id.uuidString) granted scopes=[\(scopes.joined(separator: " "))]")
             let label = await fetchIdentityLabel(accessToken: token.accessToken)
@@ -232,6 +246,7 @@ final class AuthManager {
 
             TokenStore.save(token, sessionId: sessionId)
             AuthDiagnostics.recordWrite(refreshToken: token.refreshToken, sessionId: sessionId)
+            noteRefreshTokenPresence(token, sessionId: sessionId, phase: "reauthorize")
             let granted = token.scope.components(separatedBy: " ").filter { !$0.isEmpty }.sorted()
             AppLog.auth.info("reauthorize stored session=\(sessionId.uuidString) granted scopes=[\(granted.joined(separator: " "))]")
             sessions[index].scopes = granted
@@ -409,8 +424,9 @@ final class AuthManager {
             throw AuthError.notLoggedIn
         }
         guard let refreshToken = stored.refreshToken else {
-            // 无刷新令牌则无从续期。同样保留身份，交由用户在账号切换器里手动重新授权，
-            // 不删身份，避免一次 401 把会话连锁清空。
+            // 无刷新令牌则无从续期。同样保留身份，标记「需重新授权」（Dashboard 出引导横幅，
+            // 一键重授权同 UUID 原地换新令牌），不删身份，避免一次 401 把会话连锁清空。
+            sessionsNeedingReauth.insert(sessionId)
             AppLog.auth.error("stored token has no refresh token (session kept). session=\(sessionId.uuidString)")
             throw AuthError.notLoggedIn
         }
@@ -458,6 +474,7 @@ final class AuthManager {
         )
         TokenStore.save(newToken, sessionId: sessionId)
         AuthDiagnostics.recordWrite(refreshToken: newToken.refreshToken, sessionId: sessionId)
+        sessionsNeedingReauth.remove(sessionId)   // 能刷新成功即链路健康，摘除陈旧标记
         AppLog.auth.info("refresh ok session=\(sessionId.uuidString) newRefreshFP=\(AuthDiagnostics.fingerprint(newToken.refreshToken))")
         return newToken.accessToken
     }
@@ -501,9 +518,21 @@ final class AuthManager {
         removeSession(sessionId)
     }
 
+    /// 记录本次交换是否带回 refresh token：缺失时标记该身份「需重新授权」并留证据日志
+    /// （granted scope 一并记录，便于核对 OAuth client 配置）；带回则摘除标记。
+    private func noteRefreshTokenPresence(_ token: TokenStore.StoredToken, sessionId: UUID, phase: String) {
+        if token.refreshToken == nil {
+            sessionsNeedingReauth.insert(sessionId)
+            AppLog.auth.error("token exchange returned NO refresh_token (\(phase)). session=\(sessionId.uuidString) scope=[\(token.scope)] — access token 到期后将无法续期，请核对 OAuth client 配置")
+        } else {
+            sessionsNeedingReauth.remove(sessionId)
+        }
+    }
+
     private func removeSession(_ id: UUID) {
         TokenStore.clear(sessionId: id)
         AuthDiagnostics.clearBaseline(id)
+        sessionsNeedingReauth.remove(id)
         sessions.removeAll { $0.id == id }
         AppLog.auth.notice("session removed=\(id.uuidString) remaining=\(sessions.count)")
         if currentSessionId == id {

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/TokenStore.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/TokenStore.swift
@@ -66,11 +66,18 @@ nonisolated enum TokenStore {
         query[kSecAttrSynchronizable as String] = false
         // 写入共享组让 Widget 可读；entitlement 缺失时回退默认组，保证 token 不丢
         query[kSecAttrAccessGroup as String] = sharedAccessGroup
-        if SecItemAdd(query as CFDictionary, nil) == errSecSuccess {
+        let sharedStatus = SecItemAdd(query as CFDictionary, nil)
+        if sharedStatus == errSecSuccess {
             return true
         }
         query.removeValue(forKey: kSecAttrAccessGroup as String)
-        return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+        let fallbackStatus = SecItemAdd(query as CFDictionary, nil)
+        if fallbackStatus != errSecSuccess {
+            // 两次写入都失败 = token 已被上面的 SecItemDelete 清掉、新值又没写进去，
+            // 下次读取必是 "token missing"。这里必须留痕，否则表象与静默丢 token 无法区分。
+            AppLog.auth.error("keychain token save FAILED account=\(account) sharedStatus=\(sharedStatus) fallbackStatus=\(fallbackStatus)")
+        }
+        return fallbackStatus == errSecSuccess
     }
 
     private static func load(account: String) -> StoredToken? {

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/MockCloudflare.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/MockCloudflare.swift
@@ -1,0 +1,147 @@
+//
+//  MockCloudflare.swift
+//  Orange Cloud
+//
+//  诊断专用 mock（仅 DEBUG 构建 + 启动环境变量 ORANGE_MOCK=1 时生效）：
+//  拦截 api.cloudflare.com 请求返回 canned 数据，让模拟器无需 OAuth 即可把
+//  Dashboard / Zones 驱动到「有账号有数据」状态，用于复现线上 iOS 17.0 崩溃。
+//  Release 构建不包含本文件逻辑；平时 DEBUG 运行不带环境变量也完全不生效。
+//
+
+#if DEBUG
+import Foundation
+
+nonisolated enum MockCloudflare {
+
+    static var isRequested: Bool {
+        ProcessInfo.processInfo.environment["ORANGE_MOCK"] == "1"
+    }
+
+    /// App 启动最早处调用：注册 URL 拦截 + 给身份索引里的身份塞假 token（绕过 OAuth）
+    static func activateIfRequested() {
+        guard isRequested else { return }
+        URLProtocol.registerClass(MockCFURLProtocol.self)
+        if let data = UserDefaults.standard.data(forKey: "authSessions"),
+           let list = try? JSONDecoder().decode([AuthSessionMeta].self, from: data) {
+            // 默认带假 refresh token（健康态）；ORANGE_MOCK_NO_REFRESH=1 时存无 refresh token 的
+            // 残缺 token，复现「登录授权已失效」重授权横幅（真实事故形态，见 AuthManager 注释）。
+            // expiresAt 远未来 → 永不触发真实刷新，假 refresh token 不会打到真 token 端点。
+            let noRefresh = ProcessInfo.processInfo.environment["ORANGE_MOCK_NO_REFRESH"] == "1"
+            for meta in list {
+                TokenStore.save(
+                    TokenStore.StoredToken(
+                        accessToken: "mock-token",
+                        refreshToken: noRefresh ? nil : "mock-refresh-token",
+                        expiresAt: .distantFuture,
+                        scope: meta.scopes.joined(separator: " ")
+                    ),
+                    sessionId: meta.id
+                )
+            }
+        }
+    }
+}
+
+/// 拦截发往 api.cloudflare.com 的请求，按路径返回 canned JSON
+nonisolated final class MockCFURLProtocol: URLProtocol {
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "api.cloudflare.com"
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        let body = Self.readBody(of: request)
+        let json = Self.responseJSON(path: path, body: body)
+        let data = Data(json.utf8)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    // MARK: - 路由
+
+    private static func responseJSON(path: String, body: String) -> String {
+        if path == "/client/v4/graphql" {
+            if body.contains("zoneTag_in") {
+                return trafficJSON()
+            }
+            // 账户级数据集 → 模拟免费账号 authz（Dashboard 用量区走「无权限」卡片）
+            return #"{"data":null,"errors":[{"message":"not authorized for that account","path":[],"extensions":{"code":"authz"}}]}"#
+        }
+        if path == "/client/v4/accounts" {
+            return envelope(#"[{"id":"mockacct","name":"Mock Account","type":"standard"},{"id":"mockacct2","name":"Second Account","type":"standard"}]"#, total: 2)
+        }
+        if path == "/client/v4/zones" {
+            return envelope(#"""
+            [
+             {"id":"z1","name":"example.com","status":"active","plan":{"name":"Free Website"},"name_servers":["a.ns.cloudflare.com","b.ns.cloudflare.com"]},
+             {"id":"z2","name":"orange-cloud.dev","status":"active","plan":{"name":"Pro Website"},"name_servers":["a.ns.cloudflare.com","b.ns.cloudflare.com"]},
+             {"id":"z3","name":"pending-site.io","status":"pending","plan":{"name":"Free Website"},"name_servers":["a.ns.cloudflare.com","b.ns.cloudflare.com"]}
+            ]
+            """#, total: 3)
+        }
+        if path.hasSuffix("/dns_records") {
+            return envelope("[]", total: 12)
+        }
+        if path.hasSuffix("/workers/scripts") {
+            return envelope(#"[{"id":"api-worker","handlers":["fetch"],"logpush":false},{"id":"cron-worker","handlers":["scheduled"],"logpush":false}]"#, total: 2)
+        }
+        // 其余端点：空数组成功信封（调用方多为 try? 包裹，可优雅降级）
+        return envelope("[]", total: 0)
+    }
+
+    private static func envelope(_ result: String, total: Int) -> String {
+        #"{"success":true,"errors":[],"messages":[],"result":\#(result),"result_info":{"page":1,"per_page":50,"count":\#(total),"total_count":\#(total),"total_pages":1}}"#
+    }
+
+    /// 三个 zone 各 24 个小时桶（datetime ISO8601），previous 窗口一条
+    private static func trafficJSON() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let now = Date()
+        func groups(scale: Int) -> String {
+            (0..<24).map { i -> String in
+                let dt = formatter.string(from: now.addingTimeInterval(TimeInterval(-3600 * (24 - i))))
+                let requests = (300 + (i * 37) % 900) * scale
+                return #"{"dimensions":{"datetime":"\#(dt)"},"sum":{"requests":\#(requests),"bytes":\#(requests * 2048),"threats":\#(i % 5),"pageViews":\#(requests / 2),"cachedRequests":\#(requests / 3),"cachedBytes":\#(requests * 1024)},"uniq":{"uniques":\#(requests / 10)}}"#
+            }.joined(separator: ",")
+        }
+        func node(_ tag: String, scale: Int) -> String {
+            #"{"zoneTag":"\#(tag)","httpRequests1hGroups":[\#(groups(scale: scale))],"previous":[{"sum":{"requests":\#(9000 * scale)}}]}"#
+        }
+        return #"{"data":{"viewer":{"zones":[\#(node("z1", scale: 1)),\#(node("z2", scale: 3)),\#(node("z3", scale: 0))]}},"errors":null}"#
+    }
+
+    private static func readBody(of request: URLRequest) -> String {
+        if let data = request.httpBody {
+            return String(decoding: data, as: UTF8.self)
+        }
+        guard let stream = request.httpBodyStream else { return "" }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 16 * 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            guard read > 0 else { break }
+            data.append(buffer, count: read)
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+#endif

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -106687,6 +106687,82 @@
         }
       }
     },
+    "登录授权已失效，无法自动续期" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتهت صلاحية تفويض تسجيل الدخول ولا يمكن تجديده تلقائيًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Anmeldeautorisierung ist abgelaufen und kann nicht automatisch erneuert werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign-in authorization has expired and can’t be renewed automatically"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autorización de inicio de sesión expiró y no se puede renovar automáticamente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’autorisation de connexion a expiré et ne peut pas être renouvelée automatiquement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン認証の有効期限が切れ、自動更新できません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로그인 인증이 만료되어 자동 갱신할 수 없습니다"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização de login expirou e não pode ser renovada automaticamente"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização de sessão expirou e não pode ser renovada automaticamente"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oturum açma yetkisi süresi doldu ve otomatik olarak yenilenemiyor"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入授權已失效，無法自動續期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入授權已失效，無法自動續期"
+          }
+        }
+      }
+    },
     "监控中" : {
       "localizations" : {
         "ar" : {

--- a/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
@@ -27,6 +27,9 @@ struct Orange_CloudApp: App {
         // 最先安装崩溃捕获，让启动期任意一步崩溃都能被记录、随下次反馈带出。
         CrashReporter.install()
         CrashReporter.recordBreadcrumb("AppStart begin")
+        #if DEBUG
+        MockCloudflare.activateIfRequested()   // 诊断 mock：仅 ORANGE_MOCK=1 时生效
+        #endif
         let manager = AuthManager()
         _authManager = State(initialValue: manager)
         CrashReporter.recordBreadcrumb("AppStart auth manager created")

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Components/Daybreak.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Components/Daybreak.swift
@@ -62,7 +62,20 @@ struct SkyBackground: View {
 
 // MARK: - 玻璃岛
 
-/// 「晨昏」的内容容器：材质拾取天色 + 顶亮底暗的折射描边 + 软投影。
+/// 玻璃底色：视觉上等效 `.regularMaterial` 的半透明纯色（按主题实测校准，误差 ≤3/255）。
+/// **不要改回真材质**：天空是平滑渐变，实时背景模糊对它的观感增益≈0，但每个岛/行
+/// 都会各挂一个逐帧 backdrop blur 节点——列表滚动时几十个节点同时重采样，
+/// 是 iPhone 12–14 级设备整页掉帧的主因（且与动画无关，「减少动画」开关救不了）。
+/// 半透明纯色同样透出天色随高度的渐变变化，静态内容可被整层缓存，滚动零逐帧成本。
+nonisolated enum OCGlass {
+    static func fill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 0.170, green: 0.163, blue: 0.157).opacity(0.85)
+            : Color.white.opacity(0.55)
+    }
+}
+
+/// 「晨昏」的内容容器：玻璃底透出天色 + 顶亮底暗的折射描边 + 软投影。
 private struct GlassIsland: ViewModifier {
 
     @Environment(\.colorScheme) private var colorScheme
@@ -70,7 +83,7 @@ private struct GlassIsland: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .background(.regularMaterial, in: .rect(cornerRadius: cornerRadius))
+            .background(OCGlass.fill(for: colorScheme), in: .rect(cornerRadius: cornerRadius))
             .overlay {
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .strokeBorder(
@@ -210,9 +223,20 @@ extension View {
             .background { SkyBackground() }
     }
 
-    /// List 行 / Section 的玻璃底（系统按 insetGrouped 分组形状自动裁切圆角）
+    /// List 行 / Section 的玻璃底（系统按 insetGrouped 分组形状自动裁切圆角）。
+    /// 用 OCGlass 纯色而非真材质：每行一个 backdrop blur 是列表掉帧主因，见 OCGlass 注释。
     func glassRow() -> some View {
-        listRowBackground(Rectangle().fill(.regularMaterial))
+        modifier(GlassRowBackground())
+    }
+}
+
+/// glassRow 的实现载体（listRowBackground 的取色需要读 colorScheme 环境）
+private struct GlassRowBackground: ViewModifier {
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.listRowBackground(Rectangle().fill(OCGlass.fill(for: colorScheme)))
     }
 }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -10,7 +10,32 @@ import SwiftData
 import TipKit
 import WidgetKit
 
+/// 概览页外壳：NavigationStack 常驻，账号切换只重建栈内内容。
+///
+/// **不要把 `.id(账号)` 加回 NavigationStack 外层**（也别在 MainTabView 的 tab 上加）：
+/// 重建整个 NavigationStack 会连正在显示的导航栏一起换掉，iOS 17.0.x 的 UIKit 在
+/// `-[UINavigationBar layoutSubviews]` 对此硬断言（"top item belongs to a different
+/// navigation bar"）——冷启动账号加载完成时 id 从 nil 翻转，概览页必崩（17.1 起系统才修复）。
+/// 1.5.1 曾误诊为 TipKit popover。账号维度的 @Query 谓词刷新由栈内的 `.id` 完成。
 struct DashboardView: View {
+
+    private let session: SessionStore
+
+    init(session: SessionStore) {
+        self.session = session
+    }
+
+    var body: some View {
+        NavigationStack {
+            DashboardHomeView(session: session)
+                .id(session.selectedAccount?.id)
+        }
+    }
+}
+
+/// 概览页内容（原 DashboardView 本体）：@Query 谓词在 init 按当前账号构建，
+/// 外壳用 `.id(selectedAccount)` 在账号切换时重建本视图以刷新谓词。
+private struct DashboardHomeView: View {
 
     @Environment(SessionStore.self) private var session
     @Environment(AuthManager.self) private var auth
@@ -111,68 +136,91 @@ struct DashboardView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    daybreakHeader
-                        .islandReveal(0)
-                    if session.error != nil || viewModel.loadFailed {
-                        RefreshFailedBanner { Task { await refreshAll() } }
-                    }
-                    Group {
-                        if cachedZones.isEmpty && viewModel.isLoadingAssets {
-                            statSkeleton
-                        } else {
-                            statIslands
-                        }
-                    }
-                    .islandReveal(1)
-                    usageSection
-                        .islandReveal(2)
-                    zonesSection
-                        .islandReveal(3)
-                    networkSection
-                        .islandReveal(4)
-                    bulkRedirectsSection
-                        .islandReveal(5)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                daybreakHeader
+                    .islandReveal(0)
+                if let sid = auth.currentSessionId, auth.sessionsNeedingReauth.contains(sid) {
+                    // token 缺 refresh token（无从续期）：给「重新授权」引导而非泛化的刷新失败——
+                    // 一键重授权对同一身份原地换新令牌，成功后自动摘标并重拉数据
+                    reauthBanner(sessionId: sid)
+                } else if session.error != nil || viewModel.loadFailed {
+                    RefreshFailedBanner { Task { await refreshAll() } }
                 }
-                .padding(OCLayout.pagePadding)
-            }
-            .background { SkyBackground() }
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationDestination(for: CachedZone.self) { zone in
-                ZoneDetailView(zone: zone, session: session)
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    accountMenu
+                Group {
+                    if cachedZones.isEmpty && viewModel.isLoadingAssets {
+                        statSkeleton
+                    } else {
+                        statIslands
+                    }
                 }
+                .islandReveal(1)
+                usageSection
+                    .islandReveal(2)
+                zonesSection
+                    .islandReveal(3)
+                networkSection
+                    .islandReveal(4)
+                bulkRedirectsSection
+                    .islandReveal(5)
             }
-            .task(id: session.accounts.count) {
-                AccountSwitchTip.hasMultipleAccounts = session.accounts.count > 1 || auth.sessions.count > 1
-            }
-            .task(id: displayZones.map(\.id)) {
-                await loadTraffic()
-            }
-            .task(id: session.selectedAccount?.id) {
-                await loadAssets()
-            }
-            .task(id: session.selectedAccount?.id) {
-                await loadUsage()
-            }
-            .onChange(of: accountPrefs.billingCycleDay) {
-                Task { await loadUsage(force: true) }
-            }
-            .onChange(of: dayBoundaryRaw) {
-                Task { await loadUsage(force: true) }
-            }
-            .refreshable {
-                await refreshAll()
-            }
-            .sheet(item: $usageDetail) { service in
-                usageDetailSheet(service)
+            .padding(OCLayout.pagePadding)
+        }
+        .background { SkyBackground() }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(for: CachedZone.self) { zone in
+            ZoneDetailView(zone: zone, session: session)
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                accountMenu
             }
         }
+        .task(id: session.accounts.count) {
+            AccountSwitchTip.hasMultipleAccounts = session.accounts.count > 1 || auth.sessions.count > 1
+        }
+        .task(id: displayZones.map(\.id)) {
+            await loadTraffic()
+        }
+        .task(id: session.selectedAccount?.id) {
+            await loadAssets()
+        }
+        .task(id: session.selectedAccount?.id) {
+            await loadUsage()
+        }
+        .onChange(of: accountPrefs.billingCycleDay) {
+            Task { await loadUsage(force: true) }
+        }
+        .onChange(of: dayBoundaryRaw) {
+            Task { await loadUsage(force: true) }
+        }
+        .onChange(of: auth.sessionsNeedingReauth) { old, new in
+            // 重新授权成功（当前身份的「需重授权」标记被摘除）→ 立刻重拉全部数据
+            if let sid = auth.currentSessionId, old.contains(sid), !new.contains(sid) {
+                Task { await refreshAll() }
+            }
+        }
+        .refreshable {
+            await refreshAll()
+        }
+        .sheet(item: $usageDetail) { service in
+            usageDetailSheet(service)
+        }
+    }
+
+    /// 「需重新授权」引导：说明 + 一键重授权（同身份原地换令牌），成功摘标后自动重拉
+    private func reauthBanner(sessionId: UUID) -> some View {
+        VStack(spacing: 10) {
+            Label("登录授权已失效，无法自动续期", systemImage: "key.slash")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.red)
+            ReauthorizeButton(sessionId: sessionId, scopes: [])
+                .font(.subheadline.weight(.semibold))
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .glassIsland(cornerRadius: OCLayout.chipRadius)
     }
 
     /// 下拉刷新 / 顶部失败提示重试：强制重拉账号、资产、流量、用量

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Main/MainTabView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Main/MainTabView.swift
@@ -76,8 +76,9 @@ struct MainTabView: View {
     // 让按账号过滤的 @Query 谓词刷新、列表数据重新拉取（资源跟着选中账号走）。
 
     @ViewBuilder private var dashboardTab: some View {
+        // 账号维度的重建（.id）在 DashboardView 内部、NavigationStack 之内完成——
+        // 在这里加 .id 会把可见导航栏连栈一起重建，iOS 17.0.x 必崩（详见 DashboardView 注释）。
         DashboardView(session: session)
-            .id(session.selectedAccount?.id)
     }
 
     @ViewBuilder private var zonesTab: some View {

--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,5 +1,79 @@
 [
   {
+    "version": "1.8.2",
+    "date": "2026.07.02",
+    "channel": "App Store",
+    "inApp": false,
+    "items": [
+      {
+        "icon": "wrench.and.screwdriver.fill",
+        "title": {
+          "zh-Hans": "稳定性修复",
+          "en": "Stability fixes",
+          "zh-Hant": "穩定性修復",
+          "zh-HK": "穩定性修復",
+          "ja": "安定性の修正",
+          "es-MX": "Correcciones de estabilidad",
+          "ko": "안정성 수정",
+          "pt-BR": "Correções de estabilidade",
+          "pt-PT": "Correções de estabilidade",
+          "de": "Stabilitätskorrekturen",
+          "fr": "Corrections de stabilité",
+          "ar": "إصلاحات الاستقرار",
+          "tr": "Kararlılık düzeltmeleri"
+        },
+        "detail": {
+          "zh-Hans": "修复 iOS 17.0 上打开概览页闪退的问题；登录授权失效无法自动续期时，概览页现在会给出「一键重新授权」引导，不再反复提示刷新失败。",
+          "en": "Fixes a crash when opening Overview on iOS 17.0. When sign-in authorization can no longer be renewed automatically, Overview now offers one-tap re-authorization instead of repeated refresh failures.",
+          "zh-Hant": "修復在 iOS 17.0 上開啟總覽頁閃退的問題；登入授權失效無法自動續期時，總覽頁現在會提供「一鍵重新授權」引導，不再反覆提示重新整理失敗。",
+          "zh-HK": "修復在 iOS 17.0 上開啟概覽頁閃退的問題；登入授權失效無法自動續期時，概覽頁現在會提供「一鍵重新授權」引導，不再反覆提示重新整理失敗。",
+          "ja": "iOS 17.0 で概要ページを開くとクラッシュする問題を修正しました。ログイン認証を自動更新できない場合は、概要ページにワンタップ再認証の案内を表示し、更新失敗の繰り返しをなくしました。",
+          "es-MX": "Corrige un cierre inesperado al abrir Resumen en iOS 17.0. Cuando la autorización de inicio de sesión ya no puede renovarse automáticamente, Resumen ahora ofrece reautorizar con un toque en lugar de fallas de actualización repetidas.",
+          "ko": "iOS 17.0에서 개요 페이지를 열 때 앱이 종료되는 문제를 수정했습니다. 로그인 인증을 자동 갱신할 수 없을 때는 개요 페이지에서 원탭 재인증 안내를 제공하여 새로 고침 실패가 반복되지 않습니다.",
+          "pt-BR": "Corrige uma falha ao abrir a Visão geral no iOS 17.0. Quando a autorização de login não puder mais ser renovada automaticamente, a Visão geral agora oferece reautorização com um toque em vez de falhas repetidas de atualização.",
+          "pt-PT": "Corrige uma falha ao abrir a Vista geral no iOS 17.0. Quando a autorização de sessão já não puder ser renovada automaticamente, a Vista geral passa a oferecer reautorização com um toque em vez de falhas repetidas de atualização.",
+          "de": "Behebt einen Absturz beim Öffnen der Übersicht unter iOS 17.0. Kann die Anmeldeautorisierung nicht mehr automatisch erneuert werden, bietet die Übersicht jetzt eine Neuautorisierung mit einem Tipp statt wiederholter Aktualisierungsfehler.",
+          "fr": "Corrige un plantage à l’ouverture de l’aperçu sous iOS 17.0. Lorsque l’autorisation de connexion ne peut plus être renouvelée automatiquement, l’aperçu propose désormais une réautorisation en un geste au lieu d’échecs d’actualisation répétés.",
+          "ar": "يصلح انهيارًا عند فتح صفحة النظرة العامة على iOS 17.0. وعندما يتعذر تجديد تفويض تسجيل الدخول تلقائيًا، تعرض النظرة العامة الآن إرشادًا لإعادة التفويض بنقرة واحدة بدلًا من تكرار فشل التحديث.",
+          "tr": "iOS 17.0'da Genel Bakış sayfası açılırken oluşan çökmeyi düzeltir. Oturum açma yetkisi otomatik olarak yenilenemediğinde Genel Bakış artık tekrarlanan yenileme hataları yerine tek dokunuşla yeniden yetkilendirme sunar."
+        }
+      },
+      {
+        "icon": "speedometer",
+        "title": {
+          "zh-Hans": "滑动更流畅",
+          "en": "Smoother scrolling",
+          "zh-Hant": "捲動更流暢",
+          "zh-HK": "滑動更流暢",
+          "ja": "スクロールがより滑らかに",
+          "es-MX": "Desplazamiento más fluido",
+          "ko": "더 부드러운 스크롤",
+          "pt-BR": "Rolagem mais fluida",
+          "pt-PT": "Deslocação mais fluida",
+          "de": "Flüssigeres Scrollen",
+          "fr": "Défilement plus fluide",
+          "ar": "تمرير أكثر سلاسة",
+          "tr": "Daha akıcı kaydırma"
+        },
+        "detail": {
+          "zh-Hans": "重做玻璃卡片的渲染方式：观感不变，滚动开销大幅下降，列表与概览页滑动明显更顺滑，旧机型尤其受益。",
+          "en": "Glass cards are rendered with far less overhead while looking identical — lists and Overview scroll noticeably smoother, especially on older devices.",
+          "zh-Hant": "重做玻璃卡片的算繪方式：觀感不變、捲動負擔大幅下降，清單與總覽頁捲動明顯更順暢，舊機型尤其受益。",
+          "zh-HK": "重做玻璃卡片的渲染方式：觀感不變、滑動負擔大幅下降，列表與概覽頁滑動明顯更順暢，舊機型尤其受益。",
+          "ja": "ガラスカードの描画方式を見直しました。見た目はそのままにスクロール時の負荷を大幅に削減し、リストや概要ページのスクロールが特に旧機種で滑らかになりました。",
+          "es-MX": "Las tarjetas de vidrio ahora se dibujan con mucho menos costo manteniendo el mismo aspecto: las listas y Resumen se desplazan con notable mayor fluidez, sobre todo en equipos antiguos.",
+          "ko": "글래스 카드 렌더링을 개선했습니다. 보이는 모습은 그대로 유지하면서 스크롤 부하를 크게 줄여, 목록과 개요 페이지가 특히 구형 기기에서 눈에 띄게 부드러워졌습니다.",
+          "pt-BR": "Os cartões de vidro agora são renderizados com muito menos custo, mantendo o mesmo visual — as listas e a Visão geral rolam visivelmente mais suave, principalmente em aparelhos antigos.",
+          "pt-PT": "Os cartões de vidro passam a ser renderizados com muito menos custo, mantendo o mesmo aspeto — as listas e a Vista geral deslizam visivelmente melhor, sobretudo em dispositivos antigos.",
+          "de": "Glaskarten werden bei gleichem Aussehen deutlich günstiger gerendert – Listen und die Übersicht scrollen spürbar flüssiger, besonders auf älteren Geräten.",
+          "fr": "Les cartes en verre sont rendues avec beaucoup moins de coût tout en gardant le même aspect — les listes et l’aperçu défilent nettement plus fluidement, surtout sur les appareils anciens.",
+          "ar": "أصبحت البطاقات الزجاجية تُرسم بكلفة أقل بكثير مع الحفاظ على المظهر نفسه — تمرير القوائم وصفحة النظرة العامة أصبح أكثر سلاسة، خصوصًا على الأجهزة الأقدم.",
+          "tr": "Cam kartlar aynı görünümü koruyarak çok daha düşük maliyetle çiziliyor — listeler ve Genel Bakış, özellikle eski cihazlarda belirgin şekilde daha akıcı kayıyor."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.8.1",
     "date": "2026.06.30",
     "channel": "App Store",


### PR DESCRIPTION
## 1.8.2 (build 23)

### 修复
- **iOS 17.0 概览页闪退（根治）**：`.id(账号)` 包住整个 NavigationStack，账号加载完成 id 翻转时连可见导航栏一起重建，iOS 17.0.x UIKit 在 `-[UINavigationBar layoutSubviews]` 硬断言（17.1 起系统修复）。1.5.1 的 TipKit 修复系误诊（ASC 15 条 TestFlight 崩溃日志坐实，1.5.1 修复版仍有同栈崩溃）。现 NavigationStack 壳常驻、`.id` 挪到栈内。17.0 模拟器原 2 秒必崩 → 现稳定存活；iOS 26.5 无回归。
- **滑动掉帧**：每个玻璃岛/行一个 `.regularMaterial` 逐帧 backdrop blur（44 页），是滚动掉帧主因（与动画无关）。改用像素校准半透明纯色 OCGlass（与材质差 ≤3/255，观感不变），滚动零逐帧成本。真机帧率待实测确认。
- **登录授权失效卡死**（token 无 refresh token，端点当次未发）：过期后永久 401、首页「未选择账号」。现三处收口 `sessionsNeedingReauth`，概览页出「登录授权已失效」+ 一键重新授权横幅（同 UUID 原地换 token），新文案 13 语；交换期缺 refresh_token 打证据日志。TokenStore Keychain 写入失败不再静默。

### 工具
- `MockCloudflare`：DEBUG + `ORANGE_MOCK=1` 环境变量门控（Release 不含），模拟器免 OAuth 复现登录态；`ORANGE_MOCK_NO_REFRESH=1` 复现无 refresh token 坏态。

### 发版
- 版本号 1.8.2 / build 23（12 处全同步），`xcodebuild` 编译通过、无版本不匹配警告
- changelog 1.8.2（inApp:false，仅官网历史），`pnpm changelog:gen` + `check` 通过

### 待办（合并后）
- Archive → 上传 → ASC 送审
- 真机验证：17.0 概览页不再闪退；受影响用户可回访（ihaoljy@gmail.com）
- 重登一次看 `token exchange returned NO refresh_token` 日志是否出现——坐实则查 OAuth client 配置（6-29 轮换嫌疑）；Android 同洞（无 refresh token 直接登出）另行处理