### PR TITLE
feat(android): 1.6.0 — Pages 自定义域名 + 列表排序

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         // 实况通知促升(API36) 均 if-guard 渐进增强，Android 9–11 落固定品牌调色板与常驻通知回退。
         minSdk = 28
         targetSdk = 36
-        versionCode = 8
-        versionName = "1.5.0"
+        versionCode = 9
+        versionName = "1.6.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/design/ResourceSortMenu.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/design/ResourceSortMenu.kt
@@ -1,0 +1,64 @@
+package jiamin.chen.orangecloud.core.design
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Sort
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import jiamin.chen.orangecloud.R
+import jiamin.chen.orangecloud.core.system.ResourceSort
+import java.time.Instant
+
+/** 页头排序按钮（Workers / Pages 等资源列表通用），当前选中项打勾。 */
+@Composable
+fun SortMenuButton(
+    sort: ResourceSort,
+    onSky: Color,
+    onSelect: (ResourceSort) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(Icons.AutoMirrored.Outlined.Sort, contentDescription = stringResource(R.string.sort_label), tint = onSky)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            listOf(
+                ResourceSort.NAME to R.string.sort_default,
+                ResourceSort.CREATED to R.string.sort_created,
+                ResourceSort.MODIFIED to R.string.sort_modified,
+            ).forEach { (option, label) ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(label)) },
+                    onClick = { onSelect(option); expanded = false },
+                    trailingIcon = if (sort == option) {
+                        { Icon(Icons.Outlined.Check, contentDescription = null) }
+                    } else {
+                        null
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** 按可选 ISO8601 日期串排（解析失败沉底）。名称序保持列表原有顺序。 */
+fun <T> ResourceSort.sorted(items: List<T>, created: (T) -> String?, modified: (T) -> String?): List<T> = when (this) {
+    ResourceSort.NAME -> items
+    ResourceSort.CREATED -> items.sortedByDescending { parseCfDate(created(it)) }
+    ResourceSort.MODIFIED -> items.sortedByDescending { parseCfDate(modified(it)) }
+}
+
+/** CF 返回 6 位小数的 ISO8601（如 2026-03-22T20:05:13.916883Z），Instant.parse 可直接吃。 */
+private fun parseCfDate(value: String?): Long =
+    value?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrNull() } ?: 0L

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/design/SkyList.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/design/SkyList.kt
@@ -42,7 +42,7 @@ fun rememberSkyPhase(): SkyPhase {
 val SkyPhase.onSky: Color
     get() = if (isDark) Color(0xFFF3ECE4) else Color(0xFF24190F)
 
-/** 统一页头：可选返回 + 标题 + 刷新/加载。 */
+/** 统一页头：可选返回 + 标题 + 额外操作（如排序）+ 刷新/加载。 */
 @Composable
 fun SkyHeader(
     title: String,
@@ -54,6 +54,7 @@ fun SkyHeader(
     titleSize: Int = 28,
     refreshDescription: String = "",
     backDescription: String = "",
+    actions: @Composable () -> Unit = {},
 ) {
     Row(
         modifier = modifier
@@ -75,6 +76,7 @@ fun SkyHeader(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
+        actions()
         if (isLoading) {
             CircularProgressIndicator(modifier = Modifier.size(22.dp), color = onSky, strokeWidth = 2.dp)
             Spacer(Modifier.width(12.dp))

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/system/AppPrefs.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/system/AppPrefs.kt
@@ -19,7 +19,18 @@ enum class AppAppearance(val value: Int) {
     }
 }
 
-/** App 偏好（外观 + 通知开关），存共享 DataStore。 */
+/** 资源列表排序（Workers / Pages 等通用，对应 iOS ResourceSort）。 */
+enum class ResourceSort(val value: Int) {
+    NAME(0),       // 默认：名称字母序（列表原有顺序）
+    CREATED(1),    // 创建日期，新的在前
+    MODIFIED(2);   // 最近更新，新的在前
+
+    companion object {
+        fun from(value: Int): ResourceSort = entries.firstOrNull { it.value == value } ?: NAME
+    }
+}
+
+/** App 偏好（外观 + 通知开关 + 列表排序），存共享 DataStore。 */
 @Singleton
 class AppPrefs @Inject constructor(
     private val dataStore: DataStore<Preferences>,
@@ -43,6 +54,14 @@ class AppPrefs @Inject constructor(
 
     suspend fun setNotifyWorkerErrors(enabled: Boolean) {
         dataStore.edit { it[KEY_NOTIF_WORKER] = enabled }
+    }
+
+    /** 某个资源列表的排序偏好（key 如 "workers" / "pages"）。 */
+    fun listSort(key: String): Flow<ResourceSort> =
+        dataStore.data.map { ResourceSort.from(it[intPreferencesKey("pref_sort_$key")] ?: 0) }
+
+    suspend fun setListSort(key: String, sort: ResourceSort) {
+        dataStore.edit { it[intPreferencesKey("pref_sort_$key")] = sort.value }
     }
 
     private companion object {

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
@@ -5,6 +5,13 @@ import jiamin.chen.orangecloud.R
 // ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。
 internal val whatsNewReleases: List<WhatsNewRelease> = listOf(
     WhatsNewRelease(
+        version = "1.6.0",
+        items = listOf(
+            WhatsNewItem(R.string.whatsnew_1_6_0_0_title, R.string.whatsnew_1_6_0_0_detail),
+            WhatsNewItem(R.string.whatsnew_1_6_0_1_title, R.string.whatsnew_1_6_0_1_detail),
+        ),
+    ),
+    WhatsNewRelease(
         version = "1.5.0",
         items = listOf(
             WhatsNewItem(R.string.whatsnew_1_5_0_0_title, R.string.whatsnew_1_5_0_0_detail),

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/PagesModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/PagesModels.kt
@@ -83,6 +83,42 @@ data class PagesTriggerMetadata(
     val shortHash: String? get() = commitHash?.take(8)
 }
 
+// MARK: - 自定义域名
+
+/** 项目自定义域名。GET /accounts/{id}/pages/projects/{name}/domains */
+@Serializable
+data class PagesDomain(
+    val id: String,
+    val name: String,
+    val status: String? = null, // initializing | pending | active | deactivated | blocked | error
+    @SerialName("zone_tag") val zoneTag: String? = null,
+    @SerialName("created_on") val createdOn: String? = null,
+    @SerialName("certificate_authority") val certificateAuthority: String? = null,
+    @SerialName("validation_data") val validationData: PagesDomainValidationData? = null,
+    @SerialName("verification_data") val verificationData: PagesDomainVerificationData? = null,
+)
+
+/** 证书验证信息（method == txt 时给出待添加的 TXT 记录）。 */
+@Serializable
+data class PagesDomainValidationData(
+    val status: String? = null,
+    val method: String? = null, // http | txt
+    @SerialName("txt_name") val txtName: String? = null,
+    @SerialName("txt_value") val txtValue: String? = null,
+    @SerialName("error_message") val errorMessage: String? = null,
+)
+
+/** 域名归属验证信息。 */
+@Serializable
+data class PagesDomainVerificationData(
+    val status: String? = null,
+    @SerialName("error_message") val errorMessage: String? = null,
+)
+
+/** POST .../domains 请求体。 */
+@Serializable
+data class PagesDomainAddRequest(val name: String)
+
 /** retry / rollback 的空 POST 体。 */
 @Serializable
 class PagesEmptyBody

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/DnsRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/DnsRepository.kt
@@ -30,6 +30,13 @@ class DnsRepository @Inject constructor(
         dnsRecordDao.replaceForZone(zoneId, records.map { it.toEntity(zoneId) })
     }
 
+    /** 查某主机名的解析记录（服务端按 name 精确过滤，不入缓存；Pages 域名解析检查用）。 */
+    suspend fun recordsForName(zoneId: String, name: String): List<DnsRecord> =
+        api.getList<DnsRecord>(
+            "zones/$zoneId/dns_records",
+            listOf("name" to name, "per_page" to "100"),
+        ).items
+
     /** 新建记录，成功后写入缓存并返回。 */
     suspend fun createRecord(zoneId: String, record: CreateDnsRecord): DnsRecord {
         val saved = api.post<DnsRecord, CreateDnsRecord>("zones/$zoneId/dns_records", record)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/PagesRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/PagesRepository.kt
@@ -9,6 +9,8 @@ import jiamin.chen.orangecloud.data.model.PagesAssetUpload
 import jiamin.chen.orangecloud.data.model.PagesCreateRequest
 import jiamin.chen.orangecloud.data.model.PagesDeployFile
 import jiamin.chen.orangecloud.data.model.PagesDeployment
+import jiamin.chen.orangecloud.data.model.PagesDomain
+import jiamin.chen.orangecloud.data.model.PagesDomainAddRequest
 import jiamin.chen.orangecloud.data.model.PagesEmptyBody
 import jiamin.chen.orangecloud.data.model.PagesHashesBody
 import jiamin.chen.orangecloud.data.model.PagesProject
@@ -72,6 +74,27 @@ class PagesRepository @Inject constructor(
         }
         return all
     }
+
+    // MARK: - 自定义域名
+
+    /** 项目自定义域名列表。 */
+    suspend fun listDomains(accountId: String, projectName: String): List<PagesDomain> =
+        api.getList<PagesDomain>("accounts/$accountId/pages/projects/$projectName/domains").items
+
+    /** 挂载自定义域名（page.write）。挂载后仍需 DNS 指向 <project>.pages.dev 才能生效。 */
+    suspend fun addDomain(accountId: String, projectName: String, name: String): PagesDomain =
+        api.post("accounts/$accountId/pages/projects/$projectName/domains", PagesDomainAddRequest(name))
+
+    /** 重新验证域名（PATCH 触发重试；DNS 记录补好后用它催一次）。 */
+    suspend fun retryDomain(accountId: String, projectName: String, domainName: String) {
+        api.patch<kotlinx.serialization.json.JsonElement, PagesEmptyBody>(
+            "accounts/$accountId/pages/projects/$projectName/domains/$domainName", PagesEmptyBody(),
+        )
+    }
+
+    /** 从项目移除自定义域名（不动 DNS 记录）。 */
+    suspend fun deleteDomain(accountId: String, projectName: String, domainName: String) =
+        api.delete("accounts/$accountId/pages/projects/$projectName/domains/$domainName")
 
     /** 重试部署（重新构建并部署）。 */
     suspend fun retryDeployment(accountId: String, projectName: String, deploymentId: String): PagesDeployment =

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesScreens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesScreens.kt
@@ -18,8 +18,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.CloudUpload
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.InsertDriveFile
@@ -59,7 +61,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -71,12 +75,15 @@ import jiamin.chen.orangecloud.R
 import jiamin.chen.orangecloud.core.design.SkyBackground
 import jiamin.chen.orangecloud.core.design.SkyEmptyState
 import jiamin.chen.orangecloud.core.design.SkyHeader
+import jiamin.chen.orangecloud.core.design.SortMenuButton
 import jiamin.chen.orangecloud.core.design.StatusDot
+import jiamin.chen.orangecloud.core.design.sorted
 import jiamin.chen.orangecloud.core.design.onSky
 import jiamin.chen.orangecloud.core.design.rememberSkyPhase
 import jiamin.chen.orangecloud.core.design.theme.OcOrange
 import jiamin.chen.orangecloud.core.design.theme.OcSuccess
 import jiamin.chen.orangecloud.data.model.PagesDeployment
+import jiamin.chen.orangecloud.data.model.PagesDomain
 import jiamin.chen.orangecloud.data.model.PagesProject
 import jiamin.chen.orangecloud.ui.storage.StorageListBody
 import jiamin.chen.orangecloud.ui.storage.StorageRow
@@ -90,12 +97,22 @@ fun PagesListScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val busy by viewModel.busy.collectAsStateWithLifecycle()
+    val sort by viewModel.sort.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
     val snackbar = remember { SnackbarHostState() }
     var showCreate by remember { mutableStateOf(false) }
     var toDelete by remember { mutableStateOf<PagesProject?>(null) }
     LaunchedEffect(Unit) { viewModel.errors.collect { snackbar.showSnackbar(it) } }
+    val sortedState = remember(state, sort) {
+        state.copy(
+            items = sort.sorted(
+                state.items,
+                created = { it.createdOn },
+                modified = { it.latestDeployment?.modifiedOn ?: it.latestDeployment?.createdOn ?: it.createdOn },
+            ),
+        )
+    }
 
     SkyBackground(phase = phase) {
         Box(Modifier.fillMaxSize()) {
@@ -109,9 +126,14 @@ fun PagesListScreen(
                     titleSize = 22,
                     backDescription = stringResource(R.string.common_back),
                     refreshDescription = stringResource(R.string.common_refresh),
+                    actions = {
+                        if (state.items.isNotEmpty()) {
+                            SortMenuButton(sort = sort, onSky = onSky, onSelect = { viewModel.setSort(it) })
+                        }
+                    },
                 )
                 StorageListBody(
-                    state = state,
+                    state = sortedState,
                     onSky = onSky,
                     emptyIcon = Icons.Outlined.Web,
                     emptyText = stringResource(R.string.pages_empty),
@@ -198,6 +220,9 @@ fun PagesProjectDetailScreen(
     var showConfig by remember { mutableStateOf(false) }
     var showDeployChooser by remember { mutableStateOf(false) }
     var pendingZip by remember { mutableStateOf(false) }
+    var showAddDomain by remember { mutableStateOf(false) }
+    var domainSheet by remember { mutableStateOf<PagesDomain?>(null) }
+    var domainToDelete by remember { mutableStateOf<PagesDomain?>(null) }
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         if (uri != null) deployViewModel.deployFrom(uri, pendingZip)
@@ -206,11 +231,17 @@ fun PagesProjectDetailScreen(
     val retriedMsg = stringResource(R.string.pages_retried)
     val rolledMsg = stringResource(R.string.pages_rolled_back)
     val deployedMsg = stringResource(R.string.pages_deployed)
+    val domainAddedMsg = stringResource(R.string.pages_domain_added)
+    val domainDeletedMsg = stringResource(R.string.pages_domain_deleted)
+    val cnameCreatedMsg = stringResource(R.string.pages_cname_created)
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 PagesEvent.Retried -> snackbarHostState.showSnackbar(retriedMsg)
                 PagesEvent.RolledBack -> snackbarHostState.showSnackbar(rolledMsg)
+                PagesEvent.DomainAdded -> snackbarHostState.showSnackbar(domainAddedMsg)
+                PagesEvent.DomainDeleted -> snackbarHostState.showSnackbar(domainDeletedMsg)
+                PagesEvent.CnameCreated -> snackbarHostState.showSnackbar(cnameCreatedMsg)
                 is PagesEvent.Error -> snackbarHostState.showSnackbar(event.message ?: "")
             }
         }
@@ -275,6 +306,28 @@ fun PagesProjectDetailScreen(
                             }
                         }
                         item {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth().padding(start = 4.dp, top = 8.dp),
+                            ) {
+                                Text(stringResource(R.string.pages_domains_section), color = onSky, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                                if (state.canWrite) {
+                                    TextButton(onClick = { showAddDomain = true }, enabled = state.busyDeploymentId == null) {
+                                        Text(stringResource(R.string.pages_domain_add), color = OcOrange, fontSize = 13.sp)
+                                    }
+                                }
+                            }
+                        }
+                        if (state.domains.isEmpty()) {
+                            item {
+                                Text(stringResource(R.string.pages_domain_empty), fontSize = 13.sp, color = onSky.copy(alpha = 0.7f), modifier = Modifier.padding(start = 4.dp))
+                            }
+                        } else {
+                            items(state.domains, key = { "domain-${it.id}" }) { domain ->
+                                PagesDomainRow(domain, dnsState = state.dnsStates[domain.name], onClick = { domainSheet = domain })
+                            }
+                        }
+                        item {
                             Text(stringResource(R.string.pages_deployments), color = onSky, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(start = 4.dp, top = 8.dp))
                         }
                         items(state.deployments, key = { it.id }) { dep ->
@@ -301,6 +354,42 @@ fun PagesProjectDetailScreen(
                 onSave = { cmd, dest, root -> viewModel.updateBuildConfig(cmd, dest, root); showConfig = false },
             )
         }
+    }
+
+    if (showAddDomain) {
+        AddDomainDialog(
+            onDismiss = { showAddDomain = false },
+            onAdd = { name -> viewModel.addDomain(name); showAddDomain = false },
+        )
+    }
+
+    domainSheet?.let { domain ->
+        PagesDomainSheet(
+            domain = domain,
+            dnsState = state.dnsStates[domain.name],
+            cnameTarget = state.project?.subdomain,
+            canWrite = state.canWrite,
+            canWriteDns = state.canWriteDns,
+            busy = state.busyDeploymentId == "domain",
+            onRetry = { viewModel.retryDomain(domain); domainSheet = null },
+            onCreateCname = { viewModel.createCname(domain); domainSheet = null },
+            onDelete = { domainToDelete = domain; domainSheet = null },
+            onDismiss = { domainSheet = null },
+        )
+    }
+
+    domainToDelete?.let { domain ->
+        AlertDialog(
+            onDismissRequest = { domainToDelete = null },
+            title = { Text(stringResource(R.string.pages_domain_delete_title)) },
+            text = { Text(stringResource(R.string.pages_domain_delete_msg, domain.name)) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteDomain(domain); domainToDelete = null }) {
+                    Text(stringResource(R.string.dns_delete), color = Color(0xFFE5484D))
+                }
+            },
+            dismissButton = { TextButton(onClick = { domainToDelete = null }) { Text(stringResource(R.string.common_cancel)) } },
+        )
     }
 
     if (showDeployChooser) {
@@ -418,6 +507,198 @@ private fun DeploymentRow(
             }
         }
     }
+}
+
+// MARK: - 自定义域名
+
+@Composable
+private fun PagesDomainRow(
+    domain: PagesDomain,
+    dnsState: PagesDnsState?,
+    onClick: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+    ) {
+        Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+            StatusDot(domainStatusColor(domain.status), size = 8.dp)
+            Spacer(Modifier.width(10.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    domain.name,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = FontFamily.Monospace,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (dnsState == PagesDnsState.Missing) {
+                    Text(
+                        stringResource(R.string.pages_dns_missing),
+                        fontSize = 12.sp,
+                        color = Color(0xFFC77C00),
+                    )
+                }
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                stringResource(domainStatusLabel(domain.status)),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddDomainDialog(onDismiss: () -> Unit, onAdd: (String) -> Unit) {
+    var name by rememberSaveable { mutableStateOf("") }
+    val trimmed = name.trim().lowercase()
+    val valid = trimmed.contains(".") && !trimmed.contains(" ")
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.pages_domain_add)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(name, { name = it }, label = { Text("example.com") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                Text(stringResource(R.string.pages_domain_add_hint), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onAdd(trimmed) }, enabled = valid) { Text(stringResource(R.string.pages_domain_add)) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.common_cancel)) } },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PagesDomainSheet(
+    domain: PagesDomain,
+    dnsState: PagesDnsState?,
+    cnameTarget: String?,
+    canWrite: Boolean,
+    canWriteDns: Boolean,
+    busy: Boolean,
+    onRetry: () -> Unit,
+    onCreateCname: () -> Unit,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val clipboard = LocalClipboardManager.current
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp).padding(bottom = 32.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(domain.name, fontSize = 17.sp, fontWeight = FontWeight.Bold, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                StatusDot(domainStatusColor(domain.status), size = 8.dp)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(domainStatusLabel(domain.status)), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            val errMsg = domain.verificationData?.errorMessage ?: domain.validationData?.errorMessage
+            if (!errMsg.isNullOrBlank()) {
+                Text(errMsg, fontSize = 12.sp, color = Color(0xFFE5484D))
+            }
+
+            // 归属验证 TXT（zone 不在 CF 时）
+            val validation = domain.validationData
+            if (validation?.method == "txt" && validation.status != "active" &&
+                validation.txtName != null && validation.txtValue != null
+            ) {
+                Text(stringResource(R.string.pages_txt_title), fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+                DomainCopyLine(stringResource(R.string.pages_txt_name), validation.txtName) {
+                    clipboard.setText(AnnotatedString(validation.txtName))
+                }
+                DomainCopyLine(stringResource(R.string.pages_txt_value), validation.txtValue) {
+                    clipboard.setText(AnnotatedString(validation.txtValue))
+                }
+            }
+
+            // DNS 解析
+            cnameTarget?.let { target ->
+                DomainCopyLine("CNAME", target) {
+                    clipboard.setText(AnnotatedString(target))
+                }
+            }
+            when (dnsState) {
+                is PagesDnsState.Resolved ->
+                    Text(stringResource(R.string.pages_dns_resolved), fontSize = 13.sp, color = OcSuccess)
+                is PagesDnsState.Conflicting ->
+                    Text(stringResource(R.string.pages_dns_conflicting) + " · " + dnsState.content, fontSize = 13.sp, color = Color(0xFFC77C00), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                PagesDnsState.Missing -> {
+                    if (canWriteDns) {
+                        Button(
+                            onClick = onCreateCname,
+                            enabled = !busy,
+                            colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text(stringResource(R.string.pages_dns_add_cname)) }
+                    }
+                    cnameTarget?.let {
+                        Text(stringResource(R.string.pages_dns_add_cname_hint, it), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+                PagesDnsState.External ->
+                    Text(stringResource(R.string.pages_dns_external, cnameTarget ?: ""), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                PagesDnsState.Unknown, null -> Unit
+            }
+
+            if (canWrite) {
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    if (domain.status != "active") {
+                        TextButton(onClick = onRetry, enabled = !busy) {
+                            Text(stringResource(R.string.pages_domain_retry), color = OcOrange, fontSize = 13.sp)
+                        }
+                    }
+                    TextButton(onClick = onDelete, enabled = !busy) {
+                        Text(stringResource(R.string.dns_delete), color = Color(0xFFE5484D), fontSize = 13.sp)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DomainCopyLine(label: String, value: String, onCopy: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().clickable(onClick = onCopy)) {
+        Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.width(10.dp))
+        Text(
+            value,
+            fontSize = 12.sp,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            Icons.Outlined.ContentCopy,
+            contentDescription = stringResource(R.string.r2_copy),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(14.dp),
+        )
+    }
+}
+
+private fun domainStatusLabel(status: String?): Int = when (status) {
+    "active" -> R.string.pages_domain_status_active
+    "pending" -> R.string.pages_domain_status_pending
+    "initializing" -> R.string.pages_domain_status_initializing
+    "deactivated" -> R.string.pages_domain_status_deactivated
+    "blocked" -> R.string.pages_domain_status_blocked
+    "error" -> R.string.pages_domain_status_error
+    else -> R.string.pages_status_unknown
+}
+
+private fun domainStatusColor(status: String?): Color = when (status) {
+    "active" -> OcSuccess
+    "pending", "initializing" -> Color(0xFFC77C00)
+    "blocked", "error" -> Color(0xFFE5484D)
+    else -> Color(0xFF8E8E93)
 }
 
 private fun deployStatusLabel(status: String): Int = when (status) {

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesViewModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesViewModels.kt
@@ -6,19 +6,26 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jiamin.chen.orangecloud.core.auth.AuthRepository
 import jiamin.chen.orangecloud.core.auth.Scopes
+import jiamin.chen.orangecloud.core.system.AppPrefs
+import jiamin.chen.orangecloud.core.system.ResourceSort
+import jiamin.chen.orangecloud.data.model.CreateDnsRecord
 import jiamin.chen.orangecloud.data.model.PagesBuildConfig
 import jiamin.chen.orangecloud.data.model.PagesDeployment
+import jiamin.chen.orangecloud.data.model.PagesDomain
 import jiamin.chen.orangecloud.data.model.PagesProject
 import jiamin.chen.orangecloud.data.model.PagesProjectUpdate
 import jiamin.chen.orangecloud.data.repository.AccountStore
+import jiamin.chen.orangecloud.data.repository.DnsRepository
 import jiamin.chen.orangecloud.data.repository.PagesRepository
 import jiamin.chen.orangecloud.ui.storage.StorageListViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,9 +36,18 @@ import javax.inject.Inject
 class PagesListViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val repository: PagesRepository,
+    private val appPrefs: AppPrefs,
     authRepository: AuthRepository,
 ) : StorageListViewModel<PagesProject>(accountStore, authRepository.hasScope(Scopes.PAGES_READ)) {
     val canWrite: Boolean = authRepository.hasScope(Scopes.PAGES_WRITE)
+
+    /** 列表排序偏好（持久化，与 iOS @AppStorage 对应）。 */
+    val sort: StateFlow<ResourceSort> = appPrefs.listSort("pages")
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ResourceSort.NAME)
+
+    fun setSort(sort: ResourceSort) {
+        viewModelScope.launch { appPrefs.setListSort("pages", sort) }
+    }
     private val _busy = MutableStateFlow(false)
     val busy: StateFlow<Boolean> = _busy.asStateFlow()
     private val eventChannel = Channel<String>(Channel.BUFFERED)
@@ -58,22 +74,37 @@ class PagesListViewModel @Inject constructor(
     fun delete(project: PagesProject) = op { repository.deleteProject(it, project.name) }
 }
 
-// MARK: - 项目详情 + 部署
+// MARK: - 项目详情 + 部署 + 自定义域名
 
 sealed interface PagesEvent {
     data object Retried : PagesEvent
     data object RolledBack : PagesEvent
+    data object DomainAdded : PagesEvent
+    data object DomainDeleted : PagesEvent
+    data object CnameCreated : PagesEvent
     data class Error(val message: String?) : PagesEvent
+}
+
+/** 某个自定义域名的 DNS 解析状态（zone 在当前账号内时才可查/可写）。 */
+sealed interface PagesDnsState {
+    data class Resolved(val content: String) : PagesDnsState    // 已有记录指向本项目
+    data class Conflicting(val content: String) : PagesDnsState // 已有解析记录但未指向本项目
+    data object Missing : PagesDnsState                          // 可一键添加 CNAME
+    data object External : PagesDnsState                         // zone 不在当前账号
+    data object Unknown : PagesDnsState                          // 无 dns.read 或查询失败
 }
 
 data class PagesDetailUiState(
     val projectName: String = "",
     val project: PagesProject? = null,
     val deployments: List<PagesDeployment> = emptyList(),
+    val domains: List<PagesDomain> = emptyList(),
+    val dnsStates: Map<String, PagesDnsState> = emptyMap(),   // key = 域名
     val isLoading: Boolean = false,
     val busyDeploymentId: String? = null,
     val missingScope: Boolean = false,
     val canWrite: Boolean = false,
+    val canWriteDns: Boolean = false,
     val hasError: Boolean = false,
 )
 
@@ -82,15 +113,21 @@ class PagesDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val accountStore: AccountStore,
     private val repository: PagesRepository,
+    private val dnsRepository: DnsRepository,
     authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val projectName: String = checkNotNull(savedStateHandle["project"])
     private val hasRead = authRepository.hasScope(Scopes.PAGES_READ)
     private val canWrite = authRepository.hasScope(Scopes.PAGES_WRITE)
+    private val canReadDns = authRepository.hasScope(Scopes.DNS_READ)
+    private val canWriteDns = authRepository.hasScope(Scopes.DNS_WRITE)
 
     private val _uiState = MutableStateFlow(
-        PagesDetailUiState(projectName = projectName, isLoading = hasRead, missingScope = !hasRead, canWrite = canWrite),
+        PagesDetailUiState(
+            projectName = projectName, isLoading = hasRead,
+            missingScope = !hasRead, canWrite = canWrite, canWriteDns = canWriteDns,
+        ),
     )
     val uiState: StateFlow<PagesDetailUiState> = _uiState.asStateFlow()
 
@@ -108,11 +145,92 @@ class PagesDetailViewModel @Inject constructor(
                 val accountId = accountStore.selectedAccountId.value ?: error("no account")
                 val project = repository.getProject(accountId, projectName)
                 val deployments = repository.listDeployments(accountId, projectName)
-                _uiState.update { it.copy(project = project, deployments = deployments) }
+                val domains = runCatching { repository.listDomains(accountId, projectName) }.getOrDefault(emptyList())
+                _uiState.update { it.copy(project = project, deployments = deployments, domains = domains) }
+                refreshDnsStates(project, domains)
             } catch (e: Exception) {
                 _uiState.update { it.copy(hasError = true) }
             } finally {
                 _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    /** 逐域名查解析记录（zone 不在账号内或无权限时标记为不可查/外部）。 */
+    private suspend fun refreshDnsStates(project: PagesProject?, domains: List<PagesDomain>) {
+        val target = project?.subdomain ?: return
+        val states = mutableMapOf<String, PagesDnsState>()
+        for (domain in domains) {
+            val zoneTag = domain.zoneTag
+            states[domain.name] = when {
+                zoneTag.isNullOrEmpty() -> PagesDnsState.External
+                !canReadDns -> PagesDnsState.Unknown
+                else -> runCatching {
+                    val records = dnsRepository.recordsForName(zoneTag, domain.name)
+                        .filter { it.type.uppercase() in setOf("CNAME", "A", "AAAA") }
+                    val hit = records.firstOrNull { it.content.equals(target, ignoreCase = true) }
+                    when {
+                        hit != null -> PagesDnsState.Resolved(hit.content)
+                        records.isNotEmpty() -> PagesDnsState.Conflicting(records.first().content)
+                        else -> PagesDnsState.Missing
+                    }
+                }.getOrDefault(PagesDnsState.Unknown) // zone 可能属于别的账号（403）或临时失败
+            }
+        }
+        _uiState.update { it.copy(dnsStates = states) }
+    }
+
+    // MARK: 自定义域名
+
+    fun addDomain(name: String) = domainOp { accountId ->
+        repository.addDomain(accountId, projectName, name)
+        eventChannel.send(PagesEvent.DomainAdded)
+    }
+
+    fun retryDomain(domain: PagesDomain) = domainOp { accountId ->
+        repository.retryDomain(accountId, projectName, domain.name)
+        eventChannel.send(PagesEvent.Retried)
+    }
+
+    fun deleteDomain(domain: PagesDomain) = domainOp { accountId ->
+        repository.deleteDomain(accountId, projectName, domain.name)
+        eventChannel.send(PagesEvent.DomainDeleted)
+    }
+
+    /** 一键在域名所在 Zone 添加 CNAME → <project>.pages.dev（dns.write）。 */
+    fun createCname(domain: PagesDomain) {
+        val zoneTag = domain.zoneTag ?: return
+        val target = _uiState.value.project?.subdomain ?: return
+        if (!canWriteDns || _uiState.value.busyDeploymentId != null) return
+        _uiState.update { it.copy(busyDeploymentId = "domain") }
+        viewModelScope.launch {
+            try {
+                dnsRepository.createRecord(
+                    zoneTag,
+                    CreateDnsRecord(type = "CNAME", name = domain.name, content = target, proxied = true, ttl = 1),
+                )
+                _uiState.update { it.copy(dnsStates = it.dnsStates + (domain.name to PagesDnsState.Resolved(target))) }
+                eventChannel.send(PagesEvent.CnameCreated)
+            } catch (e: Exception) {
+                eventChannel.send(PagesEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(busyDeploymentId = null) }
+            }
+        }
+    }
+
+    private inline fun domainOp(crossinline action: suspend (String) -> Unit) {
+        if (!canWrite || _uiState.value.busyDeploymentId != null) return
+        _uiState.update { it.copy(busyDeploymentId = "domain") }
+        viewModelScope.launch {
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                action(accountId)
+                load()
+            } catch (e: Exception) {
+                eventChannel.send(PagesEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(busyDeploymentId = null) }
             }
         }
     }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerListScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerListScreen.kt
@@ -43,11 +43,14 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import jiamin.chen.orangecloud.R
+import androidx.compose.runtime.remember
 import jiamin.chen.orangecloud.core.design.SkyBackground
 import jiamin.chen.orangecloud.core.design.SkyEmptyState
 import jiamin.chen.orangecloud.core.design.SkyHeader
+import jiamin.chen.orangecloud.core.design.SortMenuButton
 import jiamin.chen.orangecloud.core.design.onSky
 import jiamin.chen.orangecloud.core.design.rememberSkyPhase
+import jiamin.chen.orangecloud.core.design.sorted
 import jiamin.chen.orangecloud.core.design.theme.OcOrange
 import jiamin.chen.orangecloud.data.model.WorkerScript
 
@@ -58,8 +61,12 @@ fun WorkerListScreen(
     viewModel: WorkerListViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val sort by viewModel.sort.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val sortedWorkers = remember(uiState.workers, sort) {
+        sort.sorted(uiState.workers, created = { it.createdOn }, modified = { it.modifiedOn })
+    }
 
     SkyBackground(phase = phase) {
       Box(Modifier.fillMaxSize()) {
@@ -70,6 +77,11 @@ fun WorkerListScreen(
                 isLoading = uiState.isLoading,
                 onRefresh = { viewModel.refresh() },
                 refreshDescription = stringResource(R.string.common_refresh),
+                actions = {
+                    if (uiState.workers.isNotEmpty()) {
+                        SortMenuButton(sort = sort, onSky = onSky, onSelect = { viewModel.setSort(it) })
+                    }
+                },
             )
 
             when {
@@ -89,7 +101,7 @@ fun WorkerListScreen(
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    items(uiState.workers, key = { it.id }) { worker ->
+                    items(sortedWorkers, key = { it.id }) { worker ->
                         WorkerRow(worker, onClick = { onWorkerClick(worker.id) })
                     }
                 }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerListViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerListViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jiamin.chen.orangecloud.core.auth.AuthRepository
 import jiamin.chen.orangecloud.core.auth.Scopes
+import jiamin.chen.orangecloud.core.system.AppPrefs
+import jiamin.chen.orangecloud.core.system.ResourceSort
 import jiamin.chen.orangecloud.data.model.WorkerScript
 import jiamin.chen.orangecloud.data.repository.AccountStore
 import jiamin.chen.orangecloud.data.repository.WorkerRepository
@@ -35,8 +37,17 @@ data class WorkerListUiState(
 class WorkerListViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val workerRepository: WorkerRepository,
+    private val appPrefs: AppPrefs,
     authRepository: AuthRepository,
 ) : ViewModel() {
+
+    /** 列表排序偏好（持久化，与 iOS @AppStorage 对应）。 */
+    val sort: StateFlow<ResourceSort> = appPrefs.listSort("workers")
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ResourceSort.NAME)
+
+    fun setSort(sort: ResourceSort) {
+        viewModelScope.launch { appPrefs.setListSort("workers", sort) }
+    }
 
     private val hasReadScope = authRepository.hasScope(Scopes.WORKERS_READ)
     private val canWriteScope = authRepository.hasScope(Scopes.WORKERS_WRITE)

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -992,7 +992,7 @@
     <string name="pages_deploy_progress">جارٍ الرفع %1$d / %2$d</string>
     <string name="pages_deployed">تم النشر</string>
     <string name="pages_deploy_empty">لم يُعثر على ملفات قابلة للنشر</string>
-    <string name="pages_deploy_too_big">الملف %1$s يتجاوز حد 25 ميجابايت</string>
+    <string name="pages_deploy_too_big">الملف %1$s يتجاوز حد 25 MB</string>
     <string name="dev_ai_task_other">أخرى</string>
     <string name="dev_ai_info_task">المهمة</string>
     <string name="dev_ai_info_model">النموذج</string>
@@ -1104,4 +1104,34 @@
     <string name="alerting_empty">لا توجد أنواع تنبيهات لهذا الحساب.</string>
     <string name="perm_notifications">الإشعارات</string>
     <string name="perm_notifications_desc">ادفع تنبيهات Cloudflare إلى جهازك</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">نطاقات مخصصة</string>
+    <string name="pages_domain_add">إضافة نطاق</string>
+    <string name="pages_domain_add_hint">بعد الإضافة، وجِّه DNS النطاق إلى هذا المشروع ليصبح ساريًا.</string>
+    <string name="pages_domain_empty">لا توجد نطاقات مخصصة</string>
+    <string name="pages_domain_delete_title">حذف النطاق؟</string>
+    <string name="pages_domain_delete_msg">ستتم إزالة %1$s من مشروع Pages هذا، دون التأثير على سجلات DNS الحالية.</string>
+    <string name="pages_domain_retry">إعادة التحقق</string>
+    <string name="pages_domain_added">تمت إضافة النطاق</string>
+    <string name="pages_domain_deleted">تم حذف النطاق</string>
+    <string name="pages_cname_created">تمت إضافة سجل CNAME</string>
+    <string name="pages_domain_status_active">نشط</string>
+    <string name="pages_domain_status_pending">قيد التحقق</string>
+    <string name="pages_domain_status_initializing">قيد التهيئة</string>
+    <string name="pages_domain_status_deactivated">معطَّل</string>
+    <string name="pages_domain_status_blocked">محظور</string>
+    <string name="pages_domain_status_error">خطأ</string>
+    <string name="pages_txt_title">سجل TXT للتحقق</string>
+    <string name="pages_txt_name">اسم السجل</string>
+    <string name="pages_txt_value">قيمة السجل</string>
+    <string name="pages_dns_resolved">يشير إلى هذا المشروع</string>
+    <string name="pages_dns_conflicting">لا يشير إلى هذا المشروع</string>
+    <string name="pages_dns_missing">لا يوجد سجل DNS بعد</string>
+    <string name="pages_dns_add_cname">إضافة سجل CNAME</string>
+    <string name="pages_dns_add_cname_hint">سيُضاف سجل CNAME مفعَّل الوكيل يشير إلى %1$s في منطقة النطاق.</string>
+    <string name="pages_dns_external">هذا النطاق ليس ضمن منطقة Cloudflare في هذا الحساب. أضِف سجل CNAME يشير إلى %1$s لدى مزوِّد DNS الخاص بك.</string>
+    <string name="sort_label">الترتيب</string>
+    <string name="sort_default">افتراضي (الاسم)</string>
+    <string name="sort_created">تاريخ الإنشاء</string>
+    <string name="sort_modified">آخر تحديث</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ar/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ar/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">نطاقات Pages المخصصة</string>
+    <string name="whatsnew_1_6_0_0_detail">أدر النطاقات المخصصة داخل مشروع Pages مباشرة: إضافة وحذف وإعادة تحقق وفحص حالة DNS — مع إضافة سجل CNAME بلمسة واحدة عندما تكون منطقة النطاق ضمن حسابك.</string>
+    <string name="whatsnew_1_6_0_1_title">ترتيب القوائم</string>
+    <string name="whatsnew_1_6_0_1_detail">يمكن الآن ترتيب قوائم Workers و Pages حسب الاسم (افتراضي) أو تاريخ الإنشاء أو آخر تحديث — ويُحفظ اختيارك.</string>
     <string name="whatsnew_1_5_0_0_title">صندوق أدوات المطوّر بدون تسجيل دخول</string>
     <string name="whatsnew_1_5_0_0_detail">مجموعة من أدوات الشبكة العملية التي يمكنك استخدامها دون تسجيل الدخول: استعلام DNS، فحص شهادة SSL، ترويسات HTTP، WHOIS، تحديد موقع IP، حاسبة CIDR، وCloudflare trace — يمكن الوصول إليها مباشرةً من شاشة تسجيل الدخول.</string>
     <string name="whatsnew_1_5_0_1_title">مركز الإشعارات</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -1104,4 +1104,34 @@
     <string name="alerting_empty">Keine Warnungstypen für dieses Konto.</string>
     <string name="perm_notifications">Benachrichtigungen</string>
     <string name="perm_notifications_desc">Cloudflare-Warnungen aufs Gerät senden</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Benutzerdefinierte Domains</string>
+    <string name="pages_domain_add">Domain hinzufügen</string>
+    <string name="pages_domain_add_hint">Nach dem Hinzufügen muss der DNS-Eintrag der Domain auf dieses Projekt zeigen.</string>
+    <string name="pages_domain_empty">Keine benutzerdefinierten Domains</string>
+    <string name="pages_domain_delete_title">Domain löschen?</string>
+    <string name="pages_domain_delete_msg">%1$s wird aus diesem Pages-Projekt entfernt. Bestehende DNS-Einträge bleiben unberührt.</string>
+    <string name="pages_domain_retry">Erneut validieren</string>
+    <string name="pages_domain_added">Domain hinzugefügt</string>
+    <string name="pages_domain_deleted">Domain gelöscht</string>
+    <string name="pages_cname_created">CNAME-Eintrag hinzugefügt</string>
+    <string name="pages_domain_status_active">Aktiv</string>
+    <string name="pages_domain_status_pending">Wird überprüft</string>
+    <string name="pages_domain_status_initializing">Initialisierung</string>
+    <string name="pages_domain_status_deactivated">Deaktiviert</string>
+    <string name="pages_domain_status_blocked">Blockiert</string>
+    <string name="pages_domain_status_error">Fehler</string>
+    <string name="pages_txt_title">TXT-Eintrag zur Verifizierung</string>
+    <string name="pages_txt_name">Eintragsname</string>
+    <string name="pages_txt_value">Eintragswert</string>
+    <string name="pages_dns_resolved">Zeigt auf dieses Projekt</string>
+    <string name="pages_dns_conflicting">Zeigt nicht auf dieses Projekt</string>
+    <string name="pages_dns_missing">Noch kein DNS-Eintrag</string>
+    <string name="pages_dns_add_cname">CNAME-Eintrag hinzufügen</string>
+    <string name="pages_dns_add_cname_hint">In der Zone der Domain wird ein Proxy-CNAME-Eintrag hinzugefügt, der auf %1$s zeigt.</string>
+    <string name="pages_dns_external">Diese Domain liegt in keiner Cloudflare-Zone dieses Kontos. Fügen Sie bei Ihrem DNS-Anbieter einen CNAME-Eintrag hinzu, der auf %1$s zeigt.</string>
+    <string name="sort_label">Sortieren</string>
+    <string name="sort_default">Standard (Name)</string>
+    <string name="sort_created">Erstellungsdatum</string>
+    <string name="sort_modified">Zuletzt aktualisiert</string>
 </resources>

--- a/apps/android/app/src/main/res/values-de/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-de/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Benutzerdefinierte Domains für Pages</string>
+    <string name="whatsnew_1_6_0_0_detail">Verwalte benutzerdefinierte Domains direkt im Pages-Projekt: hinzufügen, entfernen, erneut validieren und DNS-Status prüfen – mit Ein-Tipp-CNAME, wenn die Zone der Domain in deinem Konto liegt.</string>
+    <string name="whatsnew_1_6_0_1_title">Listensortierung</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers- und Pages-Listen lassen sich jetzt nach Name (Standard), Erstellungsdatum oder letzter Aktualisierung sortieren – die Auswahl wird gemerkt.</string>
     <string name="whatsnew_1_5_0_0_title">Entwickler-Toolbox ohne Anmeldung</string>
     <string name="whatsnew_1_5_0_0_detail">Praktische Netzwerk-Tools, die du ohne Anmeldung nutzen kannst: DNS-Abfrage, SSL-Zertifikatsprüfung, HTTP-Header, WHOIS, IP-Geolokalisierung, ein CIDR-Rechner und Cloudflare-Trace – direkt vom Anmeldebildschirm aus erreichbar.</string>
     <string name="whatsnew_1_5_0_1_title">Push-Center</string>

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -1167,4 +1167,34 @@
     <string name="alerting_empty">No alert types available for this account.</string>
     <string name="perm_notifications">Notifications</string>
     <string name="perm_notifications_desc">Push Cloudflare alerts to your device</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Custom domains</string>
+    <string name="pages_domain_add">Add domain</string>
+    <string name="pages_domain_add_hint">After attaching, point the domain\'s DNS at this project for it to take effect.</string>
+    <string name="pages_domain_empty">No custom domains</string>
+    <string name="pages_domain_delete_title">Delete domain?</string>
+    <string name="pages_domain_delete_msg">%1$s will be removed from this Pages project. Existing DNS records are not affected.</string>
+    <string name="pages_domain_retry">Re-validate</string>
+    <string name="pages_domain_added">Domain added</string>
+    <string name="pages_domain_deleted">Domain deleted</string>
+    <string name="pages_cname_created">CNAME record added</string>
+    <string name="pages_domain_status_active">Active</string>
+    <string name="pages_domain_status_pending">Verifying</string>
+    <string name="pages_domain_status_initializing">Initializing</string>
+    <string name="pages_domain_status_deactivated">Deactivated</string>
+    <string name="pages_domain_status_blocked">Blocked</string>
+    <string name="pages_domain_status_error">Error</string>
+    <string name="pages_txt_title">Verification TXT record</string>
+    <string name="pages_txt_name">Record name</string>
+    <string name="pages_txt_value">Record value</string>
+    <string name="pages_dns_resolved">Pointing at this project</string>
+    <string name="pages_dns_conflicting">Not pointing at this project</string>
+    <string name="pages_dns_missing">No DNS record yet</string>
+    <string name="pages_dns_add_cname">Add CNAME record</string>
+    <string name="pages_dns_add_cname_hint">A proxied CNAME record pointing at %1$s will be added in the domain\'s zone.</string>
+    <string name="pages_dns_external">This domain isn\'t in a Cloudflare zone on this account. Add a CNAME record pointing at %1$s at your DNS provider.</string>
+    <string name="sort_label">Sort</string>
+    <string name="sort_default">Default (name)</string>
+    <string name="sort_created">Date created</string>
+    <string name="sort_modified">Recently updated</string>
 </resources>

--- a/apps/android/app/src/main/res/values-en/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-en/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages custom domains</string>
+    <string name="whatsnew_1_6_0_0_detail">Manage custom domains right inside a Pages project: add, remove, re-validate, and check DNS status — with one-tap CNAME setup when the domain’s zone is on your account.</string>
+    <string name="whatsnew_1_6_0_1_title">List sorting</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers and Pages lists can now be sorted by name (default), date created, or recently updated — your choice is remembered.</string>
     <string name="whatsnew_1_5_0_0_title">No-login developer toolbox</string>
     <string name="whatsnew_1_5_0_0_detail">A set of handy network tools you can use without signing in: DNS lookup, SSL certificate inspection, HTTP headers, WHOIS, IP geolocation, a CIDR calculator and Cloudflare trace — reachable right from the login screen.</string>
     <string name="whatsnew_1_5_0_1_title">Push Center</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -1144,4 +1144,34 @@
     <string name="alerting_empty">No hay tipos de alerta para esta cuenta.</string>
     <string name="perm_notifications">Notificaciones</string>
     <string name="perm_notifications_desc">Envía alertas de Cloudflare a tu dispositivo</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Dominios personalizados</string>
+    <string name="pages_domain_add">Agregar dominio</string>
+    <string name="pages_domain_add_hint">Después de agregarlo, apunta el DNS del dominio a este proyecto para que surta efecto.</string>
+    <string name="pages_domain_empty">No hay dominios personalizados</string>
+    <string name="pages_domain_delete_title">¿Eliminar dominio?</string>
+    <string name="pages_domain_delete_msg">Se quitará %1$s de este proyecto de Pages. Los registros DNS existentes no se verán afectados.</string>
+    <string name="pages_domain_retry">Volver a validar</string>
+    <string name="pages_domain_added">Dominio agregado</string>
+    <string name="pages_domain_deleted">Dominio eliminado</string>
+    <string name="pages_cname_created">Registro CNAME agregado</string>
+    <string name="pages_domain_status_active">Activo</string>
+    <string name="pages_domain_status_pending">Verificando</string>
+    <string name="pages_domain_status_initializing">Inicializando</string>
+    <string name="pages_domain_status_deactivated">Desactivado</string>
+    <string name="pages_domain_status_blocked">Bloqueado</string>
+    <string name="pages_domain_status_error">Error</string>
+    <string name="pages_txt_title">Registro TXT de verificación</string>
+    <string name="pages_txt_name">Nombre del registro</string>
+    <string name="pages_txt_value">Valor del registro</string>
+    <string name="pages_dns_resolved">Apunta a este proyecto</string>
+    <string name="pages_dns_conflicting">No apunta a este proyecto</string>
+    <string name="pages_dns_missing">Aún no hay registro DNS</string>
+    <string name="pages_dns_add_cname">Agregar registro CNAME</string>
+    <string name="pages_dns_add_cname_hint">Se agregará un registro CNAME con proxy que apunta a %1$s en la zona del dominio.</string>
+    <string name="pages_dns_external">Este dominio no está en una zona de Cloudflare de esta cuenta. Agrega un registro CNAME que apunte a %1$s en tu proveedor de DNS.</string>
+    <string name="sort_label">Ordenar</string>
+    <string name="sort_default">Predeterminado (nombre)</string>
+    <string name="sort_created">Fecha de creación</string>
+    <string name="sort_modified">Actualización reciente</string>
 </resources>

--- a/apps/android/app/src/main/res/values-es/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-es/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Dominios personalizados de Pages</string>
+    <string name="whatsnew_1_6_0_0_detail">Administra dominios personalizados dentro de un proyecto de Pages: agregar, eliminar, revalidar y comprobar el estado del DNS; si la zona del dominio está en tu cuenta, agrega el registro CNAME con un toque.</string>
+    <string name="whatsnew_1_6_0_1_title">Orden de listas</string>
+    <string name="whatsnew_1_6_0_1_detail">Las listas de Workers y Pages ahora se pueden ordenar por nombre (predeterminado), fecha de creación o actualización reciente; tu elección se recuerda.</string>
     <string name="whatsnew_1_5_0_0_title">Caja de herramientas para desarrolladores sin iniciar sesión</string>
     <string name="whatsnew_1_5_0_0_detail">Un conjunto de herramientas de red prácticas que puedes usar sin iniciar sesión: consulta DNS, inspección de certificados SSL, encabezados HTTP, WHOIS, geolocalización de IP, calculadora CIDR y Cloudflare trace, accesibles desde la pantalla de inicio de sesión.</string>
     <string name="whatsnew_1_5_0_1_title">Centro de notificaciones</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -992,7 +992,7 @@
     <string name="pages_deploy_progress">Téléversement %1$d / %2$d</string>
     <string name="pages_deployed">Déployé</string>
     <string name="pages_deploy_empty">Aucun fichier déployable trouvé</string>
-    <string name="pages_deploy_too_big">Le fichier %1$s dépasse la limite de 25 Mo</string>
+    <string name="pages_deploy_too_big">Le fichier %1$s dépasse la limite de 25 MB</string>
     <string name="dev_ai_task_other">Autres</string>
     <string name="dev_ai_info_task">Tâche</string>
     <string name="dev_ai_info_model">Modèle</string>
@@ -1104,4 +1104,34 @@
     <string name="alerting_empty">Aucun type d\'alerte pour ce compte.</string>
     <string name="perm_notifications">Notifications</string>
     <string name="perm_notifications_desc">Envoyez les alertes Cloudflare à votre appareil</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Domaines personnalisés</string>
+    <string name="pages_domain_add">Ajouter un domaine</string>
+    <string name="pages_domain_add_hint">Après l\'ajout, faites pointer le DNS du domaine vers ce projet pour qu\'il prenne effet.</string>
+    <string name="pages_domain_empty">Aucun domaine personnalisé</string>
+    <string name="pages_domain_delete_title">Supprimer le domaine ?</string>
+    <string name="pages_domain_delete_msg">%1$s sera retiré de ce projet Pages. Les enregistrements DNS existants ne sont pas affectés.</string>
+    <string name="pages_domain_retry">Revalider</string>
+    <string name="pages_domain_added">Domaine ajouté</string>
+    <string name="pages_domain_deleted">Domaine supprimé</string>
+    <string name="pages_cname_created">Enregistrement CNAME ajouté</string>
+    <string name="pages_domain_status_active">Actif</string>
+    <string name="pages_domain_status_pending">Vérification</string>
+    <string name="pages_domain_status_initializing">Initialisation</string>
+    <string name="pages_domain_status_deactivated">Désactivé</string>
+    <string name="pages_domain_status_blocked">Bloqué</string>
+    <string name="pages_domain_status_error">Erreur</string>
+    <string name="pages_txt_title">Enregistrement TXT de vérification</string>
+    <string name="pages_txt_name">Nom de l\'enregistrement</string>
+    <string name="pages_txt_value">Valeur de l\'enregistrement</string>
+    <string name="pages_dns_resolved">Pointe vers ce projet</string>
+    <string name="pages_dns_conflicting">Ne pointe pas vers ce projet</string>
+    <string name="pages_dns_missing">Pas encore d\'enregistrement DNS</string>
+    <string name="pages_dns_add_cname">Ajouter un enregistrement CNAME</string>
+    <string name="pages_dns_add_cname_hint">Un enregistrement CNAME proxifié pointant vers %1$s sera ajouté dans la zone du domaine.</string>
+    <string name="pages_dns_external">Ce domaine n\'est pas dans une zone Cloudflare de ce compte. Ajoutez un enregistrement CNAME pointant vers %1$s chez votre fournisseur DNS.</string>
+    <string name="sort_label">Trier</string>
+    <string name="sort_default">Par défaut (nom)</string>
+    <string name="sort_created">Date de création</string>
+    <string name="sort_modified">Mise à jour récente</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-fr/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Domaines personnalisés Pages</string>
+    <string name="whatsnew_1_6_0_0_detail">Gérez les domaines personnalisés directement dans un projet Pages : ajout, suppression, revalidation et vérification du DNS — avec création du CNAME en un geste quand la zone du domaine est sur votre compte.</string>
+    <string name="whatsnew_1_6_0_1_title">Tri des listes</string>
+    <string name="whatsnew_1_6_0_1_detail">Les listes Workers et Pages peuvent désormais être triées par nom (par défaut), date de création ou mise à jour récente — votre choix est mémorisé.</string>
     <string name="whatsnew_1_5_0_0_title">Boîte à outils développeur sans connexion</string>
     <string name="whatsnew_1_5_0_0_detail">Un ensemble d\'outils réseau pratiques utilisables sans connexion : requête DNS, inspection de certificat SSL, en-têtes HTTP, WHOIS, géolocalisation IP, calculateur CIDR et Cloudflare trace — accessibles depuis l\'écran de connexion.</string>
     <string name="whatsnew_1_5_0_1_title">Centre de push</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -1143,4 +1143,34 @@
     <string name="alerting_empty">このアカウントに利用可能なアラートがありません。</string>
     <string name="perm_notifications">通知</string>
     <string name="perm_notifications_desc">Cloudflare のアラートを端末に通知</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">カスタムドメイン</string>
+    <string name="pages_domain_add">ドメインを追加</string>
+    <string name="pages_domain_add_hint">追加後、ドメインの DNS をこのプロジェクトに向けると有効になります。</string>
+    <string name="pages_domain_empty">カスタムドメインはありません</string>
+    <string name="pages_domain_delete_title">ドメインを削除しますか？</string>
+    <string name="pages_domain_delete_msg">%1$s をこの Pages プロジェクトから削除します。既存の DNS レコードには影響しません。</string>
+    <string name="pages_domain_retry">再検証</string>
+    <string name="pages_domain_added">ドメインを追加しました</string>
+    <string name="pages_domain_deleted">ドメインを削除しました</string>
+    <string name="pages_cname_created">CNAME レコードを追加しました</string>
+    <string name="pages_domain_status_active">有効</string>
+    <string name="pages_domain_status_pending">検証中</string>
+    <string name="pages_domain_status_initializing">初期化中</string>
+    <string name="pages_domain_status_deactivated">無効化済み</string>
+    <string name="pages_domain_status_blocked">ブロック済み</string>
+    <string name="pages_domain_status_error">エラー</string>
+    <string name="pages_txt_title">検証用 TXT レコード</string>
+    <string name="pages_txt_name">レコード名</string>
+    <string name="pages_txt_value">レコード値</string>
+    <string name="pages_dns_resolved">このプロジェクトを指しています</string>
+    <string name="pages_dns_conflicting">このプロジェクトを指していません</string>
+    <string name="pages_dns_missing">DNS レコードがありません</string>
+    <string name="pages_dns_add_cname">CNAME レコードを追加</string>
+    <string name="pages_dns_add_cname_hint">ドメインのゾーンに %1$s を指すプロキシ済み CNAME レコードを追加します。</string>
+    <string name="pages_dns_external">このドメインは現在のアカウントの Cloudflare ゾーンにありません。DNS プロバイダーで %1$s を指す CNAME レコードを追加してください。</string>
+    <string name="sort_label">並べ替え</string>
+    <string name="sort_default">デフォルト（名前）</string>
+    <string name="sort_created">作成日</string>
+    <string name="sort_modified">最近の更新</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ja/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ja/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages カスタムドメイン</string>
+    <string name="whatsnew_1_6_0_0_detail">Pages プロジェクト内でカスタムドメインを直接管理：追加・削除・再検証と DNS 状態の確認に対応。ドメインが現在のアカウントにある場合は、プロジェクトへ向ける CNAME レコードをワンタップで追加できます。</string>
+    <string name="whatsnew_1_6_0_1_title">リストの並べ替え</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers と Pages のリストを名前（デフォルト）・作成日・最近の更新で並べ替えられるようになりました。選択は記憶されます。</string>
     <string name="whatsnew_1_5_0_0_title">ログイン不要の開発者ツールボックス</string>
     <string name="whatsnew_1_5_0_0_detail">ログインせずに使える定番のネットワークツール群：DNS 検索、SSL 証明書チェック、HTTP ヘッダー、WHOIS、IP 位置情報、CIDR 計算、Cloudflare trace。ログイン画面からそのまま開けます。</string>
     <string name="whatsnew_1_5_0_1_title">プッシュセンター</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -1143,4 +1143,34 @@
     <string name="alerting_empty">이 계정에 사용 가능한 알림 유형이 없습니다.</string>
     <string name="perm_notifications">알림</string>
     <string name="perm_notifications_desc">Cloudflare 알림을 기기로 푸시</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">사용자 지정 도메인</string>
+    <string name="pages_domain_add">도메인 추가</string>
+    <string name="pages_domain_add_hint">추가한 후 도메인 DNS를 이 프로젝트로 지정해야 적용됩니다.</string>
+    <string name="pages_domain_empty">사용자 지정 도메인이 없습니다</string>
+    <string name="pages_domain_delete_title">도메인을 삭제할까요?</string>
+    <string name="pages_domain_delete_msg">이 Pages 프로젝트에서 %1$s을(를) 제거합니다. 기존 DNS 레코드에는 영향이 없습니다.</string>
+    <string name="pages_domain_retry">다시 확인</string>
+    <string name="pages_domain_added">도메인이 추가되었습니다</string>
+    <string name="pages_domain_deleted">도메인이 삭제되었습니다</string>
+    <string name="pages_cname_created">CNAME 레코드가 추가되었습니다</string>
+    <string name="pages_domain_status_active">활성</string>
+    <string name="pages_domain_status_pending">확인 중</string>
+    <string name="pages_domain_status_initializing">초기화 중</string>
+    <string name="pages_domain_status_deactivated">비활성화됨</string>
+    <string name="pages_domain_status_blocked">차단됨</string>
+    <string name="pages_domain_status_error">오류</string>
+    <string name="pages_txt_title">확인용 TXT 레코드</string>
+    <string name="pages_txt_name">레코드 이름</string>
+    <string name="pages_txt_value">레코드 값</string>
+    <string name="pages_dns_resolved">이 프로젝트를 가리키고 있음</string>
+    <string name="pages_dns_conflicting">이 프로젝트를 가리키지 않음</string>
+    <string name="pages_dns_missing">DNS 레코드가 없음</string>
+    <string name="pages_dns_add_cname">CNAME 레코드 추가</string>
+    <string name="pages_dns_add_cname_hint">도메인 영역에 %1$s을(를) 가리키는 프록시된 CNAME 레코드를 추가합니다.</string>
+    <string name="pages_dns_external">이 도메인은 현재 계정의 Cloudflare 영역에 없습니다. DNS 공급업체에서 %1$s을(를) 가리키는 CNAME 레코드를 추가하세요.</string>
+    <string name="sort_label">정렬</string>
+    <string name="sort_default">기본(이름)</string>
+    <string name="sort_created">생성일</string>
+    <string name="sort_modified">최근 업데이트</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ko/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages 사용자 지정 도메인</string>
+    <string name="whatsnew_1_6_0_0_detail">Pages 프로젝트에서 사용자 지정 도메인을 직접 관리하세요: 추가·삭제·재확인과 DNS 상태 확인을 지원하며, 도메인이 현재 계정에 있으면 프로젝트를 가리키는 CNAME 레코드를 한 번에 추가할 수 있습니다.</string>
+    <string name="whatsnew_1_6_0_1_title">목록 정렬</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers와 Pages 목록을 이름(기본), 생성일, 최근 업데이트로 정렬할 수 있습니다. 선택은 기억됩니다.</string>
     <string name="whatsnew_1_5_0_0_title">로그인 없는 개발자 도구 모음</string>
     <string name="whatsnew_1_5_0_0_detail">로그인 없이 사용할 수 있는 유용한 네트워크 도구 모음: DNS 조회, SSL 인증서 검사, HTTP 헤더, WHOIS, IP 위치, CIDR 계산기, Cloudflare trace. 로그인 화면에서 바로 열 수 있습니다.</string>
     <string name="whatsnew_1_5_0_1_title">푸시 센터</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1143,4 +1143,34 @@
     <string name="alerting_empty">Nenhum tipo de alerta disponível para esta conta.</string>
     <string name="perm_notifications">Notificações</string>
     <string name="perm_notifications_desc">Envie alertas da Cloudflare ao dispositivo</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Domínios personalizados</string>
+    <string name="pages_domain_add">Adicionar domínio</string>
+    <string name="pages_domain_add_hint">Depois de adicionar, aponte o DNS do domínio para este projeto para que tenha efeito.</string>
+    <string name="pages_domain_empty">Nenhum domínio personalizado</string>
+    <string name="pages_domain_delete_title">Excluir domínio?</string>
+    <string name="pages_domain_delete_msg">%1$s será removido deste projeto do Pages. Os registros DNS existentes não serão afetados.</string>
+    <string name="pages_domain_retry">Validar novamente</string>
+    <string name="pages_domain_added">Domínio adicionado</string>
+    <string name="pages_domain_deleted">Domínio excluído</string>
+    <string name="pages_cname_created">Registro CNAME adicionado</string>
+    <string name="pages_domain_status_active">Ativo</string>
+    <string name="pages_domain_status_pending">Verificando</string>
+    <string name="pages_domain_status_initializing">Inicializando</string>
+    <string name="pages_domain_status_deactivated">Desativado</string>
+    <string name="pages_domain_status_blocked">Bloqueado</string>
+    <string name="pages_domain_status_error">Erro</string>
+    <string name="pages_txt_title">Registro TXT de verificação</string>
+    <string name="pages_txt_name">Nome do registro</string>
+    <string name="pages_txt_value">Valor do registro</string>
+    <string name="pages_dns_resolved">Apontando para este projeto</string>
+    <string name="pages_dns_conflicting">Não aponta para este projeto</string>
+    <string name="pages_dns_missing">Ainda não há registro DNS</string>
+    <string name="pages_dns_add_cname">Adicionar registro CNAME</string>
+    <string name="pages_dns_add_cname_hint">Um registro CNAME com proxy apontando para %1$s será adicionado na zona do domínio.</string>
+    <string name="pages_dns_external">Este domínio não está em uma zona do Cloudflare desta conta. Adicione um registro CNAME apontando para %1$s no seu provedor de DNS.</string>
+    <string name="sort_label">Ordenar</string>
+    <string name="sort_default">Padrão (nome)</string>
+    <string name="sort_created">Data de criação</string>
+    <string name="sort_modified">Atualização recente</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Domínios personalizados do Pages</string>
+    <string name="whatsnew_1_6_0_0_detail">Gerencie domínios personalizados dentro de um projeto do Pages: adicionar, remover, revalidar e verificar o status do DNS — com criação do registro CNAME em um toque quando a zona do domínio está na sua conta.</string>
+    <string name="whatsnew_1_6_0_1_title">Ordenação de listas</string>
+    <string name="whatsnew_1_6_0_1_detail">As listas de Workers e Pages agora podem ser ordenadas por nome (padrão), data de criação ou atualização recente — sua escolha é lembrada.</string>
     <string name="whatsnew_1_5_0_0_title">Caixa de ferramentas do desenvolvedor sem login</string>
     <string name="whatsnew_1_5_0_0_detail">Um conjunto de ferramentas de rede úteis que você pode usar sem fazer login: consulta DNS, inspeção de certificado SSL, cabeçalhos HTTP, WHOIS, geolocalização de IP, calculadora CIDR e Cloudflare trace — acessíveis direto na tela de login.</string>
     <string name="whatsnew_1_5_0_1_title">Central de Push</string>

--- a/apps/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1144,4 +1144,34 @@
     <string name="alerting_empty">Nenhum tipo de alerta disponível para esta conta.</string>
     <string name="perm_notifications">Notificações</string>
     <string name="perm_notifications_desc">Envie alertas da Cloudflare ao dispositivo</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Domínios personalizados</string>
+    <string name="pages_domain_add">Adicionar domínio</string>
+    <string name="pages_domain_add_hint">Depois de adicionar, aponte o DNS do domínio para este projeto para que produza efeito.</string>
+    <string name="pages_domain_empty">Nenhum domínio personalizado</string>
+    <string name="pages_domain_delete_title">Eliminar domínio?</string>
+    <string name="pages_domain_delete_msg">%1$s será removido deste projeto do Pages. Os registos DNS existentes não serão afetados.</string>
+    <string name="pages_domain_retry">Validar novamente</string>
+    <string name="pages_domain_added">Domínio adicionado</string>
+    <string name="pages_domain_deleted">Domínio eliminado</string>
+    <string name="pages_cname_created">Registo CNAME adicionado</string>
+    <string name="pages_domain_status_active">Ativo</string>
+    <string name="pages_domain_status_pending">A verificar</string>
+    <string name="pages_domain_status_initializing">A inicializar</string>
+    <string name="pages_domain_status_deactivated">Desativado</string>
+    <string name="pages_domain_status_blocked">Bloqueado</string>
+    <string name="pages_domain_status_error">Erro</string>
+    <string name="pages_txt_title">Registo TXT de verificação</string>
+    <string name="pages_txt_name">Nome do registo</string>
+    <string name="pages_txt_value">Valor do registo</string>
+    <string name="pages_dns_resolved">A apontar para este projeto</string>
+    <string name="pages_dns_conflicting">Não aponta para este projeto</string>
+    <string name="pages_dns_missing">Ainda não há registo DNS</string>
+    <string name="pages_dns_add_cname">Adicionar registo CNAME</string>
+    <string name="pages_dns_add_cname_hint">Será adicionado na zona do domínio um registo CNAME com proxy a apontar para %1$s.</string>
+    <string name="pages_dns_external">Este domínio não está numa zona do Cloudflare desta conta. Adicione no seu fornecedor de DNS um registo CNAME a apontar para %1$s.</string>
+    <string name="sort_label">Ordenar</string>
+    <string name="sort_default">Predefinição (nome)</string>
+    <string name="sort_created">Data de criação</string>
+    <string name="sort_modified">Atualização recente</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Domínios personalizados do Pages</string>
+    <string name="whatsnew_1_6_0_0_detail">Faça a gestão de domínios personalizados dentro de um projeto do Pages: adicionar, remover, revalidar e verificar o estado do DNS — com criação do registo CNAME num toque quando a zona do domínio está na sua conta.</string>
+    <string name="whatsnew_1_6_0_1_title">Ordenação de listas</string>
+    <string name="whatsnew_1_6_0_1_detail">As listas de Workers e Pages podem agora ser ordenadas por nome (predefinição), data de criação ou atualização recente — a sua escolha é lembrada.</string>
     <string name="whatsnew_1_5_0_0_title">Caixa de ferramentas do programador sem início de sessão</string>
     <string name="whatsnew_1_5_0_0_detail">Um conjunto de ferramentas de rede úteis que pode usar sem iniciar sessão: consulta DNS, inspeção de certificado SSL, cabeçalhos HTTP, WHOIS, geolocalização de IP, calculadora CIDR e Cloudflare trace — acessíveis a partir do ecrã de início de sessão.</string>
     <string name="whatsnew_1_5_0_1_title">Centro de Push</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -1104,4 +1104,34 @@
     <string name="alerting_empty">Bu hesap için uyarı türü yok.</string>
     <string name="perm_notifications">Bildirimler</string>
     <string name="perm_notifications_desc">Cloudflare uyarılarını cihazınıza gönderin</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">Özel alan adları</string>
+    <string name="pages_domain_add">Alan adı ekle</string>
+    <string name="pages_domain_add_hint">Ekledikten sonra alan adının DNS\'ini bu projeye yönlendirin.</string>
+    <string name="pages_domain_empty">Özel alan adı yok</string>
+    <string name="pages_domain_delete_title">Alan adı silinsin mi?</string>
+    <string name="pages_domain_delete_msg">%1$s bu Pages projesinden kaldırılacak. Mevcut DNS kayıtları etkilenmez.</string>
+    <string name="pages_domain_retry">Yeniden doğrula</string>
+    <string name="pages_domain_added">Alan adı eklendi</string>
+    <string name="pages_domain_deleted">Alan adı silindi</string>
+    <string name="pages_cname_created">CNAME kaydı eklendi</string>
+    <string name="pages_domain_status_active">Etkin</string>
+    <string name="pages_domain_status_pending">Doğrulanıyor</string>
+    <string name="pages_domain_status_initializing">Başlatılıyor</string>
+    <string name="pages_domain_status_deactivated">Devre dışı</string>
+    <string name="pages_domain_status_blocked">Engellendi</string>
+    <string name="pages_domain_status_error">Hata</string>
+    <string name="pages_txt_title">Doğrulama TXT kaydı</string>
+    <string name="pages_txt_name">Kayıt adı</string>
+    <string name="pages_txt_value">Kayıt değeri</string>
+    <string name="pages_dns_resolved">Bu projeye yönlendirilmiş</string>
+    <string name="pages_dns_conflicting">Bu projeye yönlendirilmemiş</string>
+    <string name="pages_dns_missing">Henüz DNS kaydı yok</string>
+    <string name="pages_dns_add_cname">CNAME kaydı ekle</string>
+    <string name="pages_dns_add_cname_hint">Alan adının bölgesine %1$s adresini gösteren proxy\'li bir CNAME kaydı eklenecek.</string>
+    <string name="pages_dns_external">Bu alan adı bu hesaptaki bir Cloudflare bölgesinde değil. DNS sağlayıcınızda %1$s adresini gösteren bir CNAME kaydı ekleyin.</string>
+    <string name="sort_label">Sırala</string>
+    <string name="sort_default">Varsayılan (ad)</string>
+    <string name="sort_created">Oluşturma tarihi</string>
+    <string name="sort_modified">Son güncelleme</string>
 </resources>

--- a/apps/android/app/src/main/res/values-tr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-tr/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages özel alan adları</string>
+    <string name="whatsnew_1_6_0_0_detail">Özel alan adlarını doğrudan Pages projesi içinde yönetin: ekleme, silme, yeniden doğrulama ve DNS durumu kontrolü — alan adının bölgesi hesabınızdaysa tek dokunuşla CNAME kaydı ekleyin.</string>
+    <string name="whatsnew_1_6_0_1_title">Liste sıralama</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers ve Pages listeleri artık ada (varsayılan), oluşturma tarihine veya son güncellemeye göre sıralanabilir; seçiminiz hatırlanır.</string>
     <string name="whatsnew_1_5_0_0_title">Girişsiz geliştirici araç kutusu</string>
     <string name="whatsnew_1_5_0_0_detail">Oturum açmadan kullanabileceğiniz pratik ağ araçları: DNS sorgusu, SSL sertifikası incelemesi, HTTP başlıkları, WHOIS, IP konumu, CIDR hesaplayıcı ve Cloudflare trace — giriş ekranından doğrudan erişilebilir.</string>
     <string name="whatsnew_1_5_0_1_title">Push Merkezi</string>

--- a/apps/android/app/src/main/res/values-zh-rHK/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/strings.xml
@@ -1143,4 +1143,34 @@
     <string name="alerting_empty">此帳戶暫無可用告警類型。</string>
     <string name="perm_notifications">通知</string>
     <string name="perm_notifications_desc">把 Cloudflare 告警推到裝置</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">自訂域名</string>
+    <string name="pages_domain_add">新增域名</string>
+    <string name="pages_domain_add_hint">掛載後需將域名解析指向本項目才會生效。</string>
+    <string name="pages_domain_empty">暫無自訂域名</string>
+    <string name="pages_domain_delete_title">刪除域名？</string>
+    <string name="pages_domain_delete_msg">將從該 Pages 項目移除 %1$s，不影響現有 DNS 記錄。</string>
+    <string name="pages_domain_retry">重新驗證</string>
+    <string name="pages_domain_added">已新增域名</string>
+    <string name="pages_domain_deleted">已刪除域名</string>
+    <string name="pages_cname_created">已新增 CNAME 記錄</string>
+    <string name="pages_domain_status_active">生效中</string>
+    <string name="pages_domain_status_pending">驗證中</string>
+    <string name="pages_domain_status_initializing">初始化</string>
+    <string name="pages_domain_status_deactivated">已停用</string>
+    <string name="pages_domain_status_blocked">已封鎖</string>
+    <string name="pages_domain_status_error">錯誤</string>
+    <string name="pages_txt_title">驗證 TXT 記錄</string>
+    <string name="pages_txt_name">記錄名稱</string>
+    <string name="pages_txt_value">記錄值</string>
+    <string name="pages_dns_resolved">已指向本項目</string>
+    <string name="pages_dns_conflicting">未指向本項目</string>
+    <string name="pages_dns_missing">尚無解析記錄</string>
+    <string name="pages_dns_add_cname">新增 CNAME 記錄</string>
+    <string name="pages_dns_add_cname_hint">將在該域名所在的區域新增一條已代理的 CNAME 記錄，指向 %1$s。</string>
+    <string name="pages_dns_external">該域名不在當前帳戶的 Cloudflare 區域內，請在域名服務商處新增指向 %1$s 的 CNAME 記錄。</string>
+    <string name="sort_label">排序</string>
+    <string name="sort_default">默認（名稱）</string>
+    <string name="sort_created">創建日期</string>
+    <string name="sort_modified">最近更新</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages 自訂域名</string>
+    <string name="whatsnew_1_6_0_0_detail">Pages 項目現可直接管理自訂域名：新增、刪除、重新驗證並檢查解析狀態；域名在當前帳戶時，還能一鍵新增指向項目的 CNAME 記錄。</string>
+    <string name="whatsnew_1_6_0_1_title">列表排序</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers 與 Pages 列表新增排序：默認（名稱）、創建日期、最近更新，選擇會被記住。</string>
     <string name="whatsnew_1_5_0_0_title">免登入開發者工具箱</string>
     <string name="whatsnew_1_5_0_0_detail">無需登入即可使用一組常用網路工具：DNS 查詢、SSL 憑證檢查、HTTP 標頭、WHOIS、IP 歸屬、CIDR 計算與 Cloudflare trace。開啟 App 在登入頁就能直接進入。</string>
     <string name="whatsnew_1_5_0_1_title">推送中心</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -1143,4 +1143,34 @@
     <string name="alerting_empty">此帳戶暫無可用告警類型。</string>
     <string name="perm_notifications">通知</string>
     <string name="perm_notifications_desc">把 Cloudflare 告警推到裝置</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">自訂網域</string>
+    <string name="pages_domain_add">新增網域</string>
+    <string name="pages_domain_add_hint">掛載後需將網域解析指向本專案才會生效。</string>
+    <string name="pages_domain_empty">尚無自訂網域</string>
+    <string name="pages_domain_delete_title">刪除網域？</string>
+    <string name="pages_domain_delete_msg">將從該 Pages 專案移除 %1$s，不影響現有 DNS 記錄。</string>
+    <string name="pages_domain_retry">重新驗證</string>
+    <string name="pages_domain_added">已新增網域</string>
+    <string name="pages_domain_deleted">已刪除網域</string>
+    <string name="pages_cname_created">已新增 CNAME 記錄</string>
+    <string name="pages_domain_status_active">生效中</string>
+    <string name="pages_domain_status_pending">驗證中</string>
+    <string name="pages_domain_status_initializing">初始化</string>
+    <string name="pages_domain_status_deactivated">已停用</string>
+    <string name="pages_domain_status_blocked">已封鎖</string>
+    <string name="pages_domain_status_error">錯誤</string>
+    <string name="pages_txt_title">驗證 TXT 記錄</string>
+    <string name="pages_txt_name">記錄名稱</string>
+    <string name="pages_txt_value">記錄值</string>
+    <string name="pages_dns_resolved">已指向本專案</string>
+    <string name="pages_dns_conflicting">未指向本專案</string>
+    <string name="pages_dns_missing">尚無解析記錄</string>
+    <string name="pages_dns_add_cname">新增 CNAME 記錄</string>
+    <string name="pages_dns_add_cname_hint">將在該網域所在的區域新增一條已代理的 CNAME 記錄，指向 %1$s。</string>
+    <string name="pages_dns_external">該網域不在目前帳號的 Cloudflare 區域內，請在網域服務商處新增指向 %1$s 的 CNAME 記錄。</string>
+    <string name="sort_label">排序</string>
+    <string name="sort_default">預設（名稱）</string>
+    <string name="sort_created">建立日期</string>
+    <string name="sort_modified">最近更新</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages 自訂網域</string>
+    <string name="whatsnew_1_6_0_0_detail">Pages 專案現可直接管理自訂網域：新增、刪除、重新驗證並檢查解析狀態；網域在目前帳號時，還能一鍵新增指向專案的 CNAME 記錄。</string>
+    <string name="whatsnew_1_6_0_1_title">清單排序</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers 與 Pages 清單新增排序：預設（名稱）、建立日期、最近更新，選擇會被記住。</string>
     <string name="whatsnew_1_5_0_0_title">免登入開發者工具箱</string>
     <string name="whatsnew_1_5_0_0_detail">無需登入即可使用一組常用網路工具：DNS 查詢、SSL 憑證檢查、HTTP 標頭、WHOIS、IP 歸屬、CIDR 計算與 Cloudflare trace。開啟 App 在登入頁就能直接進入。</string>
     <string name="whatsnew_1_5_0_1_title">推送中心</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1232,4 +1232,34 @@
     <string name="alerting_empty">该账号暂无可用告警类型。</string>
     <string name="perm_notifications">通知</string>
     <string name="perm_notifications_desc">把 Cloudflare 告警推到设备</string>
+    <!-- Pages 自定义域名 + 列表排序 -->
+    <string name="pages_domains_section">自定义域名</string>
+    <string name="pages_domain_add">添加域名</string>
+    <string name="pages_domain_add_hint">挂载后需将域名解析指向本项目才能生效。</string>
+    <string name="pages_domain_empty">暂无自定义域名</string>
+    <string name="pages_domain_delete_title">删除域名？</string>
+    <string name="pages_domain_delete_msg">将从该 Pages 项目移除 %1$s，不影响已有 DNS 记录。</string>
+    <string name="pages_domain_retry">重新验证</string>
+    <string name="pages_domain_added">已添加域名</string>
+    <string name="pages_domain_deleted">已删除域名</string>
+    <string name="pages_cname_created">已添加 CNAME 记录</string>
+    <string name="pages_domain_status_active">生效中</string>
+    <string name="pages_domain_status_pending">验证中</string>
+    <string name="pages_domain_status_initializing">初始化</string>
+    <string name="pages_domain_status_deactivated">已停用</string>
+    <string name="pages_domain_status_blocked">已封锁</string>
+    <string name="pages_domain_status_error">错误</string>
+    <string name="pages_txt_title">验证 TXT 记录</string>
+    <string name="pages_txt_name">记录名</string>
+    <string name="pages_txt_value">记录值</string>
+    <string name="pages_dns_resolved">已指向本项目</string>
+    <string name="pages_dns_conflicting">未指向本项目</string>
+    <string name="pages_dns_missing">尚无解析记录</string>
+    <string name="pages_dns_add_cname">添加 CNAME 记录</string>
+    <string name="pages_dns_add_cname_hint">将在该域名所在的区域添加一条已代理的 CNAME 记录，指向 %1$s。</string>
+    <string name="pages_dns_external">该域名不在当前账号的 Cloudflare 区域内，请在域名服务商处添加指向 %1$s 的 CNAME 记录。</string>
+    <string name="sort_label">排序</string>
+    <string name="sort_default">默认（名称）</string>
+    <string name="sort_created">创建日期</string>
+    <string name="sort_modified">最近更新</string>
 </resources>

--- a/apps/android/app/src/main/res/values/whatsnew.xml
+++ b/apps/android/app/src/main/res/values/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_0_0_title">Pages 自定义域名</string>
+    <string name="whatsnew_1_6_0_0_detail">Pages 项目现可直接管理自定义域名：添加、删除、重新验证并检查解析状态；域名在当前账号时，还能一键添加指向项目的 CNAME 记录。</string>
+    <string name="whatsnew_1_6_0_1_title">列表排序</string>
+    <string name="whatsnew_1_6_0_1_detail">Workers 与 Pages 列表新增排序：默认（名称）、创建日期、最近更新，选择会被记住。</string>
     <string name="whatsnew_1_5_0_0_title">免登录开发者工具箱</string>
     <string name="whatsnew_1_5_0_0_detail">无需登录即可使用一组常用网络工具：DNS 查询、SSL 证书检查、HTTP 头、WHOIS、IP 归属、CIDR 计算与 Cloudflare trace。打开 App 在登录页就能直接进入。</string>
     <string name="whatsnew_1_5_0_1_title">推送中心</string>


### PR DESCRIPTION
## 新功能
- **Pages 自定义域名管理**：项目详情新增域名区块——列表 / 添加 / 删除 / 重新验证，检查 DNS 解析状态；域名所在 zone 在当前账号时，一键添加指向 `<项目>.pages.dev` 的已代理 CNAME（page.write / dns.write 门控；zone 不在 CF 时展示 TXT 归属验证记录可复制）
- **列表排序**：Workers 与 Pages 列表支持 默认（名称）/ 创建日期 / 最近更新，DataStore 持久化；`SkyHeader` 新增 actions 槽，`SortMenuButton` 组件可复用

## 修复
- fr/ar 译文中被本地化的 MB 单位改回国际通用符号

## 发版核对
- [x] 版本 1.6.0（versionCode 9）
- [x] 新文案补齐 13 个语言目录；What's New 生成物随单一数据源更新（源条目在 #41）
- [x] play / direct / oss 三风味 assembleDebug 全绿

依赖合并顺序：#41 先合。