### PR TITLE
release(ios): 1.8.2(25) — 17.0 导航栈闪退根治 + 体验者计划 opt-in 遥测

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5EAB1E0000000000000000E3 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5EAB1E0000000000000000E2 /* Sentry */; };
 		AB12CD00000000000000000C /* OrangeCloudWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AB12CD000000000000000001 /* OrangeCloudWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E9AD1A792FE1B6A90020AAAF /* Orange Cloud Watch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = E9AD1A6F2FE1B6A80020AAAF /* Orange Cloud Watch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E9AD1A852FE1B6CA0020AAAF /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9AD1A842FE1B6CA0020AAAF /* WidgetKit.framework */; };
@@ -258,6 +259,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EAB1E0000000000000000E3 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -445,6 +447,7 @@
 			);
 			name = "Orange Cloud";
 			packageProductDependencies = (
+				5EAB1E0000000000000000E2 /* Sentry */,
 			);
 			productName = "Orange Cloud";
 			productReference = E9EF3A232FD98F7B007C2377 /* Orange Cloud.app */;
@@ -501,6 +504,9 @@
 			);
 			mainGroup = E9EF3A1A2FD98F7B007C2377;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				5EAB1E0000000000000000E1 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E9EF3A242FD98F7B007C2377 /* Products */;
 			projectDirPath = "";
@@ -641,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -673,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -706,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -740,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -774,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -808,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -840,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -870,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -900,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -930,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -963,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1006,7 +1012,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1233,6 +1239,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		5EAB1E0000000000000000E1 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5EAB1E0000000000000000E2 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5EAB1E0000000000000000E1 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E9EF3A1B2FD98F7B007C2377 /* Project object */;
 }

--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "a72b37d142139a9f8de021ec1a2d4e7ec2a7ffc9ebc87493f58bac80a85691cb",
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
+        "version" : "8.58.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ContentView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ContentView.swift
@@ -55,6 +55,7 @@ private struct SessionRootView: View {
         MainTabView()
             .environment(session)
             .whatsNewSheet()
+            .telemetryConsentPrompt()
     }
 }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Diagnostics/Telemetry.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Diagnostics/Telemetry.swift
