### PR TITLE
feat(ios): 1.9.0 — Pages 自定义域名 + 列表排序 + 数据单位固定国际符号

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/ZoneDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud Watch Watch App/ZoneDetailView.swift
@@ -63,7 +63,7 @@ struct ZoneDetailView: View {
             MetricTile(title: String(localized: "命中率"), value: current.cacheHitRate.map { "\(Int($0))%" } ?? "—")
             MetricTile(title: String(localized: "威胁"),   value: current.threats.watchCompact)
             MetricTile(title: String(localized: "访客"),   value: current.uniques.watchCompact)
-            MetricTile(title: String(localized: "带宽"),   value: Int64(current.bytes).formatted(.byteCount(style: .decimal)))
+            MetricTile(title: String(localized: "带宽"),   value: Int64(current.bytes).ocBytes)
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -653,7 +653,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -673,7 +673,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -685,7 +685,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -706,7 +706,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -717,7 +717,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -740,7 +740,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -751,7 +751,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -774,7 +774,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -786,7 +786,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -808,7 +808,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -820,7 +820,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -840,7 +840,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -852,7 +852,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -870,7 +870,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -882,7 +882,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -900,7 +900,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -912,7 +912,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -930,7 +930,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -942,7 +942,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -963,7 +963,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -982,7 +982,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1006,7 +1006,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1025,7 +1025,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Intelligence/AnalyticsIntelligence.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Intelligence/AnalyticsIntelligence.swift
@@ -41,7 +41,7 @@ nonisolated struct TrafficSummaryInput: Sendable {
         var lines: [String] = []
         lines.append("Time window: \(periodLabel)")
         lines.append("Total requests: \(totalRequests.formatted(.number.grouping(.automatic)))\(Self.trend(requestsTrend))")
-        let bytes = Int64(totalBytes).formatted(.byteCount(style: .decimal))
+        let bytes = Int64(totalBytes).ocBytes
         lines.append("Data served: \(bytes)\(Self.trend(bytesTrend))")
         lines.append("Unique visitors: \(totalUniques.formatted(.number.grouping(.automatic)))\(Self.trend(uniquesTrend))")
         lines.append("Threats blocked: \(totalThreats.formatted(.number.grouping(.automatic)))\(Self.trend(threatsTrend))")

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -457,6 +457,158 @@
         }
       }
     },
+    "Pages 自定义域名": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages custom domains"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages 自訂網域"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages 自訂域名"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages カスタムドメイン"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dominios personalizados de Pages"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages 사용자 지정 도메인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domínios personalizados do Pages"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domínios personalizados do Pages"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Domains für Pages"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domaines personnalisés Pages"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نطاقات Pages المخصصة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages özel alan adları"
+          }
+        }
+      }
+    },
+    "Pages 项目现可直接管理自定义域名：添加、删除、重新验证并检查解析状态；域名在当前账号时，还能一键添加指向项目的 CNAME 记录。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage custom domains right inside a Pages project: add, remove, re-validate, and check DNS status — with one-tap CNAME setup when the domain’s zone is on your account."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages 專案現可直接管理自訂網域：新增、刪除、重新驗證並檢查解析狀態；網域在目前帳號時，還能一鍵新增指向專案的 CNAME 記錄。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages 項目現可直接管理自訂域名：新增、刪除、重新驗證並檢查解析狀態；域名在當前帳戶時，還能一鍵新增指向項目的 CNAME 記錄。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages プロジェクト内でカスタムドメインを直接管理：追加・削除・再検証と DNS 状態の確認に対応。ドメインが現在のアカウントにある場合は、プロジェクトへ向ける CNAME レコードをワンタップで追加できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administra dominios personalizados dentro de un proyecto de Pages: agregar, eliminar, revalidar y comprobar el estado del DNS; si la zona del dominio está en tu cuenta, agrega el registro CNAME con un toque."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages 프로젝트에서 사용자 지정 도메인을 직접 관리하세요: 추가·삭제·재확인과 DNS 상태 확인을 지원하며, 도메인이 현재 계정에 있으면 프로젝트를 가리키는 CNAME 레코드를 한 번에 추가할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie domínios personalizados dentro de um projeto do Pages: adicionar, remover, revalidar e verificar o status do DNS — com criação do registro CNAME em um toque quando a zona do domínio está na sua conta."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faça a gestão de domínios personalizados dentro de um projeto do Pages: adicionar, remover, revalidar e verificar o estado do DNS — com criação do registo CNAME num toque quando a zona do domínio está na sua conta."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwalte benutzerdefinierte Domains direkt im Pages-Projekt: hinzufügen, entfernen, erneut validieren und DNS-Status prüfen – mit Ein-Tipp-CNAME, wenn die Zone der Domain in deinem Konto liegt."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérez les domaines personnalisés directement dans un projet Pages : ajout, suppression, revalidation et vérification du DNS — avec création du CNAME en un geste quand la zone du domaine est sur votre compte."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدر النطاقات المخصصة داخل مشروع Pages مباشرة: إضافة وحذف وإعادة تحقق وفحص حالة DNS — مع إضافة سجل CNAME بلمسة واحدة عندما تكون منطقة النطاق ضمن حسابك."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel alan adlarını doğrudan Pages projesi içinde yönetin: ekleme, silme, yeniden doğrulama ve DNS durumu kontrolü — alan adının bölgesi hesabınızdaysa tek dokunuşla CNAME kaydı ekleyin."
+          }
+        }
+      }
+    },
     "Queues 现可暂停/恢复投递、清空消息、调整保留期与延迟；Hyperdrive 可编辑查询缓存与源数据库连接；Durable Objects 可浏览对象实例；Workers AI 能直接在 App 内试运行文本生成模型，缺权限时可一键补授权、无需退出登录。": {
       "localizations": {
         "en": {
@@ -1137,6 +1289,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Görsel WAF kural oluşturucu"
+          }
+        }
+      }
+    },
+    "Workers 与 Pages 列表新增排序：默认（名称）、创建日期、最近更新，选择会被记住。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers and Pages lists can now be sorted by name (default), date created, or recently updated — your choice is remembered."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 與 Pages 清單新增排序：預設（名稱）、建立日期、最近更新，選擇會被記住。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 與 Pages 列表新增排序：默認（名稱）、創建日期、最近更新，選擇會被記住。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers と Pages のリストを名前（デフォルト）・作成日・最近の更新で並べ替えられるようになりました。選択は記憶されます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las listas de Workers y Pages ahora se pueden ordenar por nombre (predeterminado), fecha de creación o actualización reciente; tu elección se recuerda."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers와 Pages 목록을 이름(기본), 생성일, 최근 업데이트로 정렬할 수 있습니다. 선택은 기억됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As listas de Workers e Pages agora podem ser ordenadas por nome (padrão), data de criação ou atualização recente — sua escolha é lembrada."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As listas de Workers e Pages podem agora ser ordenadas por nome (predefinição), data de criação ou atualização recente — a sua escolha é lembrada."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers- und Pages-Listen lassen sich jetzt nach Name (Standard), Erstellungsdatum oder letzter Aktualisierung sortieren – die Auswahl wird gemerkt."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les listes Workers et Pages peuvent désormais être triées par nom (par défaut), date de création ou mise à jour récente — votre choix est mémorisé."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يمكن الآن ترتيب قوائم Workers و Pages حسب الاسم (افتراضي) أو تاريخ الإنشاء أو آخر تحديث — ويُحفظ اختيارك."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers ve Pages listeleri artık ada (varsayılan), oluşturma tarihine veya son güncellemeye göre sıralanabilir; seçiminiz hatırlanır."
           }
         }
       }
@@ -2053,6 +2281,82 @@
         }
       }
     },
+    "列表排序": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "List sorting"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清單排序"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "列表排序"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リストの並べ替え"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orden de listas"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목록 정렬"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenação de listas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenação de listas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listensortierung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tri des listes"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتيب القوائم"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liste sıralama"
+          }
+        }
+      }
+    },
     "创建资源，不止于查看": {
       "localizations": {
         "en": {
@@ -2885,6 +3189,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alan adları ve Rotalar"
+          }
+        }
+      }
+    },
+    "存储与流量单位在所有语言下统一显示为国际通用符号（KB / MB / GB），不再随语言翻译。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage and traffic sizes now always use the universal unit symbols (KB / MB / GB) in every language, instead of localized unit names."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存與流量單位在所有語言下統一顯示為國際通用符號（KB / MB / GB），不再隨語言翻譯。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存與流量單位在所有語言下統一顯示為國際通用符號（KB / MB / GB），不再隨語言翻譯。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージや通信量の単位を、どの言語でも国際的な表記（KB / MB / GB）で統一しました。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los tamaños de almacenamiento y tráfico ahora usan siempre los símbolos universales (KB / MB / GB) en todos los idiomas."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장 용량과 트래픽 단위를 모든 언어에서 국제 공용 기호(KB / MB / GB)로 통일했습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os tamanhos de armazenamento e tráfego agora usam sempre os símbolos universais (KB / MB / GB) em todos os idiomas."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os tamanhos de armazenamento e tráfego usam agora sempre os símbolos universais (KB / MB / GB) em todos os idiomas."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicher- und Traffic-Größen verwenden jetzt in allen Sprachen einheitlich die universellen Einheitensymbole (KB / MB / GB)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les tailles de stockage et de trafic utilisent désormais les symboles universels (KB / MB / GB) dans toutes les langues."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحجام التخزين وحركة المرور تُعرض الآن دائمًا بالرموز العالمية (KB / MB / GB) في جميع اللغات."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depolama ve trafik boyutları artık tüm dillerde evrensel birim simgeleriyle (KB / MB / GB) gösteriliyor."
           }
         }
       }
