### PR TITLE
fix(android): 授权流补 offline_access 根治「自动退出账号」

### DIFF
--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/AuthRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/AuthRepository.kt
@@ -97,11 +97,19 @@ class AuthRepository @Inject constructor(
         val state = UUID.randomUUID().toString()
         savePending(Pending(verifier, state))
 
+        // CF dash OAuth（Hydra 系）只在请求 offline_access 时才签发 refresh token；
+        // 2026-06-29 client 轮换后不带它的登录拿不到 refresh token，access token 到期后
+        // refreshAccessToken 走 removeSession → 用户被「自动退出账号」（issue #44 楼层反馈）。
+        // 与 iOS 1.8.2(26) 同修：在唯一咽喉点统一追加，勿在 UI 层散落。
+        val scopeWithOffline =
+            if (scopeString.split(" ").contains("offline_access")) scopeString
+            else "$scopeString offline_access"
+
         return Uri.parse(OAuthConfig.AUTHORIZATION_URL).buildUpon()
             .appendQueryParameter("response_type", "code")
             .appendQueryParameter("client_id", OAuthConfig.clientId)
             .appendQueryParameter("redirect_uri", OAuthConfig.REDIRECT_URI)
-            .appendQueryParameter("scope", scopeString)
+            .appendQueryParameter("scope", scopeWithOffline)
             .appendQueryParameter("state", state)
             .appendQueryParameter("code_challenge", challenge)
             .appendQueryParameter("code_challenge_method", "S256")


### PR DESCRIPTION
与 iOS 1.8.2(26) 同修：`buildAuthorizationUri` 唯一咽喉点统一追加 `offline_access`。

**机制**（同 iOS 侧探针与真机日志坐实的链条）：CF dash OAuth（Hydra 系）只在请求 `offline_access` 时才签发 refresh token；2026-06-29 client 轮换后的新登录拿不到 refresh token，access token 到期后 `refreshAccessToken` 走无-refresh-token 分支直接 `removeSession`——即 #44 楼层反馈的「安卓版还是会自动退出账号」。

- 修复后新登录正常续期；已受损的会话被登出后**重登一次即根治**
- scope 已在 OAuth client 注册（2026-07-05 dash 实列 359 scope 核对）
- `./gradlew assembleDebug` 全风味通过
- 合并对 Xcode Cloud 无影响（workflow 只对 iOS 路径生效，web/android 推送实证不触发）

Ref: #44