@@ -1,0 +1,120 @@
+//
+//  Telemetry.swift
+//  Orange Cloud
+//
+//  体验者计划（opt-in 遥测）：Sentry 封装。**默认完全不启动**——仅当用户在
+//  弹窗或「设置」里明确加入后才初始化并上报；拒绝/未选择时零网络、零采集。
+//
+//  隐私边界（与 AppLog 脱敏铁律同源）：只转发日志门面里的匿名诊断消息
+//  （令牌只有不可逆指纹、无 Cookie、无密钥值），重点是 auth 类别（身份认证排查）；
+//  sendDefaultPii 关闭、关闭 swizzling（不自动采集网络请求/UI 事件）、
+//  不采集截图与视图层级、不设置任何用户身份。崩溃采集开启（Sentry 会链式保留
+//  先安装的 CrashReporter handler，两者可共存；Apple 崩溃报告不受影响）。
+//
+
+import Foundation
+import os
+import Sentry
+
+// MARK: - 上报入口（nonisolated，供 AppLog 等任意线程转发）
+
+nonisolated enum TelemetryReporter {
+
+    private static let dsn =
+        "https://0731592c0467b3fc21b8ddbc245d16cf@o4511298316337152.ingest.us.sentry.io/4511680020676608"
+
+    /// AppLog 从任意线程读，用锁保证可见性；只在用户同意后置 true
+    private static let enabledFlag = OSAllocatedUnfairLock(initialState: false)
+
+    static var isEnabled: Bool { enabledFlag.withLock { $0 } }
+
+    static func start() {
+        guard !isEnabled else { return }
+        SentrySDK.start { options in
+            options.dsn = dsn
+            #if DEBUG
+            options.environment = "debug"
+            #else
+            options.environment = "release"
+            #endif
+            options.sendDefaultPii = false        // 不带 IP / 用户身份
+            options.attachScreenshot = false
+            options.attachViewHierarchy = false
+            options.enableSwizzling = false       // 不自动抓网络/UI（API URL 含账号、域名 ID）
+            options.tracesSampleRate = 0          // 不做性能采样，只要日志 / 事件 / 崩溃
+        }
+        enabledFlag.withLock { $0 = true }
+        addBreadcrumb(category: "telemetry", message: "telemetry started")
+    }
+
+    static func stop() {
+        guard isEnabled else { return }
+        enabledFlag.withLock { $0 = false }
+        SentrySDK.close()
+    }
+
+    /// AppLog 转发面：auth 类别全级别进 breadcrumb（认证排查的时间线），
+    /// 任何类别的 error 升级为 Sentry 事件（带前面积累的面包屑上下文一起上报）。
+    static func forward(category: String, level: String, message: String) {
+        guard isEnabled else { return }
+        if level == "error" {
+            let event = Event(level: .error)
+            event.message = SentryMessage(formatted: message)
+            event.logger = category
+            SentrySDK.capture(event: event)
+        } else if category == "auth" {
+            addBreadcrumb(category: category, message: message)
+        }
+    }
+
+    private static func addBreadcrumb(category: String, message: String) {
+        let crumb = Breadcrumb(level: .info, category: category)
+        crumb.message = message
+        SentrySDK.addBreadcrumb(crumb)
+    }
+}
+
+// MARK: - 同意状态（MainActor，驱动弹窗与设置开关）
+
+@Observable
+@MainActor
+final class TelemetryStore {
+
+    static let shared = TelemetryStore()
+
+    enum Consent: String {
+        case unasked, granted, declined
+    }
+
+    private static let consentKey = "telemetryConsent"
+
+    private(set) var consent: Consent
+
+    /// 设置页 Toggle 绑定
+    var isOptedIn: Bool {
+        get { consent == .granted }
+        set { setConsent(newValue ? .granted : .declined) }
+    }
+
+    private init() {
+        consent = Consent(rawValue: UserDefaults.standard.string(forKey: Self.consentKey) ?? "") ?? .unasked
+        // 「默认不初始化」：只有历史上已同意过才在启动时拉起 SDK
+        if consent == .granted {
+            TelemetryReporter.start()
+        }
+    }
+
+    func setConsent(_ value: Consent) {
+        guard value != consent else { return }
+        consent = value
+        UserDefaults.standard.set(value.rawValue, forKey: Self.consentKey)
+        switch value {
+        case .granted:
+            AppLog.app.notice("telemetry consent granted")
+            TelemetryReporter.start()
+        case .declined, .unasked:
+            AppLog.app.notice("telemetry consent revoked/declined")
+            TelemetryReporter.stop()
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Logging/AppLog.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Logging/AppLog.swift
@@ -56,6 +56,9 @@ nonisolated struct AppLog: Sendable {
         case .error:  logger.error("\(message, privacy: .public)")
         }
         LogFileStore.shared.append(level: level, category: category, message: message)
+        // 体验者计划（opt-in）：auth 时间线 + 全类别 error 镜像到 Sentry。
+        // 消息已按上方脱敏铁律清洗，未开启时此调用是空转。
+        TelemetryReporter.forward(category: category.rawValue, level: level.rawValue, message: message)
     }
 
     // MARK: - 启动环境头

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/MockCloudflare.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/MockCloudflare.swift
@@ -64,9 +64,20 @@ nonisolated final class MockCFURLProtocol: URLProtocol {
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "application/json"]
         )!
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: data)
-        client?.urlProtocolDidFinishLoading(self)
+        // ORANGE_MOCK_ACCOUNTS_DELAY_MS：延迟 /accounts 响应，拉宽「账号加载完成前」的
+        // 操作窗口（复现 selectedAccount 翻转时用户已切到其它 tab 的时序）。
+        let delayMs = ProcessInfo.processInfo.environment["ORANGE_MOCK_ACCOUNTS_DELAY_MS"].flatMap(Int.init) ?? 0
+        let delay: TimeInterval = (path == "/client/v4/accounts" && delayMs > 0) ? Double(delayMs) / 1000 : 0
+        let deliver = { [client] in
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        if delay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay, execute: deliver)
+        } else {
+            deliver()
+        }
     }
 
     override func stopLoading() {}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.swift
@@ -51,4 +51,6 @@ nonisolated enum WhatsNewStore {
 /// 全新安装首次登录后不打扰。由 App.init 在创建 AuthManager 后写入。
 enum WhatsNewGate {
     static var wasLoggedInAtLaunch = false
+    /// 本次启动弹了 What's New：体验者计划询问等其它一次性弹窗让路，下次启动再问
+    static var presentedThisLaunch = false
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -137632,6 +137632,462 @@
           }
         }
       }