@@ -3873,6 +4253,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Push Merkezi"
+          }
+        }
+      }
+    },
+    "数据单位显示": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data unit display"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "數據單位顯示"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "數據單位顯示"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データ単位の表示"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unidades de datos"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터 단위 표시"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unidades de dados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unidades de dados"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeige von Dateneinheiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affichage des unités"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض وحدات البيانات"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veri birimi gösterimi"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,23 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "1.9.0", items: [
+            WhatsNewItem(
+                icon:   "globe",
+                title:  String(localized: "Pages 自定义域名", table: "WhatsNew"),
+                detail: String(localized: "Pages 项目现可直接管理自定义域名：添加、删除、重新验证并检查解析状态；域名在当前账号时，还能一键添加指向项目的 CNAME 记录。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "arrow.up.arrow.down",
+                title:  String(localized: "列表排序", table: "WhatsNew"),
+                detail: String(localized: "Workers 与 Pages 列表新增排序：默认（名称）、创建日期、最近更新，选择会被记住。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "textformat.123",
+                title:  String(localized: "数据单位显示", table: "WhatsNew"),
+                detail: String(localized: "存储与流量单位在所有语言下统一显示为国际通用符号（KB / MB / GB），不再随语言翻译。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "1.8.0", items: [
             WhatsNewItem(
                 icon:   "bell.badge.fill",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -1,6 +1,1754 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "%lld 个域名" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld نطاقات"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Domains"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld domains"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld dominios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld domaines"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 件のドメイン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도메인 %lld개"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld domínios"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld domínios"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld alan adı"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個域名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個網域"
+          }
+        }
+      }
+    },
+    "创建日期" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تاريخ الإنشاء"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellungsdatum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date Created"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de creación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date de création"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생성일"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data de criação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data de criação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oluşturma tarihi"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "創建日期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立日期"
+          }
+        }
+      }
+    },
+    "最近更新" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آخر تحديث"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zuletzt aktualisiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recently Updated"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualización reciente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mise à jour récente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近の更新"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 업데이트"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualização recente"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualização recente"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son güncelleme"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近更新"
+          }
+        }
+      }
+    },
+    "排序" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الترتيب"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sortieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trier"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "並べ替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정렬"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sırala"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
+        }
+      }
+    },
+    "默认（名称）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افتراضي (الاسم)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standard (Name)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default (Name)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predeterminado (nombre)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Par défaut (nom)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルト（名前）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본(이름)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Padrão (nome)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predefinição (nome)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Varsayılan (ad)"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默認（名稱）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設（名稱）"
+          }
+        }
+      }
+    },
+    "生效中" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نشط"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiv"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actif"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativo"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etkin"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生效中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生效中"
+          }
+        }
+      }
+    },
+    "已封锁" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "محظور"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blockiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocked"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloqueado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloqué"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブロック済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "차단됨"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloqueado"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloqueado"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engellendi"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已封鎖"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已封鎖"
+          }
+        }
+      }
+    },
+    "重新验证" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة التحقق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneut validieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-validate"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a validar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revalider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再検証"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 확인"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validar novamente"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validar novamente"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeniden doğrula"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新驗證"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新驗證"
+          }
+        }
+      }
+    },
+    "记录名" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اسم السجل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eintragsname"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record Name"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del registro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de l’enregistrement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レコード名"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레코드 이름"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome do registro"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome do registo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kayıt adı"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記錄名稱"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記錄名稱"
+          }
+        }
+      }
+    },
+    "验证 TXT 记录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سجل TXT للتحقق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TXT-Eintrag zur Verifizierung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verification TXT Record"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registro TXT de verificación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement TXT de vérification"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検証用 TXT レコード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인용 TXT 레코드"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registro TXT de verificação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registo TXT de verificação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doğrulama TXT kaydı"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證 TXT 記錄"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證 TXT 記錄"
+          }
+        }
+      }
+    },
+    "已指向本项目" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يشير إلى هذا المشروع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt auf dieses Projekt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointing at this project"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apunta a este proyecto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointe vers ce projet"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このプロジェクトを指しています"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 프로젝트를 가리키고 있음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apontando para este projeto"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A apontar para este projeto"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu projeye yönlendirilmiş"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已指向本項目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已指向本專案"
+          }
+        }
+      }
+    },
+    "未指向本项目" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يشير إلى هذا المشروع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt nicht auf dieses Projekt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not pointing at this project"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No apunta a este proyecto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne pointe pas vers ce projet"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このプロジェクトを指していません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 프로젝트를 가리키지 않음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não aponta para este projeto"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não aponta para este projeto"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu projeye yönlendirilmemiş"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未指向本項目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未指向本專案"
+          }
+        }
+      }
+    },
+    "添加 CNAME 记录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة سجل CNAME"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CNAME-Eintrag hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add CNAME Record"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar registro CNAME"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un enregistrement CNAME"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CNAME レコードを追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CNAME 레코드 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar registro CNAME"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar registo CNAME"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CNAME kaydı ekle"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 CNAME 記錄"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 CNAME 記錄"
+          }
+        }
+      }
+    },
+    "尚无解析记录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يوجد سجل DNS بعد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch kein DNS-Eintrag"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No DNS record yet"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay registro DNS"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore d’enregistrement DNS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS レコードがありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS 레코드가 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda não há registro DNS"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda não há registo DNS"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz DNS kaydı yok"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無解析記錄"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無解析記錄"
+          }
+        }
+      }
+    },
+    "没有自定义域名" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد نطاقات مخصصة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine benutzerdefinierten Domains"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Custom Domains"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay dominios personalizados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun domaine personnalisé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタムドメインはありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정 도메인 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum domínio personalizado"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum domínio personalizado"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özel alan adı yok"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有自訂域名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有自訂網域"
+          }
+        }
+      }
+    },
+    "删除域名" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف النطاق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domain entfernen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Domain"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar dominio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le domaine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドメインを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도메인 삭제"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excluir domínio"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar domínio"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alan adını sil"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除域名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除網域"
+          }
+        }
+      }
+    },
+    "删除域名「%@」？" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف النطاق ”%@“؟"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domain „%@“ entfernen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove domain “%@”?"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Eliminar el dominio “%@”?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le domaine « %@ » ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドメイン「%@」を削除しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도메인 “%@”을(를) 삭제할까요?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excluir o domínio “%@”?"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar o domínio “%@”?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” alan adı silinsin mi?"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除域名「%@」？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除網域「%@」？"
+          }
+        }
+      }
+    },
+    "将从该 Pages 项目移除此域名，不影响已有 DNS 记录。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ستتم إزالة هذا النطاق من مشروع Pages، دون التأثير على سجلات DNS الحالية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Domain wird aus diesem Pages-Projekt entfernt. Bestehende DNS-Einträge bleiben unberührt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The domain will be removed from this Pages project. Existing DNS records are not affected."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El dominio se quitará de este proyecto de Pages. Los registros DNS existentes no se verán afectados."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le domaine sera retiré de ce projet Pages. Les enregistrements DNS existants ne sont pas affectés."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このドメインを Pages プロジェクトから削除します。既存の DNS レコードには影響しません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 Pages 프로젝트에서 도메인을 제거합니다. 기존 DNS 레코드에는 영향이 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O domínio será removido deste projeto do Pages. Os registros DNS existentes não serão afetados."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O domínio será removido deste projeto do Pages. Os registos DNS existentes não serão afetados."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alan adı bu Pages projesinden kaldırılacak. Mevcut DNS kayıtları etkilenmez."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將從該 Pages 項目移除此域名，不影響現有 DNS 記錄。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將從該 Pages 專案移除此網域，不影響現有 DNS 記錄。"
+          }
+        }
+      }
+    },
+    "挂载后需将域名解析指向本项目才能生效。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بعد الإضافة، وجِّه DNS النطاق إلى هذا المشروع ليصبح ساريًا."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach dem Hinzufügen muss der DNS-Eintrag der Domain auf dieses Projekt zeigen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After attaching, point the domain’s DNS at this project for it to take effect."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Después de agregarlo, apunta el DNS del dominio a este proyecto para que surta efecto."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Après l’ajout, faites pointer le DNS du domaine vers ce projet pour qu’il prenne effet."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加後、ドメインの DNS をこのプロジェクトに向けると有効になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가한 후 도메인 DNS를 이 프로젝트로 지정해야 적용됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depois de adicionar, aponte o DNS do domínio para este projeto para que tenha efeito."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depois de adicionar, aponte o DNS do domínio para este projeto para que produza efeito."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekledikten sonra alan adının DNS’ini bu projeye yönlendirin."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掛載後需將域名解析指向本項目才會生效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掛載後需將網域解析指向本專案才會生效。"
+          }
+        }
+      }
+    },
+    "绑定你自己的域名，并在此完成解析与验证。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اربط نطاقك الخاص وأكمل هنا إعداد DNS والتحقق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinden Sie Ihre eigene Domain und schließen Sie DNS-Einrichtung und Validierung hier ab."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attach your own domain, then finish DNS setup and validation here."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vincula tu propio dominio y completa aquí la resolución y la validación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Associez votre propre domaine, puis terminez ici la résolution et la validation."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "独自ドメインを追加し、ここで DNS 設定と検証を行えます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자신의 도메인을 연결하고 여기에서 DNS 설정과 확인을 완료하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vincule seu próprio domínio e conclua aqui a resolução e a validação."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Associe o seu próprio domínio e conclua aqui a resolução e a validação."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kendi alan adınızı bağlayın, DNS kurulumunu ve doğrulamayı burada tamamlayın."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綁定你自己的域名，並在此完成解析與驗證。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綁定你自己的網域，並在此完成解析與驗證。"
+          }
+        }
+      }
+    },
+    "将在该域名所在的区域添加一条已代理的 CNAME 记录，指向 %@。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سيُضاف سجل CNAME مفعَّل الوكيل يشير إلى %@ في منطقة النطاق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In der Zone der Domain wird ein Proxy-CNAME-Eintrag hinzugefügt, der auf %@ zeigt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A proxied CNAME record pointing at %@ will be added in the domain’s zone."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se agregará un registro CNAME con proxy que apunta a %@ en la zona del dominio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un enregistrement CNAME proxifié pointant vers %@ sera ajouté dans la zone du domaine."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドメインのゾーンに %@ を指すプロキシ済み CNAME レコードを追加します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도메인 영역에 %@을(를) 가리키는 프록시된 CNAME 레코드를 추가합니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Um registro CNAME com proxy apontando para %@ será adicionado na zona do domínio."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Será adicionado na zona do domínio um registo CNAME com proxy a apontar para %@."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alan adının bölgesine %@ adresini gösteren proxy’li bir CNAME kaydı eklenecek."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將在該域名所在的區域新增一條已代理的 CNAME 記錄，指向 %@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將在該網域所在的區域新增一條已代理的 CNAME 記錄，指向 %@。"
+          }
+        }
+      }
+    },
+    "该域名不在当前账号的 Cloudflare 区域内，请在域名服务商处添加指向 %@ 的 CNAME 记录。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هذا النطاق ليس ضمن منطقة Cloudflare في هذا الحساب. أضِف سجل CNAME يشير إلى %@ لدى مزوِّد DNS الخاص بك."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Domain liegt in keiner Cloudflare-Zone dieses Kontos. Fügen Sie bei Ihrem DNS-Anbieter einen CNAME-Eintrag hinzu, der auf %@ zeigt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This domain isn’t in a Cloudflare zone on this account. Add a CNAME record pointing at %@ at your DNS provider."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este dominio no está en una zona de Cloudflare de esta cuenta. Agrega un registro CNAME que apunte a %@ en tu proveedor de DNS."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce domaine n’est pas dans une zone Cloudflare de ce compte. Ajoutez un enregistrement CNAME pointant vers %@ chez votre fournisseur DNS."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このドメインは現在のアカウントの Cloudflare ゾーンにありません。DNS プロバイダーで %@ を指す CNAME レコードを追加してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 도메인은 현재 계정의 Cloudflare 영역에 없습니다. DNS 공급업체에서 %@을(를) 가리키는 CNAME 레코드를 추가하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio não está em uma zona do Cloudflare desta conta. Adicione um registro CNAME apontando para %@ no seu provedor de DNS."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio não está numa zona do Cloudflare desta conta. Adicione no seu fornecedor de DNS um registo CNAME a apontar para %@."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu alan adı bu hesaptaki bir Cloudflare bölgesinde değil. DNS sağlayıcınızda %@ adresini gösteren bir CNAME kaydı ekleyin."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該域名不在當前帳戶的 Cloudflare 區域內，請在域名服務商處新增指向 %@ 的 CNAME 記錄。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該網域不在目前帳號的 Cloudflare 區域內，請在網域服務商處新增指向 %@ 的 CNAME 記錄。"
+          }
+        }
+      }
+    },
+    "当前授权未包含 DNS 写权限（dns.write）。\n请在设置中退出登录后重新授权以启用此功能。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يتضمّن التفويض الحالي إذن الكتابة لـ DNS ‏(dns.write).\nسجّل الخروج من الإعدادات وأعد التفويض لتفعيله."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Autorisierung enthält keine Schreibberechtigung für DNS (dns.write).\nMelde dich in den Einstellungen ab und autorisiere erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your authorization doesn't include write permission for DNS (dns.write).\nSign out in Settings and re-authorize to enable it."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu autorización no incluye el permiso de escritura de DNS (dns.write).\nCierra sesión en Ajustes y vuelve a autorizar para habilitarlo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre autorisation n’inclut pas la permission d’écriture DNS (dns.write).\nDéconnectez-vous dans Réglages et réautorisez pour l’activer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の認可には DNS の書き込み権限（dns.write）が含まれていません。\n設定でサインアウトして再認可すると有効になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 권한에 DNS 쓰기 권한(dns.write)이 없습니다.\n설정에서 로그아웃 후 다시 인증하면 활성화됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sua autorização não inclui a permissão de escrita de DNS (dns.write).\nSaia nas Configurações e autorize novamente para ativar."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A sua autorização não inclui a permissão de escrita de DNS (dns.write).\nTermine sessão nas Definições e autorize novamente para ativar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yetkilendirmeniz DNS yazma iznini (dns.write) içermiyor.\nAyarlar’da çıkış yapıp yeniden yetkilendirin."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的授權未包含 DNS 的寫入權限（dns.write）。\n請在設定中登出後重新授權以啟用此功能。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的授權未包含 DNS 的寫入權限（dns.write）。\n請在設定中登出後重新授權以啟用此功能。"
+          }
+        }
+      }
+    },
     "添加主机名" : {
       "localizations" : {
         "ar" : {
@@ -9087,7 +10835,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يحدّ Cloudflare API الرفع الواحد بنحو 300 ميغابايت؛ الكائنات الأكبر لا يمكن نسخها أو نقلها داخل التطبيق."
+            "value" : "يحدّ Cloudflare API الرفع الواحد بنحو 300 MB؛ الكائنات الأكبر لا يمكن نسخها أو نقلها داخل التطبيق."
           }
         },
         "de" : {
@@ -9111,7 +10859,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’API Cloudflare limite un envoi unique à environ 300 Mo ; les objets plus volumineux ne peuvent pas être copiés ou déplacés dans l’app."
+            "value" : "L’API Cloudflare limite un envoi unique à environ 300 MB ; les objets plus volumineux ne peuvent pas être copiés ou déplacés dans l’app."
           }
         },
         "ja" : {
@@ -15791,7 +17539,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يمكن أن تستخدم المفاتيح / للإشارة إلى مستويات المجلدات. الكائنات التي تتجاوز 300 ميغابايت لا يمكن نسخها / نقلها بسبب قيود واجهة برمجة التطبيقات."
+            "value" : "يمكن أن تستخدم المفاتيح / للإشارة إلى مستويات المجلدات. الكائنات التي تتجاوز 300 MB لا يمكن نسخها / نقلها بسبب قيود واجهة برمجة التطبيقات."
           }
         },
         "de" : {
@@ -15815,7 +17563,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les clés peuvent utiliser / pour indiquer les niveaux de dossier. Les objets de plus de 300 Mo ne peuvent pas être copiés ou déplacés en raison des limites de l’API."
+            "value" : "Les clés peuvent utiliser / pour indiquer les niveaux de dossier. Les objets de plus de 300 MB ne peuvent pas être copiés ou déplacés en raison des limites de l’API."
           }
         },
         "ja" : {
@@ -56254,7 +58002,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يتجاوز الكائن 300 ميغابايت ولا يمكن نسخه أو نقله داخل التطبيق بسبب قيود Cloudflare API"
+            "value" : "يتجاوز الكائن 300 MB ولا يمكن نسخه أو نقله داخل التطبيق بسبب قيود Cloudflare API"
           }
         },
         "de" : {
@@ -56278,7 +58026,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’objet dépasse 300 Mo et ne peut pas être copié ou déplacé dans l’app en raison des limites de l’API Cloudflare"
+            "value" : "L’objet dépasse 300 MB et ne peut pas être copié ou déplacé dans l’app en raison des limites de l’API Cloudflare"
           }
         },
         "ja" : {
@@ -68506,7 +70254,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "عند التفعيل، تظهر هذه الحزمة في تطبيق الملفات بالنظام مثل iCloud Drive — التصفح والقراءة والرفع والحذف، والفتح بأي تطبيق. الرفع لكل ملف محدود بنحو 300 ميجابايت (واجهة Cloudflare)."
+            "value" : "عند التفعيل، تظهر هذه الحزمة في تطبيق الملفات بالنظام مثل iCloud Drive — التصفح والقراءة والرفع والحذف، والفتح بأي تطبيق. الرفع لكل ملف محدود بنحو 300 MB (واجهة Cloudflare)."
           }
         },
         "de" : {
@@ -68530,7 +70278,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Une fois activé, ce bucket apparaît dans l'app Fichiers du système comme iCloud Drive — parcourir, lire, téléverser et supprimer, et ouvrir avec n'importe quelle app. Le téléversement par fichier est limité à environ 300 Mo (API Cloudflare)."
+            "value" : "Une fois activé, ce bucket apparaît dans l'app Fichiers du système comme iCloud Drive — parcourir, lire, téléverser et supprimer, et ouvrir avec n'importe quelle app. Le téléversement par fichier est limité à environ 300 MB (API Cloudflare)."
           }
         },
         "ja" : {
@@ -75050,7 +76798,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الملف %@ يتجاوز 25 ميغابايت، أي فوق حد Pages لكل ملف"
+            "value" : "الملف %@ يتجاوز 25 MB، أي فوق حد Pages لكل ملف"
           }
         },
         "de" : {
@@ -75074,7 +76822,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le fichier %@ dépasse 25 Mo, au-delà de la limite Pages par fichier"
+            "value" : "Le fichier %@ dépasse 25 MB, au-delà de la limite Pages par fichier"
           }
         },
         "ja" : {
@@ -75126,7 +76874,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الملف %@ يتجاوز 25 ميغابايت، أي فوق الحد لكل ملف"
+            "value" : "الملف %@ يتجاوز 25 MB، أي فوق الحد لكل ملف"
           }
         },
         "de" : {
@@ -75150,7 +76898,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le fichier %@ dépasse 25 Mo, au-delà de la limite par fichier"
+            "value" : "Le fichier %@ dépasse 25 MB, au-delà de la limite par fichier"
           }
         },
         "ja" : {
@@ -122966,7 +124714,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا يمكن بعد معاينة الكائنات التي يتجاوز حجمها 50 ميجابايت داخل التطبيق."
+            "value" : "لا يمكن بعد معاينة الكائنات التي يتجاوز حجمها 50 MB داخل التطبيق."
           }
         },
         "de" : {
@@ -122990,7 +124738,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les objets de plus de 50 Mo ne peuvent pas encore être prévisualisés dans l’app."
+            "value" : "Les objets de plus de 50 MB ne peuvent pas encore être prévisualisés dans l’app."
           }
         },
         "ja" : {

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/PagesModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/PagesModels.swift
@@ -177,6 +177,80 @@ nonisolated enum PagesDeployStatus: String, Sendable {
     }
 }
 
+// MARK: - 自定义域名
+
+/// 项目自定义域名。GET /accounts/{id}/pages/projects/{name}/domains
+nonisolated struct PagesDomain: Codable, Identifiable, Sendable {
+    let id:                   String
+    let name:                 String
+    let status:               String?   // initializing | pending | active | deactivated | blocked | error
+    let zoneTag:              String?   // 域名所在 Zone（在当前 Cloudflare 上才有意义）
+    let createdOn:            String?
+    let certificateAuthority: String?
+    let validationData:       PagesDomainValidationData?
+    let verificationData:     PagesDomainVerificationData?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, status
+        case zoneTag              = "zone_tag"
+        case createdOn            = "created_on"
+        case certificateAuthority = "certificate_authority"
+        case validationData       = "validation_data"
+        case verificationData     = "verification_data"
+    }
+
+    var statusValue: PagesDomainStatus { PagesDomainStatus(rawValue: status ?? "") ?? .unknown }
+}
+
+/// 证书验证信息（method == txt 时给出待添加的 TXT 记录）
+nonisolated struct PagesDomainValidationData: Codable, Sendable {
+    let status:       String?
+    let method:       String?    // http | txt
+    let txtName:      String?
+    let txtValue:     String?
+    let errorMessage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, method
+        case txtName      = "txt_name"
+        case txtValue     = "txt_value"
+        case errorMessage = "error_message"
+    }
+}
+
+/// 域名归属验证信息
+nonisolated struct PagesDomainVerificationData: Codable, Sendable {
+    let status:       String?
+    let errorMessage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case errorMessage = "error_message"
+    }
+}
+
+nonisolated enum PagesDomainStatus: String, Sendable {
+    case initializing, pending, active, deactivated, blocked, error
+    case unknown = ""
+
+    var label: String {
+        switch self {
+        case .active:       String(localized: "生效中")
+        case .pending:      String(localized: "验证中")
+        case .initializing: String(localized: "初始化")
+        case .deactivated:  String(localized: "已停用")
+        case .blocked:      String(localized: "已封锁")
+        case .error:        String(localized: "错误")
+        case .unknown:      String(localized: "未知")
+        }
+    }
+}
+
+/// POST .../domains 请求体
+nonisolated struct PagesDomainAddRequest: Codable, Sendable {
+    let name: String
+}
+
 // MARK: - 写入载荷
 
 /// PATCH 项目：仅传要改的字段（顶层合并，省略字段不变）。环境变量不在此（脱敏风险，App 内只读）。

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/DNSService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/DNSService.swift
@@ -36,6 +36,21 @@ struct DNSService {
         return records
     }
 