+    },
+    "加入体验者计划？" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل تريد الانضمام إلى برنامج تحسين التطبيق؟"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Am Insider-Programm teilnehmen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Join the Insider Program?"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Unirte al programa Insider?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejoindre le programme Insider ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インサイダープログラムに参加しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인사이더 프로그램에 참여하시겠습니까?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Participar do Programa Insider?"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aderir ao Programa Insider?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider Programı'na katılmak ister misiniz?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入體驗者計畫？"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入體驗者計劃？"
+          }
+        }
+      }
+    },
+    "加入" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انضمام"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teilnehmen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Join"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unirme"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejoindre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "참여"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Participar"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aderir"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katıl"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
+          }
+        }
+      }
+    },
+    "暂不" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ليس الآن"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt nicht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Now"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahora no"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus tard"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今はしない"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "나중에"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agora não"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agora não"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şimdi değil"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不"
+          }
+        }
+      }
+    },
+    "开启后，App 会上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。可随时在设置中关闭。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عند التفعيل، يرسل التطبيق سجلات تشخيص مجهولة الهوية ومعلومات الأعطال (لا تتضمن أبدًا رموزك أو بيانات حسابك أو أي معلومات شخصية) لمساعدتنا في تحديد مشكلات تسجيل الدخول والاستقرار بشكل أسرع. يمكنك إيقافه في أي وقت من الإعدادات."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn aktiviert, sendet die App anonyme Diagnoseprotokolle und Absturzberichte (niemals deine Tokens, Kontodaten oder persönliche Informationen), damit wir Anmelde- und Stabilitätsprobleme schneller eingrenzen können. Du kannst dies jederzeit in den Einstellungen deaktivieren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, the app reports anonymous diagnostic logs and crash data (never your tokens, account data, or any personal information) to help us track down sign-in and stability issues faster. You can turn this off anytime in Settings."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al activarlo, la app envía registros de diagnóstico anónimos e informes de fallos (nunca tus tokens, datos de cuenta ni información personal) para ayudarnos a identificar más rápido los problemas de inicio de sesión y estabilidad. Puedes desactivarlo en cualquier momento en Ajustes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une fois activé, l'app envoie des journaux de diagnostic anonymes et des rapports de plantage (jamais vos jetons, données de compte ni aucune information personnelle) pour nous aider à identifier plus vite les problèmes de connexion et de stabilité. Vous pouvez désactiver cela à tout moment dans les réglages."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、匿名の診断ログとクラッシュ情報（トークン、アカウントデータ、個人情報は一切含まれません）を送信し、ログインや安定性の問題の特定に役立てます。設定でいつでもオフにできます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화하면 익명 진단 로그와 충돌 정보(토큰, 계정 데이터, 개인정보는 포함되지 않음)를 전송하여 로그인 및 안정성 문제를 더 빠르게 파악하는 데 도움이 됩니다. 설정에서 언제든지 끌 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, o app envia registros de diagnóstico anônimos e relatórios de falhas (nunca seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rápido problemas de login e estabilidade. Você pode desativar a qualquer momento nos Ajustes."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, a app envia registos de diagnóstico anónimos e relatórios de falhas (nunca os seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rapidamente problemas de início de sessão e estabilidade. Pode desativar a qualquer momento nas Definições."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etkinleştirildiğinde uygulama, oturum açma ve kararlılık sorunlarını daha hızlı bulmamıza yardımcı olmak için anonim tanılama günlükleri ve çökme bilgileri gönderir (belirteçleriniz, hesap verileriniz veya hiçbir kişisel bilgi asla dahil edilmez). Ayarlar'dan istediğiniz zaman kapatabilirsiniz."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後，App 會回報匿名診斷日誌與當機資訊（不含權杖、帳號資料或任何個人資訊），協助我們更快定位登入與穩定性問題。可隨時在設定中關閉。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後，App 會上報匿名診斷日誌與崩潰資訊（不含權杖、帳戶資料或任何個人資料），協助我們更快定位登入與穩定性問題。可隨時在設定中關閉。"
+          }
+        }
+      }
+    },
+    "体验者计划" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برنامج تحسين التطبيق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider-Programm"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider Program"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programa Insider"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programme Insider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インサイダープログラム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인사이더 프로그램"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programa Insider"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programa Insider"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider Programı"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "體驗者計畫"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "體驗者計劃"
+          }
+        }
+      }
+    },
+    "开启后上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عند التفعيل، تُرسَل سجلات تشخيص مجهولة الهوية ومعلومات الأعطال (لا تتضمن أبدًا رموزك أو بيانات حسابك أو أي معلومات شخصية) لمساعدتنا في تحديد مشكلات تسجيل الدخول والاستقرار بشكل أسرع."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn aktiviert, werden anonyme Diagnoseprotokolle und Absturzberichte gesendet (niemals deine Tokens, Kontodaten oder persönliche Informationen), damit wir Anmelde- und Stabilitätsprobleme schneller eingrenzen können."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, reports anonymous diagnostic logs and crash data (never your tokens, account data, or any personal information) to help us track down sign-in and stability issues faster."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al activarlo, se envían registros de diagnóstico anónimos e informes de fallos (nunca tus tokens, datos de cuenta ni información personal) para ayudarnos a identificar más rápido los problemas de inicio de sesión y estabilidad."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une fois activé, envoie des journaux de diagnostic anonymes et des rapports de plantage (jamais vos jetons, données de compte ni aucune information personnelle) pour nous aider à identifier plus vite les problèmes de connexion et de stabilité."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、匿名の診断ログとクラッシュ情報（トークン、アカウントデータ、個人情報は一切含まれません）を送信し、ログインや安定性の問題の特定に役立てます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화하면 익명 진단 로그와 충돌 정보(토큰, 계정 데이터, 개인정보는 포함되지 않음)를 전송하여 로그인 및 안정성 문제를 더 빠르게 파악하는 데 도움이 됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, envia registros de diagnóstico anônimos e relatórios de falhas (nunca seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rápido problemas de login e estabilidade."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, envia registos de diagnóstico anónimos e relatórios de falhas (nunca os seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rapidamente problemas de início de sessão e estabilidade."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etkinleştirildiğinde, oturum açma ve kararlılık sorunlarını daha hızlı bulmamıza yardımcı olmak için anonim tanılama günlükleri ve çökme bilgileri gönderilir (belirteçleriniz, hesap verileriniz veya hiçbir kişisel bilgi asla dahil edilmez)."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後回報匿名診斷日誌與當機資訊（不含權杖、帳號資料或任何個人資訊），協助我們更快定位登入與穩定性問題。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後上報匿名診斷日誌與崩潰資訊（不含權杖、帳戶資料或任何個人資料），協助我們更快定位登入與穩定性問題。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
@@ -41,6 +41,9 @@ struct Orange_CloudApp: App {
         }
         WatchSessionManager.shared.start(authManager: manager)
         EntitlementStore.shared.start()
+        // 体验者计划：仅当用户此前已同意才会真正拉起 Sentry（默认不初始化）。
+        // 须在 CrashReporter.install() 之后，让 Sentry 链式保留我们的崩溃 handler。
+        _ = TelemetryStore.shared
         Self.reapOrphanTailActivities()
         try? Tips.configure()
         AppLog.logLaunch(

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/DeveloperPlatform/DeveloperHubView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/DeveloperPlatform/DeveloperHubView.swift
@@ -14,7 +14,16 @@ struct DeveloperHubView: View {
     let session: SessionStore
 
     var body: some View {
+        // NavigationStack 常驻，账号切换只重建栈内内容（.id 在栈内、挂在 hubList 上）。
+        // **不要把 .id(账号) 挪回栈外或 MainTabView**：selectedAccount 可能在本 Tab 可见时
+        // 才翻转，重建可见 NavigationStack 在 iOS 17.0.x 导航栏硬断言必崩（1.8.2(24) 复发根因）。
         NavigationStack {
+            hubList
+                .id(session.selectedAccount?.id)
+        }
+    }
+
+    private var hubList: some View {
             List {
                 // List 内由系统提供 NavigationLink chevron，勿再传 showsChevron（否则双箭头）。
                 Section("计算") {
@@ -75,7 +84,6 @@ struct DeveloperHubView: View {
             .navigationDestination(for: CachedWorkerScript.self) { script in
                 WorkerDetailView(script: script, session: session)
             }
-        }
     }
 }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Main/MainTabView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Main/MainTabView.swift
@@ -72,29 +72,27 @@ struct MainTabView: View {
 
     // MARK: - Tab 内容（两套 TabView 写法共用）
 
-    // 各资源 Tab 用 .id(selectedAccount) 绑定当前账号：账号切换时整页重建，
-    // 让按账号过滤的 @Query 谓词刷新、列表数据重新拉取（资源跟着选中账号走）。
+    // 账号维度的重建（.id(selectedAccount)）一律在各 Tab 视图内部、导航容器之内完成，
+    // **这里不允许出现任何 .id**：ensureAccounts 可能在任意 Tab 可见时才完成或重试成功
+    // （启动拉取失败后各页 load 都会重试），selectedAccount nil→账号翻转若重建可见
+    // NavigationStack，iOS 17.0.x 导航栏硬断言必崩——1.8.2(24) 复发的根因就是
+    // zones/developer/storage 三个 Tab 在此处残留的外层 .id（详见 DashboardView 注释）。
 
     @ViewBuilder private var dashboardTab: some View {
-        // 账号维度的重建（.id）在 DashboardView 内部、NavigationStack 之内完成——
-        // 在这里加 .id 会把可见导航栏连栈一起重建，iOS 17.0.x 必崩（详见 DashboardView 注释）。
         DashboardView(session: session)
     }
 
     @ViewBuilder private var zonesTab: some View {
         ZoneListView(session: session)
-            .id(session.selectedAccount?.id)
     }
 
     @ViewBuilder private var developerTab: some View {
         // 开发者平台聚合入口：Workers / Queues / Durable Objects / Hyperdrive / Workers AI / AI Gateway
         DeveloperHubView(session: session)
-            .id(session.selectedAccount?.id)
     }
 
     @ViewBuilder private var storageTab: some View {
         StorageView(session: session)
-            .id(session.selectedAccount?.id)
     }
 
     @ViewBuilder private var settingsTab: some View {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Settings/SettingsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Settings/SettingsView.swift
@@ -288,6 +288,19 @@ struct SettingsView: View {
                 }
                 .glassRow()
 
+                // ── 体验者计划（opt-in 遥测）──
+                Section {
+                    Toggle(isOn: Bindable(TelemetryStore.shared).isOptedIn) {
+                        HStack(spacing: 12) {
+                            TintIcon(systemImage: "waveform.path.ecg", color: .teal)
+                            Text("体验者计划")
+                        }
+                    }
+                } footer: {
+                    Text("开启后上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。")
+                }
+                .glassRow()
+
                 // ── 关于（详情收进二级页，给根页减负）──
                 Section {
                     NavigationLink {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/StorageView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/StorageView.swift
@@ -49,7 +49,28 @@ enum StorageKind: String, CaseIterable, Identifiable {
     }
 }
 
+/// 存储 Tab 外壳：NavigationStack 常驻，账号切换只重建栈内内容。
+/// **不要把 `.id(账号)` 挪回栈外或 MainTabView**：selectedAccount 可能在本 Tab 可见时
+/// 才翻转（ensureAccounts 延迟完成/重试），重建可见 NavigationStack 在 iOS 17.0.x
+/// 导航栏硬断言必崩（1.8.2(24) 复发根因，详见 DashboardView 注释）。
 struct StorageView: View {
+
+    private let session: SessionStore
+
+    init(session: SessionStore) {
+        self.session = session
+    }
+
+    var body: some View {
+        NavigationStack {
+            StorageContent(session: session)
+                .id(session.selectedAccount?.id)
+        }
+    }
+}
+
+/// 存储页内容（原 StorageView 本体）：ViewModel 持有的列表随外壳 `.id` 在账号切换时重置。
+private struct StorageContent: View {
 
     @Environment(SessionStore.self) private var session
     @Environment(AuthManager.self) private var auth
@@ -80,56 +101,54 @@ struct StorageView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            Group {
-                // 整模块 Pro 闸门：免费层不展示存储内容
-                if entitlements.isPro {
-                    proContent
-                } else {
-                    ProLockedView(feature: .storage)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
+        Group {
+            // 整模块 Pro 闸门：免费层不展示存储内容
+            if entitlements.isPro {
+                proContent
+            } else {
+                ProLockedView(feature: .storage)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .background { SkyBackground() }
-            .navigationTitle("存储")
-            .toolbar {
-                // R2 / D1 / KV 三段均提供创建入口（按各自写权限门控）
-                if entitlements.isPro, auth.hasScope(kind.requiredScope) {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button(kind.createLabel, systemImage: "plus") { startCreate() }
-                    }
-                }
-            }
-            .sheet(isPresented: $showR2Create) {
-                R2CreateView(viewModel: r2ViewModel, accountId: session.selectedAccount?.id ?? "")
-            }
-            .sheet(isPresented: $showD1Create) {
-                D1CreateView(viewModel: d1ViewModel, accountId: session.selectedAccount?.id ?? "")
-            }
-            .sheet(isPresented: $showKVCreate) {
-                KVCreateView(viewModel: kvViewModel, accountId: session.selectedAccount?.id ?? "")
-            }
-            .sheet(item: $bucketToDelete) { bucket in
-                R2BucketDeleteConfirmView(bucket: bucket, viewModel: r2ViewModel, accountId: session.selectedAccount?.id ?? "")
-            }
-            .sheet(item: $databaseToDelete) { database in
-                D1DeleteConfirmView(database: database, viewModel: d1ViewModel, accountId: session.selectedAccount?.id ?? "")
-            }
-            .sheet(item: $namespaceToDelete) { namespace in
-                KVNamespaceDeleteConfirmView(namespace: namespace, viewModel: kvViewModel, accountId: session.selectedAccount?.id ?? "")
-            }
-            .alert("权限不足", isPresented: $writeDenied) {
-                Button("好", role: .cancel) {}
-            } message: {
-                Text("当前授权未包含此资源的写权限（\(kind.writeScope)）。\n请在设置中退出登录后重新授权以启用此功能。")
-            }
-            .sensoryFeedback(.success, trigger: r2ViewModel.didCreate)
-            .sensoryFeedback(.success, trigger: r2ViewModel.didDelete)
-            .sensoryFeedback(.success, trigger: d1ViewModel.didCreate)
-            .sensoryFeedback(.success, trigger: d1ViewModel.didDelete)
-            .sensoryFeedback(.success, trigger: kvViewModel.didCreate)
-            .sensoryFeedback(.success, trigger: kvViewModel.didDelete)
         }
+        .background { SkyBackground() }
+        .navigationTitle("存储")
+        .toolbar {
+            // R2 / D1 / KV 三段均提供创建入口（按各自写权限门控）
+            if entitlements.isPro, auth.hasScope(kind.requiredScope) {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(kind.createLabel, systemImage: "plus") { startCreate() }
+                }
+            }
+        }
+        .sheet(isPresented: $showR2Create) {
+            R2CreateView(viewModel: r2ViewModel, accountId: session.selectedAccount?.id ?? "")
+        }
+        .sheet(isPresented: $showD1Create) {
+            D1CreateView(viewModel: d1ViewModel, accountId: session.selectedAccount?.id ?? "")
+        }
+        .sheet(isPresented: $showKVCreate) {
+            KVCreateView(viewModel: kvViewModel, accountId: session.selectedAccount?.id ?? "")
+        }
+        .sheet(item: $bucketToDelete) { bucket in
+            R2BucketDeleteConfirmView(bucket: bucket, viewModel: r2ViewModel, accountId: session.selectedAccount?.id ?? "")
+        }
+        .sheet(item: $databaseToDelete) { database in
+            D1DeleteConfirmView(database: database, viewModel: d1ViewModel, accountId: session.selectedAccount?.id ?? "")
+        }
+        .sheet(item: $namespaceToDelete) { namespace in
+            KVNamespaceDeleteConfirmView(namespace: namespace, viewModel: kvViewModel, accountId: session.selectedAccount?.id ?? "")
+        }
+        .alert("权限不足", isPresented: $writeDenied) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("当前授权未包含此资源的写权限（\(kind.writeScope)）。\n请在设置中退出登录后重新授权以启用此功能。")
+        }
+        .sensoryFeedback(.success, trigger: r2ViewModel.didCreate)
+        .sensoryFeedback(.success, trigger: r2ViewModel.didDelete)
+        .sensoryFeedback(.success, trigger: d1ViewModel.didCreate)
+        .sensoryFeedback(.success, trigger: d1ViewModel.didDelete)
+        .sensoryFeedback(.success, trigger: kvViewModel.didCreate)
+        .sensoryFeedback(.success, trigger: kvViewModel.didDelete)
     }
 
     private var proContent: some View {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/WhatsNew/WhatsNewView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/WhatsNew/WhatsNewView.swift
@@ -122,6 +122,42 @@ private struct WhatsNewModifier: ViewModifier {
             lastSeen = current          // 版本升了但无可展示内容：对齐，避免反复评估
         } else {
             payload = Payload(items: unseen)   // 内容与呈现同时确定，避免 iOS 17 捕获旧值
+            WhatsNewGate.presentedThisLaunch = true   // 体验者计划询问本次让路
         }
+    }
+}
+
+// MARK: - 体验者计划一次性询问
+
+/// 登录后主界面挂载：consent 尚未选择时弹一次「加入体验者计划？」。
+/// 与 What's New 错峰（同一启动只出一个弹窗）；拒绝后不再打扰，设置里可随时改。
+struct TelemetryConsentModifier: ViewModifier {
+
+    @State private var showAsk = false
+    private let telemetry = TelemetryStore.shared
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                guard telemetry.consent == .unasked else { return }
+                // 等 What's New 先完成评估/呈现；主界面稳定后再问
+                try? await Task.sleep(for: .seconds(2))
+                guard !WhatsNewGate.presentedThisLaunch,
+                      telemetry.consent == .unasked else { return }
+                showAsk = true
+            }
+            .alert("加入体验者计划？", isPresented: $showAsk) {
+                Button("加入") { telemetry.setConsent(.granted) }
+                Button("暂不", role: .cancel) { telemetry.setConsent(.declined) }
+            } message: {
+                Text("开启后，App 会上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。可随时在设置中关闭。")
+            }
+    }
+}
+
+extension View {
+    /// 体验者计划一次性询问（挂在登录后的会话根视图，What's New 之后）
+    func telemetryConsentPrompt() -> some View {
+        modifier(TelemetryConsentModifier())
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneListView.swift
@@ -11,29 +11,75 @@ import SwiftUI
 import SwiftData
 import TipKit
 
+/// 域名 Tab 外壳：导航容器（Stack / Split）常驻，账号切换只重建容器内内容。
+/// **不要把 `.id(账号)` 挪回容器外层或 MainTabView**：ensureAccounts 可能在本 Tab
+/// 可见时才完成或重试成功，selectedAccount nil→账号翻转若整体重建可见 NavigationStack，
+/// iOS 17.0.x 导航栏硬断言必崩（1.8.2(24) 复发根因，详见 DashboardView 注释）。
 struct ZoneListView: View {
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var selectedZone: CachedZone?
+
+    private let session: SessionStore
+
+    init(session: SessionStore) {
+        self.session = session
+    }
+
+    var body: some View {
+        if sizeClass == .regular {
+            NavigationSplitView {
+                ZoneListContent(session: session, isSplit: true, selectedZone: $selectedZone)
+                    .id(session.selectedAccount?.id)
+                    // 选中态住在外壳，账号切换时手动清空，否则 detail 栏残留旧账号的域名
+                    .onChange(of: session.selectedAccount?.id) {
+                        selectedZone = nil
+                    }
+            } detail: {
+                if let zone = selectedZone {
+                    NavigationStack {
+                        ZoneDetailView(zone: zone, session: session)
+                    }
+                } else {
+                    ContentUnavailableView("选择一个域名", systemImage: "globe", description: Text("从左侧列表选择域名查看详情"))
+                }
+            }
+        } else {
+            NavigationStack {
+                ZoneListContent(session: session, isSplit: false, selectedZone: .constant(nil))
+                    .id(session.selectedAccount?.id)
+            }
+        }
+    }
+}
+
+/// 域名列表内容（原 ZoneListView 本体）：@Query 谓词在 init 按当前账号构建，
+/// 外壳用 `.id(selectedAccount)` 在账号切换时重建本视图以刷新谓词。
+private struct ZoneListContent: View {
 
     @Environment(SessionStore.self) private var session
     @Environment(AuthManager.self) private var auth
     @Environment(\.modelContext) private var modelContext
-    @Environment(\.horizontalSizeClass) private var sizeClass
     @Query private var cachedZones: [CachedZone]
 
     @State private var viewModel: ZoneListViewModel
     @State private var searchText = ""
-    @State private var selectedZone: CachedZone?
     @State private var showAddSheet = false
     @State private var showAddDenied = false
     @Namespace private var namespace
 
-    init(session: SessionStore) {
-        // 只读当前账号的域名；父视图用 .id(selectedAccount) 在切换账号时重建以刷新谓词。
+    private let isSplit: Bool
+    @Binding private var selectedZone: CachedZone?
+
+    init(session: SessionStore, isSplit: Bool, selectedZone: Binding<CachedZone?>) {
         let accountId = session.selectedAccount?.id ?? ""
         _cachedZones = Query(
             filter: #Predicate<CachedZone> { $0.accountId == accountId },
             sort: \CachedZone.name
         )
         _viewModel = State(initialValue: ZoneListViewModel(zoneService: session.zoneService))
+        self.isSplit = isSplit
+        _selectedZone = selectedZone
     }
 
     private var filteredZones: [CachedZone] {
@@ -56,8 +102,8 @@ struct ZoneListView: View {
 
     var body: some View {
         Group {
-            if sizeClass == .regular {
-                splitLayout
+            if isSplit {
+                sidebarLayout
             } else {
                 stackLayout
             }
@@ -87,82 +133,70 @@ struct ZoneListView: View {
         }
     }
 
-    // MARK: - iPad 双栏（regular）
+    // MARK: - iPad 侧栏（regular；NavigationSplitView 容器在外壳）
 
-    private var splitLayout: some View {
-        NavigationSplitView {
-            Group {
-                if cachedZones.isEmpty && viewModel.isLoading {
-                    SkeletonList(rows: 8, icon: .circle(30), trailing: true)
-                } else if cachedZones.isEmpty {
-                    emptyState
-                } else if filteredZones.isEmpty {
-                    ContentUnavailableView.search(text: searchText)
-                } else {
-                    List(selection: $selectedZone) {
-                        Section {
-                            ForEach(filteredZones) { zone in
-                                ZoneSidebarRow(zone: zone)
-                                    .tag(zone)
-                            }
-                        } header: {
-                            Text("\(cachedZones.count) 个域名 · \(activeCount) 个已启用")
-                        }
-                    }
-                    .refreshable { await refresh(force: true) }
-                }
-            }
-            .navigationTitle("域名")
-            .searchable(text: $searchText, prompt: "搜索域名")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    refreshButton
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    addButton
-                }
-            }
-            .navigationSplitViewColumnWidth(min: 300, ideal: 340)
-        } detail: {
-            if let zone = selectedZone {
-                NavigationStack {
-                    ZoneDetailView(zone: zone, session: session)
-                }
+    private var sidebarLayout: some View {
+        Group {
+            if cachedZones.isEmpty && viewModel.isLoading {
+                SkeletonList(rows: 8, icon: .circle(30), trailing: true)
+            } else if cachedZones.isEmpty {
+                emptyState
+            } else if filteredZones.isEmpty {
+                ContentUnavailableView.search(text: searchText)
             } else {
-                ContentUnavailableView("选择一个域名", systemImage: "globe", description: Text("从左侧列表选择域名查看详情"))
+                List(selection: $selectedZone) {
+                    Section {
+                        ForEach(filteredZones) { zone in
+                            ZoneSidebarRow(zone: zone)
+                                .tag(zone)
+                        }
+                    } header: {
+                        Text("\(cachedZones.count) 个域名 · \(activeCount) 个已启用")
+                    }
+                }
+                .refreshable { await refresh(force: true) }
             }
         }
+        .navigationTitle("域名")
+        .searchable(text: $searchText, prompt: "搜索域名")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                refreshButton
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                addButton
+            }
+        }
+        .navigationSplitViewColumnWidth(min: 300, ideal: 340)
     }
 
-    // MARK: - iPhone 单栏（compact）
+    // MARK: - iPhone 单栏（compact；NavigationStack 容器在外壳）
 
     private var stackLayout: some View {
-        NavigationStack {
-            Group {
-                if cachedZones.isEmpty && viewModel.isLoading {
-                    SkeletonCardList()
-                } else if cachedZones.isEmpty {
-                    emptyState
-                } else if filteredZones.isEmpty {
-                    ContentUnavailableView.search(text: searchText)
-                } else {
-                    zoneList
-                }
+        Group {
+            if cachedZones.isEmpty && viewModel.isLoading {
+                SkeletonCardList()
+            } else if cachedZones.isEmpty {
+                emptyState
+            } else if filteredZones.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+            } else {
+                zoneList
             }
-            .background { SkyBackground() }
-            .navigationTitle("域名")
-            .searchable(text: $searchText, prompt: "搜索域名")
-            .navigationDestination(for: CachedZone.self) { zone in
-                ZoneDetailView(zone: zone, session: session)
-                    .zoomNavigationTransition(sourceID: zone.id, in: namespace)
+        }
+        .background { SkyBackground() }
+        .navigationTitle("域名")
+        .searchable(text: $searchText, prompt: "搜索域名")
+        .navigationDestination(for: CachedZone.self) { zone in
+            ZoneDetailView(zone: zone, session: session)
+                .zoomNavigationTransition(sourceID: zone.id, in: namespace)
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                refreshButton
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    refreshButton
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    addButton
-                }
+            ToolbarItem(placement: .topBarTrailing) {
+                addButton
             }
         }
     }


### PR DESCRIPTION
## 内容

**fix(ios)**: 根治 iOS 17.0 三个资源 Tab（域名/开发者/存储）可见时账号翻转重建可见 NavigationStack 的闪退——1.8.2(24) 复发的真根因（外层 `.id(selectedAccount)` 残留 + `ensureAccounts` 各页重试）。拆壳修复照 Dashboard 既有模式；17.0 模拟器复现路径修复前 100% 崩、修复后全场景存活，26.5 连环导航双测通过。

**feat(ios)**: 体验者计划 opt-in 遥测（sentry-cocoa 8.58.3，仅主 App target）。默认完全不初始化，登录后一次性询问 + 设置页开关；auth 日志时间线 + error 事件，复用 AppLog 脱敏铁律，sendDefaultPii/swizzling/截图/性能采样全关。新文案 6 key ×12 语。

**版本**: build 24 → 25（12 处，grep 核对）；MARKETING_VERSION 维持 1.8.2，changelog 无需新条目（`pnpm changelog:check` 通过）。

## 验证

- `xcodebuild -scheme "Orange Cloud" build`（Xcode-beta 全 target）无 error、无版本不匹配 warning
- 17.0 模拟器：崩溃复现路径（延迟账号响应 + 立即切 tab）修复前必崩 → 修复后存活；账号/身份切换行为对等
- Sentry：未同意零流量 → 弹窗 → 加入即上传 → 设置开关同步（模拟器实测）

## 发版后待办

- Sentry dSYM 上传未配（崩溃栈暂为裸地址）
- ASC 隐私营养标签需声明「诊断数据」（opt-in 也要报）