+    /// 查某主机名的解析记录（服务端按 name 精确过滤，Pages 域名解析检查用）
+    func listRecords(zoneId: String, name: String) async throws -> [DNSRecord] {
+        let response: CFAPIResponseArray<DNSRecord> = try await client.get(
+            "zones/\(zoneId)/dns_records",
+            queryItems: [
+                URLQueryItem(name: "name",     value: name),
+                URLQueryItem(name: "per_page", value: "100"),
+            ]
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return response.result ?? []
+    }
+
     /// 仅取记录总数（per_page 最小档 + result_info.total_count，不拉全量记录）
     func recordCount(zoneId: String) async throws -> Int {
         let response: CFAPIResponseArray<DNSRecord> = try await client.get(

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/PagesService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/PagesService.swift
@@ -137,6 +137,41 @@ struct PagesService {
         try await client.delete("accounts/\(accountId)/pages/projects/\(projectName)/deployments/\(deploymentId)")
     }
 
+    // MARK: - 自定义域名
+
+    /// 项目自定义域名列表
+    func listDomains(accountId: String, projectName: String) async throws -> [PagesDomain] {
+        let response: CFAPIResponseArray<PagesDomain> = try await client.get(
+            "accounts/\(accountId)/pages/projects/\(projectName)/domains"
+        )
+        guard response.success else { throw response.toAPIError() }
+        return response.result ?? []
+    }
+
+    /// 挂载自定义域名（page.write）。挂载后仍需 DNS 指向 <project>.pages.dev 才能生效。
+    func addDomain(accountId: String, projectName: String, name: String) async throws -> PagesDomain {
+        let response: CFAPIResponse<PagesDomain> = try await client.post(
+            "accounts/\(accountId)/pages/projects/\(projectName)/domains",
+            body: PagesDomainAddRequest(name: name)
+        )
+        guard response.success, let domain = response.result else { throw response.toAPIError() }
+        return domain
+    }
+
+    /// 重新验证域名（PATCH 触发重试；DNS 记录补好后用它催一次）
+    func retryDomain(accountId: String, projectName: String, domainName: String) async throws {
+        let response: CFAPIResponse<JSONValue> = try await client.patch(
+            "accounts/\(accountId)/pages/projects/\(projectName)/domains/\(domainName)",
+            body: PagesEmptyBody()
+        )
+        guard response.success else { throw response.toAPIError() }
+    }
+
+    /// 从项目移除自定义域名（不动 DNS 记录）
+    func deleteDomain(accountId: String, projectName: String, domainName: String) async throws {
+        try await client.delete("accounts/\(accountId)/pages/projects/\(projectName)/domains/\(domainName)")
+    }
+
     // MARK: - 直接上传部署（Direct Upload）
     //
     // 流程对齐 wrangler：① 取上传 JWT → ② check-missing 问服务端缺哪些资源

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/PagesViewModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/PagesViewModels.swift
@@ -186,6 +186,160 @@ final class PagesProjectDetailViewModel {
     }
 }
 
+// MARK: - 自定义域名
+
+@Observable
+@MainActor
+final class PagesDomainsViewModel {
+
+    /// 某个域名的 DNS 解析状态（zone 在当前账号内时才可查/可写）
+    enum DNSState: Equatable {
+        case resolved(String)     // 已有记录指向本项目（content）
+        case conflicting(String)  // 已有解析记录但未指向本项目
+        case missing              // zone 在账号内且尚无解析记录，可一键添加 CNAME
+        case external             // zone 不在当前账号（去域名服务商处配置）
+        case unknown              // 无 dns.read 或查询失败
+    }
+
+    private(set) var domains: [PagesDomain] = []
+    private(set) var dnsStates: [String: DNSState] = [:]   // key = 域名
+    var isLoading = false
+    var loaded = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false      // sensoryFeedback 触发器
+
+    private let service: PagesService
+    private let dnsService: DNSService
+    let accountId: String
+    let projectName: String
+    /// CNAME 目标：<project>.pages.dev
+    let cnameTarget: String?
+
+    init(service: PagesService, dnsService: DNSService, accountId: String, projectName: String, subdomain: String?) {
+        self.service = service
+        self.dnsService = dnsService
+        self.accountId = accountId
+        self.projectName = projectName
+        self.cnameTarget = subdomain
+    }
+
+    func load(canReadDNS: Bool) async {
+        isLoading = true
+        error = nil
+        do {
+            domains = try await service.listDomains(accountId: accountId, projectName: projectName)
+            loaded = true
+            await refreshDNSStates(canReadDNS: canReadDNS)
+        } catch is CancellationError {
+        } catch let urlError as URLError where urlError.code == .cancelled {
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    /// 逐域名查解析记录（zone 不在账号内或无权限时标记为不可查）
+    private func refreshDNSStates(canReadDNS: Bool) async {
+        var states: [String: DNSState] = [:]
+        for domain in domains {
+            guard let zoneTag = domain.zoneTag, !zoneTag.isEmpty else {
+                states[domain.name] = .external
+                continue
+            }
+            guard canReadDNS, let target = cnameTarget else {
+                states[domain.name] = .unknown
+                continue
+            }
+            do {
+                let records = try await dnsService.listRecords(zoneId: zoneTag, name: domain.name)
+                    .filter { ["CNAME", "A", "AAAA"].contains($0.type.uppercased()) }
+                if let hit = records.first(where: { $0.content.lowercased() == target.lowercased() }) {
+                    states[domain.name] = .resolved(hit.content)
+                } else if let other = records.first {
+                    states[domain.name] = .conflicting(other.content)
+                } else {
+                    states[domain.name] = .missing
+                }
+            } catch {
+                // zone 可能属于别的账号（403）或临时失败：不阻塞域名列表
+                states[domain.name] = .unknown
+            }
+        }
+        dnsStates = states
+    }
+
+    func add(name: String, canReadDNS: Bool) async -> Bool {
+        guard !isMutating else { return false }
+        isMutating = true
+        error = nil
+        defer { isMutating = false }
+        do {
+            _ = try await service.addDomain(accountId: accountId, projectName: projectName, name: name)
+            await load(canReadDNS: canReadDNS)
+            didMutate.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
+    func retry(_ domain: PagesDomain, canReadDNS: Bool) async -> Bool {
+        guard !isMutating else { return false }
+        isMutating = true
+        error = nil
+        defer { isMutating = false }
+        do {
+            try await service.retryDomain(accountId: accountId, projectName: projectName, domainName: domain.name)
+            await load(canReadDNS: canReadDNS)
+            didMutate.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
+    func delete(_ domain: PagesDomain) async -> Bool {
+        guard !isMutating else { return false }
+        isMutating = true
+        error = nil
+        defer { isMutating = false }
+        do {
+            try await service.deleteDomain(accountId: accountId, projectName: projectName, domainName: domain.name)
+            domains.removeAll { $0.id == domain.id }
+            dnsStates[domain.name] = nil
+            didMutate.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
+    /// 一键在域名所在 Zone 添加 CNAME → <project>.pages.dev（dns.write）
+    func createCNAME(for domain: PagesDomain) async -> Bool {
+        guard !isMutating, let zoneTag = domain.zoneTag, let target = cnameTarget else { return false }
+        isMutating = true
+        error = nil
+        defer { isMutating = false }
+        do {
+            let record = CreateDNSRecord(
+                type: "CNAME", name: domain.name, content: target,
+                proxied: true, ttl: 1, priority: nil, comment: nil
+            )
+            _ = try await dnsService.createRecord(zoneId: zoneTag, record: record)
+            dnsStates[domain.name] = .resolved(target)
+            didMutate.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+}
+
 // MARK: - 直接上传部署
 
 @Observable

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Analytics/ZoneAnalyticsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Analytics/ZoneAnalyticsView.swift
@@ -445,7 +445,7 @@ struct ZoneAnalyticsSection: View {
         LazyVGrid(columns: [GridItem(.flexible(), spacing: 14), GridItem(.flexible())], spacing: 14) {
             SmallStatCard(
                 title: String(localized: "带宽"),
-                value: Int64(viewModel.totalBytes).formatted(.byteCount(style: .decimal)),
+                value: Int64(viewModel.totalBytes).ocBytes,
                 trend: viewModel.bytesTrend,
                 sparkValues: viewModel.points.map { Double($0.bytes) },
                 sparkColor: .ocOrange

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Components/ResourceSortMenu.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Components/ResourceSortMenu.swift
@@ -1,0 +1,56 @@
+//
+//  ResourceSortMenu.swift
+//  Orange Cloud
+//
+//  资源列表排序（Workers / Pages 等通用）：默认（名称）/ 创建日期 / 最近更新。
+//  选择用 @AppStorage 持久化（ResourceSort 是 String RawRepresentable，可直接存）。
+//
+
+import SwiftUI
+
+nonisolated enum ResourceSort: String, CaseIterable {
+    case name       // 默认：名称字母序（列表原有顺序）
+    case created    // 创建日期，新的在前
+    case modified   // 最近更新，新的在前
+
+    var label: String {
+        switch self {
+        case .name:     String(localized: "默认（名称）")
+        case .created:  String(localized: "创建日期")
+        case .modified: String(localized: "最近更新")
+        }
+    }
+
+    /// 按可选 ISO8601 日期串排（nil 沉底）。名称序由调用方保持原顺序。
+    func sorted<T>(_ items: [T], created: (T) -> String?, modified: (T) -> String?) -> [T] {
+        switch self {
+        case .name:     items
+        case .created:  Self.sortByDate(items, key: created)
+        case .modified: Self.sortByDate(items, key: modified)
+        }
+    }
+
+    private static func sortByDate<T>(_ items: [T], key: (T) -> String?) -> [T] {
+        items
+            .map { ($0, WorkerScript.parseDate(key($0)) ?? .distantPast) }
+            .sorted { $0.1 > $1.1 }
+            .map(\.0)
+    }
+}
+
+/// 工具栏排序菜单（当前选中项自动打勾）
+struct ResourceSortMenu: View {
+    @Binding var sort: ResourceSort
+
+    var body: some View {
+        Menu {
+            Picker("排序", selection: $sort) {
+                ForEach(ResourceSort.allCases, id: \.self) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+        } label: {
+            Label("排序", systemImage: "arrow.up.arrow.down")
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -274,7 +274,7 @@ private struct DashboardHomeView: View {
             value.formatted(.number.notation(.compactName))
         }
         func bytes(_ value: Int) -> String {
-            Int64(value).formatted(.byteCount(style: .decimal))
+            Int64(value).ocBytes
         }
 
         var services: [WidgetUsageService] = []
@@ -722,7 +722,7 @@ private struct DashboardHomeView: View {
         if !effectiveR2Paid {
             candidates.append(GaugedMetric(
                 context: String(localized: "存储"),
-                valueText: Int64(usage.r2StorageBytes).formatted(.byteCount(style: .decimal)),
+                valueText: Int64(usage.r2StorageBytes).ocBytes,
                 quotaText: "/ 10 GB",
                 ratio: Double(usage.r2StorageBytes) / 10_000_000_000
             ))
@@ -754,7 +754,7 @@ private struct DashboardHomeView: View {
         if let storage = usage.d1StorageBytes {
             candidates.append(GaugedMetric(
                 context: String(localized: "存储"),
-                valueText: Int64(storage).formatted(.byteCount(style: .file)),
+                valueText: Int64(storage).ocBytes,
                 quotaText: "/ 5 GB",
                 ratio: Double(storage) / 5_000_000_000
             ))
@@ -786,7 +786,7 @@ private struct DashboardHomeView: View {
         if let storage = usage.kvStorageBytes {
             candidates.append(GaugedMetric(
                 context: String(localized: "存储"),
-                valueText: Int64(storage).formatted(.byteCount(style: .file)),
+                valueText: Int64(storage).ocBytes,
                 quotaText: "/ 1 GB",
                 ratio: Double(storage) / 1_000_000_000
             ))
@@ -871,7 +871,7 @@ private struct DashboardHomeView: View {
             UsageRow(
                 icon: "externaldrive",
                 title: String(localized: "R2 存储"),
-                valueText: Int64(usage.r2StorageBytes).formatted(.byteCount(style: .decimal))
+                valueText: Int64(usage.r2StorageBytes).ocBytes
                     + (effectiveR2Paid ? "" : " / 10 GB"),
                 used: effectiveR2Paid ? nil : usage.r2StorageBytes,
                 quota: effectiveR2Paid ? nil : 10_000_000_000
@@ -930,7 +930,7 @@ private struct DashboardHomeView: View {
                 UsageRow(
                     icon: "cylinder",
                     title: String(localized: "D1 存储"),
-                    valueText: Int64(d1Storage).formatted(.byteCount(style: .file)) + " / 5 GB",
+                    valueText: Int64(d1Storage).ocBytes + " / 5 GB",
                     used: d1Storage,
                     quota: 5_000_000_000
                 )
@@ -974,7 +974,7 @@ private struct DashboardHomeView: View {
                 UsageRow(
                     icon: "square.grid.2x2",
                     title: String(localized: "KV 存储"),
-                    valueText: Int64(kvStorage).formatted(.byteCount(style: .file)) + " / 1 GB",
+                    valueText: Int64(kvStorage).ocBytes + " / 1 GB",
                     used: kvStorage,
                     quota: 1_000_000_000
                 )

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesDeployView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesDeployView.swift
@@ -150,7 +150,7 @@ struct PagesDeployView: View {
                     HStack {
                         Text(file.path).font(.caption.monospaced()).lineLimit(1).truncationMode(.middle)
                         Spacer()
-                        Text(Int64(file.data.count).formatted(.byteCount(style: .file)))
+                        Text(Int64(file.data.count).ocBytes)
                             .font(.caption2).foregroundStyle(.secondary)
                     }
                 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesDomainsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesDomainsView.swift
@@ -1,0 +1,432 @@
+//
+//  PagesDomainsView.swift
+//  Orange Cloud
+//
+//  Pages 项目自定义域名：列表 / 添加 / 删除 / 重新验证，
+//  并检查 DNS 解析状态，zone 在当前账号时可一键添加 CNAME → <project>.pages.dev。
+//
+
+import SwiftUI
+
+struct PagesDomainsView: View {
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: PagesDomainsViewModel
+    @State private var showAdd = false
+    @State private var newDomain = ""
+    @State private var detailTarget: PagesDomain?
+    @State private var deleteTarget: PagesDomain?
+    @State private var writeDenied = false
+
+    init(project: PagesProject, session: SessionStore) {
+        _viewModel = State(initialValue: PagesDomainsViewModel(
+            service: session.pagesService,
+            dnsService: session.dnsService,
+            accountId: session.selectedAccount?.id ?? "",
+            projectName: project.name,
+            subdomain: project.subdomain
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("page.write") }
+    private var canReadDNS: Bool { auth.hasScope("dns.read") }
+    private var canWriteDNS: Bool { auth.hasScope("dns.write") }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading && !viewModel.loaded {
+                SkeletonList(rows: 4, trailing: true)
+            } else if viewModel.domains.isEmpty {
+                emptyState
+            } else {
+                domainList
+            }
+        }
+        .background { SkyBackground() }
+        .navigationTitle("自定义域名")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("添加域名", systemImage: "plus") {
+                    if canWrite { showAdd = true } else { writeDenied = true }
+                }
+            }
+        }
+        .task { await viewModel.load(canReadDNS: canReadDNS) }
+        .sheet(item: $detailTarget) { domain in
+            PagesDomainDetailSheet(
+                domain: domain,
+                viewModel: viewModel,
+                canWrite: canWrite,
+                canReadDNS: canReadDNS,
+                canWriteDNS: canWriteDNS
+            )
+        }
+        .alert("添加域名", isPresented: $showAdd) {
+            addAlertActions
+        } message: {
+            Text("挂载后需将域名解析指向本项目才能生效。")
+        }
+        .confirmationDialog(
+            Text("删除域名「\(deleteTarget?.name ?? "")」？"),
+            isPresented: .init(get: { deleteTarget != nil }, set: { if !$0 { deleteTarget = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("删除域名", role: .destructive, action: deleteConfirmedDomain)
+        } message: {
+            Text("将从该 Pages 项目移除此域名，不影响已有 DNS 记录。")
+        }
+        .sensoryFeedback(.success, trigger: viewModel.didMutate)
+        .alert("权限不足", isPresented: $writeDenied) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("当前授权未包含 Pages 写权限（page.write）。\n请在设置中退出登录后重新授权以启用此功能。")
+        }
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var addAlertActions: some View {
+        // String 重载：占位符不走本地化
+        TextField("example.com" as String, text: $newDomain)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+        Button("添加", action: addDomain)
+        Button("取消", role: .cancel) { newDomain = "" }
+    }
+
+    private func addDomain() {
+        let name = newDomain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        newDomain = ""
+        guard name.contains("."), !name.contains(" ") else { return }
+        Task { await viewModel.add(name: name, canReadDNS: canReadDNS) }
+    }
+
+    private func deleteConfirmedDomain() {
+        if let target = deleteTarget {
+            Task { await viewModel.delete(target) }
+        }
+        deleteTarget = nil
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("没有自定义域名", systemImage: "globe")
+        } description: {
+            Text("绑定你自己的域名，并在此完成解析与验证。")
+        } actions: {
+            if canWrite {
+                Button("添加域名") { showAdd = true }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Color.ocOrangePressed)
+                    .fontWeight(.bold)
+            }
+        }
+    }
+
+    private var domainList: some View {
+        List {
+            Section {
+                ForEach(viewModel.domains) { domain in
+                    Button {
+                        detailTarget = domain
+                    } label: {
+                        domainRow(domain)
+                    }
+                    .foregroundStyle(.primary)
+                    .swipeActions(edge: .trailing) {
+                        if canWrite {
+                            Button("删除域名", systemImage: "trash", role: .destructive) {
+                                deleteTarget = domain
+                            }
+                        }
+                    }
+                }
+            } footer: {
+                Text("\(viewModel.domains.count) 个域名")
+            }
+            .glassRow()
+        }
+        .scrollContentBackground(.hidden)
+        .refreshable { await viewModel.load(canReadDNS: canReadDNS) }
+    }
+
+    private func domainRow(_ domain: PagesDomain) -> some View {
+        HStack(spacing: 12) {
+            TintIcon(systemImage: "globe", color: .ocOrange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(domain.name)
+                    .font(.callout.weight(.semibold).monospaced())
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if case .missing = viewModel.dnsStates[domain.name] {
+                    Text("尚无解析记录")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+            Spacer()
+            PagesDomainStatusBadge(status: domain.statusValue)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - 域名详情（状态 / TXT 验证 / DNS 解析 / 操作）
+
+private struct PagesDomainDetailSheet: View {
+
+    let domain: PagesDomain
+    let viewModel: PagesDomainsViewModel
+    let canWrite: Bool
+    let canReadDNS: Bool
+    let canWriteDNS: Bool
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteConfirm = false
+    @State private var dnsWriteDenied = false
+
+    /// 操作后列表会刷新，展示始终取 viewModel 里的最新快照
+    private var current: PagesDomain { viewModel.domains.first { $0.id == domain.id } ?? domain }
+    private var dnsState: PagesDomainsViewModel.DNSState? { viewModel.dnsStates[current.name] }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                statusSection
+                txtSection
+                dnsSection
+                actionsSection
+            }
+            .navigationTitle(current.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("完成") { dismiss() }
+                }
+            }
+            .confirmationDialog("删除域名「\(current.name)」？", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+                Button("删除域名", role: .destructive) {
+                    Task {
+                        if await viewModel.delete(current) { dismiss() }
+                    }
+                }
+            } message: {
+                Text("将从该 Pages 项目移除此域名，不影响已有 DNS 记录。")
+            }
+            .alert("权限不足", isPresented: $dnsWriteDenied) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text("当前授权未包含 DNS 写权限（dns.write）。\n请在设置中退出登录后重新授权以启用此功能。")
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    // MARK: 状态
+
+    private var statusSection: some View {
+        Section {
+            HStack {
+                Text("状态")
+                Spacer()
+                PagesDomainStatusBadge(status: current.statusValue)
+            }
+            if let target = viewModel.cnameTarget {
+                HStack {
+                    Text(verbatim: "CNAME")
+                    Spacer()
+                    Text(target)
+                        .font(.callout.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .contextMenu {
+                    Button("复制", systemImage: "doc.on.doc") {
+                        UIPasteboard.general.string = target
+                    }
+                }
+            }
+        } footer: {
+            if let message = current.verificationData?.errorMessage ?? current.validationData?.errorMessage,
+               !message.isEmpty {
+                Text(message)
+            }
+        }
+    }
+
+    // MARK: TXT 验证（zone 不在 CF 时的归属验证）
+
+    @ViewBuilder
+    private var txtSection: some View {
+        if let validation = current.validationData,
+           validation.method == "txt",
+           validation.status != "active",
+           let txtName = validation.txtName,
+           let txtValue = validation.txtValue {
+            Section {
+                copyRow(title: Text("记录名"), value: txtName)
+                copyRow(title: Text("记录值"), value: txtValue)
+            } header: {
+                Text("验证 TXT 记录")
+            }
+        }
+    }
+
+    private func copyRow(title: Text, value: String) -> some View {
+        HStack {
+            title
+            Spacer()
+            Text(value)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .contextMenu {
+            Button("复制", systemImage: "doc.on.doc") {
+                UIPasteboard.general.string = value
+            }
+        }
+    }
+
+    // MARK: DNS 解析
+
+    @ViewBuilder
+    private var dnsSection: some View {
+        switch dnsState {
+        case .resolved(let content):
+            Section {
+                HStack(spacing: 10) {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+                    Text("已指向本项目")
+                    Spacer()
+                    Text(content)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            } header: {
+                Text(verbatim: "DNS")
+            }
+        case .conflicting(let content):
+            Section {
+                HStack(spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+                    Text("未指向本项目")
+                    Spacer()
+                    Text(content)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            } header: {
+                Text(verbatim: "DNS")
+            }
+        case .missing:
+            Section {
+                Button {
+                    if canWriteDNS {
+                        Task { await viewModel.createCNAME(for: current) }
+                    } else {
+                        dnsWriteDenied = true
+                    }
+                } label: {
+                    HStack(spacing: 12) {
+                        TintIcon(systemImage: "plus.circle", color: .ocOrange)
+                        Text("添加 CNAME 记录")
+                        if viewModel.isMutating {
+                            Spacer()
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(viewModel.isMutating)
+            } header: {
+                Text(verbatim: "DNS")
+            } footer: {
+                if let target = viewModel.cnameTarget {
+                    Text("将在该域名所在的区域添加一条已代理的 CNAME 记录，指向 \(target)。")
+                }
+            }
+        case .external:
+            Section {
+                Text("该域名不在当前账号的 Cloudflare 区域内，请在域名服务商处添加指向 \(viewModel.cnameTarget ?? "") 的 CNAME 记录。")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text(verbatim: "DNS")
+            }
+        case .unknown, nil:
+            EmptyView()
+        }
+    }
+
+    // MARK: 操作
+
+    @ViewBuilder
+    private var actionsSection: some View {
+        if canWrite {
+            Section {
+                if current.statusValue != .active {
+                    Button {
+                        Task { await viewModel.retry(current, canReadDNS: canReadDNS) }
+                    } label: {
+                        HStack(spacing: 12) {
+                            TintIcon(systemImage: "arrow.clockwise", color: .blue)
+                            Text("重新验证")
+                            if viewModel.isMutating {
+                                Spacer()
+                                ProgressView()
+                            }
+                        }
+                    }
+                    .disabled(viewModel.isMutating)
+                }
+                Button(role: .destructive) {
+                    showDeleteConfirm = true
+                } label: {
+                    HStack(spacing: 12) {
+                        TintIcon(systemImage: "trash", color: .red)
+                        Text("删除域名")
+                    }
+                }
+                .disabled(viewModel.isMutating)
+            }
+        }
+    }
+}
+
+// MARK: - 状态徽章
+
+struct PagesDomainStatusBadge: View {
+    let status: PagesDomainStatus
+    var body: some View {
+        Text(status.label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.14), in: Capsule())
+    }
+    private var color: Color {
+        switch status {
+        case .active:                .green
+        case .pending, .initializing: .orange
+        case .blocked, .error:       .red
+        case .deactivated, .unknown: .gray
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesProjectDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesProjectDetailView.swift
@@ -16,7 +16,10 @@ struct PagesProjectDetailView: View {
     @State private var showDeploy = false
     @Environment(\.dismiss) private var dismiss
 
+    private let session: SessionStore
+
     init(project: PagesProject, session: SessionStore) {
+        self.session = session
         let accountId = session.selectedAccount?.id ?? ""
         _viewModel = State(initialValue: PagesProjectDetailViewModel(
             project: project,
@@ -96,9 +99,16 @@ struct PagesProjectDetailView: View {
             if let repo = project.source?.config?.repoLabel {
                 infoRow(project.source?.type == "gitlab" ? "GitLab" : "GitHub", value: repo)
             }
-            if let domains = project.domains, !domains.isEmpty {
-                ForEach(domains, id: \.self) { domain in
-                    infoRow("自定义域名", value: domain)
+            NavigationLink {
+                PagesDomainsView(project: project, session: session)
+            } label: {
+                HStack {
+                    Text("自定义域名")
+                    Spacer()
+                    if let domains = project.domains, !domains.isEmpty {
+                        Text("\(domains.count) 个域名")
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             if let date = WorkerScript.parseDate(project.createdOn) {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesProjectListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Pages/PagesProjectListView.swift
@@ -16,6 +16,7 @@ struct PagesProjectListView: View {
     @State private var searchText = ""
     @State private var showCreate = false
     @State private var writeDenied = false
+    @AppStorage("pagesListSort") private var sort: ResourceSort = .name
 
     /// 创建项目需要写权限（page.read 已是进入本页的前置条件）
     private var canWrite: Bool { auth.hasScope("page.write") }
@@ -26,8 +27,14 @@ struct PagesProjectListView: View {
     }
 
     private var filtered: [PagesProject] {
-        guard !searchText.isEmpty else { return viewModel.projects }
-        return viewModel.projects.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        let projects = searchText.isEmpty
+            ? viewModel.projects
+            : viewModel.projects.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        return sort.sorted(
+            projects,
+            created: \.createdOn,
+            modified: { $0.latestDeployment?.modifiedOn ?? $0.latestDeployment?.createdOn ?? $0.createdOn }
+        )
     }
 
     var body: some View {
@@ -73,6 +80,9 @@ struct PagesProjectListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, prompt: "搜索项目")
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ResourceSortMenu(sort: $sort)
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 Button("创建项目", systemImage: "plus") {
                     if canWrite { showCreate = true } else { writeDenied = true }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/KVKeyListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/KVKeyListView.swift
@@ -165,7 +165,7 @@ struct KVValueView: View {
                 ContentUnavailableView {
                     Label("二进制数据", systemImage: "doc.zipper")
                 } description: {
-                    Text("该值不是 UTF-8 文本（\(Int64(viewModel.byteCount).formatted(.byteCount(style: .file)))），暂不支持预览")
+                    Text("该值不是 UTF-8 文本（\(Int64(viewModel.byteCount).ocBytes)），暂不支持预览")
                 }
             } else {
                 editor
@@ -246,7 +246,7 @@ struct KVValueView: View {
             }
 
             Label {
-                Text("\(Int64(viewModel.byteCount).formatted(.byteCount(style: .file)))\(canWrite ? "" : String(localized: " · 只读授权"))")
+                Text("\(Int64(viewModel.byteCount).ocBytes)\(canWrite ? "" : String(localized: " · 只读授权"))")
             } icon: {
                 Image(systemName: canWrite ? "pencil" : "lock")
             }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2ObjectListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2ObjectListView.swift
@@ -391,7 +391,7 @@ private struct R2ObjectRow: View {
                     .truncationMode(.middle)
                 HStack(spacing: 6) {
                     if let size = object.size {
-                        Text(Int64(size).formatted(.byteCount(style: .file)))
+                        Text(Int64(size).ocBytes)
                     }
                     if let modified = WorkerScript.parseDate(object.lastModified) {
                         Text(modified, format: .relative(presentation: .named))
@@ -434,7 +434,7 @@ private struct R2ObjectDetailView: View {
                             .multilineTextAlignment(.trailing)
                     }
                     if let size = object.size {
-                        LabeledContent("大小", value: Int64(size).formatted(.byteCount(style: .file)))
+                        LabeledContent("大小", value: Int64(size).ocBytes)
                     }
                     if let contentType = object.httpMetadata?.contentType {
                         LabeledContent("Content-Type", value: contentType)

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/StorageView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/StorageView.swift
@@ -212,7 +212,7 @@ struct StorageView: View {
     /// 桶副标题：有用量数据时显示存储/对象/请求，否则回退到位置 · 创建日期
     private func r2Subtitle(for bucket: R2Bucket) -> String {
         if let usage = r2ViewModel.usageByBucket[bucket.name], usage.storageBytes > 0 || usage.objectCount > 0 {
-            var parts = [Int64(usage.storageBytes).formatted(.byteCount(style: .file))]
+            var parts = [Int64(usage.storageBytes).ocBytes]
             if usage.objectCount > 0 { parts.append(String(localized: "\(usage.objectCount) 个对象")) }
             if usage.totalRequests > 0 { parts.append(String(localized: "本月 \(usage.totalRequests.formatted()) 次操作")) }
             return parts.joined(separator: " · ")
@@ -250,7 +250,7 @@ struct StorageView: View {
                         icon: "cylinder", tint: .blue, mono: true,
                         name: database.name,
                         sub: [
-                            database.fileSize.map { Int64($0).formatted(.byteCount(style: .file)) },
+                            database.fileSize.map { Int64($0).ocBytes },
                             database.numTables.map { String(localized: "\($0) 张表") },
                         ].compactMap(\.self).joined(separator: " · ")
                     )

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Toolbox/HTTPProbeToolView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Toolbox/HTTPProbeToolView.swift
@@ -82,7 +82,7 @@ struct HTTPProbeToolView: View {
         [
             ToolKVRow("状态", "\(r.statusCode) \(r.statusText)"),
             ToolKVRow("耗时", "\(r.durationMS) ms"),
-            ToolKVRow("大小", ByteCountFormatter.string(fromByteCount: Int64(r.bodyByteCount), countStyle: .binary)),
+            ToolKVRow("大小", Int64(r.bodyByteCount).ocBytesBinary),
             ToolKVRow("最终地址", r.finalURL),
         ]
     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerListView.swift
@@ -23,6 +23,7 @@ struct WorkerListView: View {
     @State private var showTailDenied = false
     @State private var showCreate = false
     @State private var createDenied = false
+    @AppStorage("workerListSort") private var sort: ResourceSort = .name
 
     private var canWrite: Bool { auth.hasScope("workers-scripts.write") }
 
@@ -39,8 +40,10 @@ struct WorkerListView: View {
     }
 
     private var filteredScripts: [CachedWorkerScript] {
-        guard !searchText.isEmpty else { return cachedScripts }
-        return cachedScripts.filter { $0.id.localizedCaseInsensitiveContains(searchText) }
+        let scripts = searchText.isEmpty
+            ? Array(cachedScripts)
+            : cachedScripts.filter { $0.id.localizedCaseInsensitiveContains(searchText) }
+        return sort.sorted(scripts, created: \.createdOn, modified: \.modifiedOn)
     }
 
     var body: some View {
@@ -70,6 +73,9 @@ struct WorkerListView: View {
                 }
             }
             .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ResourceSortMenu(sort: $sort)
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("新建 Worker", systemImage: "plus") {
                         if canWrite { showCreate = true } else { createDenied = true }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerUploadView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerUploadView.swift
@@ -213,7 +213,7 @@ struct WorkerUploadView: View {
                     HStack {
                         Text(module.name).font(.caption.monospaced()).lineLimit(1).truncationMode(.middle)
                         Spacer()
-                        Text(Int64(module.data.count).formatted(.byteCount(style: .file)))
+                        Text(Int64(module.data.count).ocBytes)
                             .font(.caption2).foregroundStyle(.secondary)
                     }
                 }
@@ -250,7 +250,7 @@ struct WorkerUploadView: View {
                     HStack {
                         Text(file.path).font(.caption.monospaced()).lineLimit(1).truncationMode(.middle)
                         Spacer()
-                        Text(Int64(file.data.count).formatted(.byteCount(style: .file)))
+                        Text(Int64(file.data.count).ocBytes)
                             .font(.caption2).foregroundStyle(.secondary)
                     }
                 }

--- a/apps/ios/Orange Cloud/OrangeCloudWidgets/UsageFetcher.swift
+++ b/apps/ios/Orange Cloud/OrangeCloudWidgets/UsageFetcher.swift
@@ -416,7 +416,7 @@ nonisolated enum UsageFetcher {
     }
 
     private static func bytes(_ value: Int) -> String {
-        Int64(value).formatted(.byteCount(style: .decimal))
+        Int64(value).ocBytes
     }
 }
 

--- a/apps/ios/Orange Cloud/OrangeCloudWidgets/ZoneWidgets.swift
+++ b/apps/ios/Orange Cloud/OrangeCloudWidgets/ZoneWidgets.swift
@@ -333,7 +333,7 @@ struct ZoneStatWidgetView: View {
             (.requests,  String(localized: "请求"), zone.requests.formatted(.number.notation(.compactName))),
             (.threats,   String(localized: "拦截"), zone.threats.formatted(.number.notation(.compactName))),
             (.visitors,  String(localized: "访客"), zone.uniques.formatted(.number.notation(.compactName))),
-            (.bandwidth, String(localized: "带宽"), Int64(zone.bytes).formatted(.byteCount(style: .decimal))),
+            (.bandwidth, String(localized: "带宽"), Int64(zone.bytes).ocBytes),
         ]
         return Array(all.filter { $0.0 != entry.metric }.prefix(2).map { ($0.1, $0.2) })
     }
@@ -463,7 +463,7 @@ struct ZoneChartWidgetView: View {
                 if let hitRate = zone.cacheHitRate {
                     overviewStat(String(localized: "命中率"), "\(Int(hitRate))%")
                 }
-                overviewStat(String(localized: "带宽"), Int64(zone.bytes).formatted(.byteCount(style: .decimal)))
+                overviewStat(String(localized: "带宽"), Int64(zone.bytes).ocBytes)
                 overviewStat(String(localized: "威胁"), zone.threats.formatted(.number.notation(.compactName)))
                 overviewStat(String(localized: "访客"), zone.uniques.formatted(.number.notation(.compactName)))
             }

--- a/apps/ios/Orange Cloud/Shared/ByteFormat.swift
+++ b/apps/ios/Orange Cloud/Shared/ByteFormat.swift
@@ -1,0 +1,33 @@
+//
+//  ByteFormat.swift
+//  Orange Cloud（主 App / Widget / 手表共用）
+//
+//  字节数展示：数字随本地化，单位固定用国际通用符号（B/KB/MB/GB/TB/PB）。
+//  系统 .byteCount / ByteCountFormatter 会把单位本地化（法语 Mo、阿语 ميغابايت），
+//  存储/流量单位行业惯例不翻译，故手工拼接。
+//
+
+import Foundation
+
+nonisolated extension Int64 {
+
+    /// 十进制（1000 进位），对应系统 .decimal / .file 的量级口径
+    var ocBytes: String { Self.ocFormat(self, base: 1000) }
+
+    /// 二进制（1024 进位），对应系统 .binary
+    var ocBytesBinary: String { Self.ocFormat(self, base: 1024) }
+
+    private static func ocFormat(_ bytes: Int64, base: Double) -> String {
+        guard bytes > 0 else { return "0 B" }
+        let units = ["B", "KB", "MB", "GB", "TB", "PB"]
+        var value = Double(bytes)
+        var index = 0
+        while value >= base, index < units.count - 1 {
+            value /= base
+            index += 1
+        }
+        // B 不带小数；其余按量级保留 0–2 位（与系统展示精度相当）
+        let fraction = index == 0 ? 0 : (value >= 100 ? 0 : (value >= 10 ? 1 : 2))
+        return value.formatted(.number.precision(.fractionLength(0...fraction))) + " " + units[index]
+    }
+}

--- a/apps/ios/Orange Cloud/Shared/WidgetConfigIntents.swift
+++ b/apps/ios/Orange Cloud/Shared/WidgetConfigIntents.swift
@@ -226,7 +226,7 @@ nonisolated enum ZoneWidgetMetric: String {
     func valueText(_ zone: WidgetZoneMetrics) -> String {
         switch self {
         case .requests:  zone.requests.formatted(.number.notation(.compactName))
-        case .bandwidth: Int64(zone.bytes).formatted(.byteCount(style: .decimal))
+        case .bandwidth: Int64(zone.bytes).ocBytes
         case .threats:   zone.threats.formatted(.number.notation(.compactName))
         case .visitors:  zone.uniques.formatted(.number.notation(.compactName))
         }


### PR DESCRIPTION
## 新功能
- **Pages 自定义域名管理**：项目详情新增「自定义域名」入口——列表 / 添加 / 删除 / 重新验证，检查 DNS 解析状态；域名所在 zone 在当前账号时，一键添加指向 `<项目>.pages.dev` 的已代理 CNAME（page.write / dns.write 门控；zone 不在 CF 时展示 TXT 归属验证记录可复制）
- **列表排序**：Workers 与 Pages 列表支持 默认（名称）/ 创建日期 / 最近更新，@AppStorage 记忆；`ResourceSortMenu` 组件可复用给其它资源列表

## 修复
- **数据单位固定国际符号**：新增 `Shared/ByteFormat`（`.ocBytes` / `.ocBytesBinary`）替换系统 `.byteCount`——法语 Mo、阿语 ميغابايت 不再出现，主 App / 小组件 / 手表全量替换；catalog 中 fr/ar 译文单位同步改回 MB

## 发版核对
- [x] 版本 1.9.0（build 24），MARKETING_VERSION / CURRENT_PROJECT_VERSION 各 12 处同步
- [x] 新文案 13 语入 `Localizable.xcstrings`；What's New 生成物随单一数据源更新（源条目在 #41）
- [x] `xcodebuild -scheme "Orange Cloud"` BUILD SUCCEEDED，无版本不匹配 warning

依赖合并顺序：#41 先合。