### PR TITLE
feat(ios): WAF 规则编辑 + SwiftData 缓存崩溃全量收口

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheContainer.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheContainer.swift
@@ -49,6 +49,16 @@ nonisolated enum CacheContainer {
         }
     }()
 
+    /// 启动早期在主线程串行预热一次实体解析。Sentry APPLE-IOS-Y（1.8.2+27~1.8.3+30）：
+    /// iOS 17.x 冷启动后数秒内的首次 fetch 抛「could not locate an NSEntityDescription for
+    /// entity name 'CachedZone'」，疑为首次实体解析的并发竞态（@Query / Intents 查询 /
+    /// ViewModel fetch 同窗口首触）。在任何并发访问前做一次守卫下的空谓词 fetch 灌热实体
+    /// 描述；即便竞态假说不成立，异常也会被 SafeCache 兜住并计入店健康。
+    @MainActor
+    static func warmUp() {
+        _ = SafeCache.fetch(FetchDescriptor<CachedZone>(), context: shared.mainContext)
+    }
+
     // MARK: - 店健康记录（TF 崩溃点 D8tiH4pqdctLgx_nCLGnZ：单机纯谓词 fetch 也抛 NSException）
 
     private static let rebuildFlagKey = "ocCacheStoreNeedsRebuild"

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CachePolicy.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CachePolicy.swift
@@ -28,7 +28,7 @@ enum CachePolicy {
     // CoreData 层抛 ObjC 异常（TF 崩溃点 D8tiH4pqdctLgx_nCLGnZ，1.8.1/1.8.2 实测）。
     // 1.8.2(24) 改纯谓词后同一台设备仍在崩（build 24/27 日志砸在纯谓词 fetch 本身），
     // 说明该机缓存库已损坏——Swift 的 try? 接不住 CoreData 的 NSException，必须经
-    // safeFetch 的 ObjC @try 垫片兜底：异常按「缓存不新鲜」处理（触发正常重拉），
+    // SafeCache 的 ObjC @try 垫片兜底：异常按「缓存不新鲜」处理（触发正常重拉），
     // 连续异常由 CacheContainer 标记下次启动清库重建。
     // 单账号/单域名下的缓存行数很小，内存里取 max(updatedAt) 足够。
 
@@ -37,7 +37,7 @@ enum CachePolicy {
         let descriptor = FetchDescriptor<CachedZone>(
             predicate: #Predicate { $0.accountId == accountId }
         )
-        guard let cached = safeFetch(descriptor, context: context), !cached.isEmpty else { return false }
+        guard let cached = SafeCache.fetch(descriptor, context: context), !cached.isEmpty else { return false }
         return isFresh(cached.map(\.updatedAt).max(), ttl: zones)
     }
 
@@ -46,24 +46,7 @@ enum CachePolicy {
         let descriptor = FetchDescriptor<CachedDNSRecord>(
             predicate: #Predicate { $0.zoneId == zoneId }
         )
-        guard let cached = safeFetch(descriptor, context: context), !cached.isEmpty else { return false }
+        guard let cached = SafeCache.fetch(descriptor, context: context), !cached.isEmpty else { return false }
         return isFresh(cached.map(\.updatedAt).max(), ttl: dns)
-    }
-
-    /// 带 ObjC 异常兜底的 fetch：异常时记一次店异常并返回 nil（调用方当缓存不新鲜）。
-    private static func safeFetch<T: PersistentModel>(
-        _ descriptor: FetchDescriptor<T>, context: ModelContext
-    ) -> [T]? {
-        var fetched: [T]?
-        let exception = OCCatchException {
-            fetched = try? context.fetch(descriptor)
-        }
-        if let exception {
-            AppLog.app.error("缓存 fetch 抛 ObjC 异常（已兜住，按不新鲜处理）：\(exception.name.rawValue) — \(exception.reason ?? "无 reason")")
-            CacheContainer.noteFetchException()
-            return nil
-        }
-        CacheContainer.noteFetchHealthy()
-        return fetched
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheSync.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheSync.swift
@@ -15,25 +15,28 @@ enum CacheSync {
 
     /// Zone 列表 upsert 进缓存（删掉远端已不存在的条目），
     /// 并同步主屏 Widget 快照与 Spotlight 索引。
-    static func syncZones(_ zones: [Zone], accountId: String, accountName: String, context: ModelContext) throws {
-        // 仅在当前账号范围内 upsert：删除远端已不存在的条目时不能波及其它账号的缓存，
-        // 否则切换账号会清空别的账号的域名（连带丢失它们的 pinned 状态）。
-        let predicate = #Predicate<CachedZone> { $0.accountId == accountId }
-        let existing = try context.fetch(FetchDescriptor<CachedZone>(predicate: predicate))
-        let fetchedIDs = Set(zones.map(\.id))
+    /// 缓存写失败（含 iOS 17.x 的 CoreData NSException）静默放弃：数据已在手，UI 不受影响。
+    static func syncZones(_ zones: [Zone], accountId: String, accountName: String, context: ModelContext) {
+        SafeCache.perform("syncZones") {
+            // 仅在当前账号范围内 upsert：删除远端已不存在的条目时不能波及其它账号的缓存，
+            // 否则切换账号会清空别的账号的域名（连带丢失它们的 pinned 状态）。
+            let predicate = #Predicate<CachedZone> { $0.accountId == accountId }
+            let existing = try context.fetch(FetchDescriptor<CachedZone>(predicate: predicate))
+            let fetchedIDs = Set(zones.map(\.id))
 
-        for cached in existing where !fetchedIDs.contains(cached.id) {
-            context.delete(cached)
-        }
-        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
-        for zone in zones {
-            if let cached = existingByID[zone.id] {
-                cached.update(from: zone)
-            } else {
-                context.insert(CachedZone(from: zone, accountId: accountId))
+            for cached in existing where !fetchedIDs.contains(cached.id) {
+                context.delete(cached)
             }
+            let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+            for zone in zones {
+                if let cached = existingByID[zone.id] {
+                    cached.update(from: zone)
+                } else {
+                    context.insert(CachedZone(from: zone, accountId: accountId))
+                }
+            }
+            try context.save()
         }
-        try context.save()
 
         WidgetSnapshot(
             accountId: accountId,
@@ -47,23 +50,25 @@ enum CacheSync {
         SpotlightIndexer.indexZones(zones)
     }
 
-    /// Worker 脚本列表 upsert 进缓存（仅限当前账号）
-    static func syncWorkers(_ scripts: [WorkerScript], accountId: String, context: ModelContext) throws {
-        let predicate = #Predicate<CachedWorkerScript> { $0.accountId == accountId }
-        let existing = try context.fetch(FetchDescriptor<CachedWorkerScript>(predicate: predicate))
-        let fetchedIDs = Set(scripts.map(\.id))
+    /// Worker 脚本列表 upsert 进缓存（仅限当前账号）；写失败静默放弃（同上）。
+    static func syncWorkers(_ scripts: [WorkerScript], accountId: String, context: ModelContext) {
+        SafeCache.perform("syncWorkers") {
+            let predicate = #Predicate<CachedWorkerScript> { $0.accountId == accountId }
+            let existing = try context.fetch(FetchDescriptor<CachedWorkerScript>(predicate: predicate))
+            let fetchedIDs = Set(scripts.map(\.id))
 
-        for cached in existing where !fetchedIDs.contains(cached.id) {
-            context.delete(cached)
-        }
-        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
-        for script in scripts {
-            if let cached = existingByID[script.id] {
-                cached.update(from: script)
-            } else {
-                context.insert(CachedWorkerScript(from: script, accountId: accountId))
+            for cached in existing where !fetchedIDs.contains(cached.id) {
+                context.delete(cached)
             }
+            let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+            for script in scripts {
+                if let cached = existingByID[script.id] {
+                    cached.update(from: script)
+                } else {
+                    context.insert(CachedWorkerScript(from: script, accountId: accountId))
+                }
+            }
+            try context.save()
         }
-        try context.save()
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/SafeCache.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/SafeCache.swift
@@ -1,0 +1,60 @@
+//
+//  SafeCache.swift
+//  Orange Cloud
+//
+//  SwiftData 缓存读写的 ObjC 异常收口。iOS 17.x 的 CoreData 会在个别设备上直接抛
+//  NSException（TF 崩溃点 D8tiH4pqdctLgx_nCLGnZ：纯谓词 fetch；Sentry APPLE-IOS-Y：
+//  冷启动早期实体解析失败 "could not locate an NSEntityDescription for entity name"），
+//  Swift 的 try/try? 只接 Swift Error，接不住 NSException。缓存是可随时从 API 重拉的
+//  非关键数据，绝不允许它把 App 崩掉——所有对缓存库的 fetch / 写入段必须经此收口，
+//  异常按「缓存缺失」处理并计入店健康（连续异常触发下次启动清库重建）。
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+enum SafeCache {
+
+    /// 带 ObjC 异常兜底的 fetch：异常时返回 nil（调用方按缓存缺失 / 不新鲜处理）。
+    static func fetch<T: PersistentModel>(
+        _ descriptor: FetchDescriptor<T>, context: ModelContext
+    ) -> [T]? {
+        var fetched: [T]?
+        let exception = OCCatchException {
+            fetched = try? context.fetch(descriptor)
+        }
+        if let exception {
+            note(exception, label: "fetch \(T.self)")
+            return nil
+        }
+        CacheContainer.noteFetchHealthy()
+        return fetched
+    }
+
+    /// 把一段同步的缓存读写（fetch + insert/delete + save）整体包进 ObjC @try。
+    /// 异常时整段放弃并返回 false；body 里的 Swift Error 只记日志（缓存写失败不上抛，
+    /// API 数据已在手，UI 不受影响）。注意 body 必须是同步代码，不能包含 await。
+    @discardableResult
+    static func perform(_ label: String, _ body: () throws -> Void) -> Bool {
+        var swiftError: Error?
+        let exception = OCCatchException {
+            do { try body() } catch { swiftError = error }
+        }
+        if let exception {
+            note(exception, label: label)
+            return false
+        }
+        CacheContainer.noteFetchHealthy()
+        if let swiftError {
+            AppLog.app.info("缓存操作失败（已忽略，\(label)）：\(swiftError.localizedDescription)")
+            return false
+        }
+        return true
+    }
+
+    private static func note(_ exception: NSException, label: String) {
+        AppLog.app.error("缓存 \(label) 抛 ObjC 异常（已兜住，按缓存缺失处理）：\(exception.name.rawValue) — \(exception.reason ?? "无 reason")")
+        CacheContainer.noteFetchException()
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Intents/ZoneEntity.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Intents/ZoneEntity.swift
@@ -37,10 +37,13 @@ nonisolated struct ZoneEntity: AppEntity, Identifiable {
 
 nonisolated struct ZoneEntityQuery: EntityQuery {
 
+    // fetch 一律走 SafeCache（iOS 17.x CoreData 会抛 Swift 接不住的 NSException，
+    // 系统在冷启动就可能来查实体，异常按无缓存处理，绝不让 Intents 查询崩掉 App）。
+
     func entities(for identifiers: [ZoneEntity.ID]) async throws -> [ZoneEntity] {
-        try await MainActor.run {
+        await MainActor.run {
             let context = ModelContext(CacheContainer.shared)
-            let zones = try context.fetch(FetchDescriptor<CachedZone>())
+            let zones = SafeCache.fetch(FetchDescriptor<CachedZone>(), context: context) ?? []
             return zones
                 .filter { identifiers.contains($0.id) }
                 .map(ZoneEntity.init(from:))
@@ -48,12 +51,13 @@ nonisolated struct ZoneEntityQuery: EntityQuery {
     }
 
     func suggestedEntities() async throws -> [ZoneEntity] {
-        try await MainActor.run {
+        await MainActor.run {
             let context = ModelContext(CacheContainer.shared)
-            let zones = try context.fetch(
-                FetchDescriptor<CachedZone>(sortBy: [SortDescriptor(\.name)])
-            )
-            return zones.map(ZoneEntity.init(from:))
+            let zones = SafeCache.fetch(FetchDescriptor<CachedZone>(), context: context) ?? []
+            // 内存排序：iOS 17.0 的 CoreData 对带 sortBy 的 fetch 更易触发 NSException（缓存行数小，内存排序足够）
+            return zones
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                .map(ZoneEntity.init(from:))
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/AppNotifications.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/AppNotifications.swift
@@ -51,7 +51,8 @@ enum AppNotifications {
     /// Zone 状态：与 SwiftData 缓存对比，变化即通知并回写缓存
     private static func checkZoneStatusChanges(zoneService: ZoneService) async {
         let context = ModelContext(CacheContainer.shared)
-        guard let cached = try? context.fetch(FetchDescriptor<CachedZone>()), !cached.isEmpty else { return }
+        guard let cached = SafeCache.fetch(FetchDescriptor<CachedZone>(), context: context),
+              !cached.isEmpty else { return }
 
         var changes: [(name: String, from: String, to: String)] = []
         // 按缓存中的账户分组拉取（上限 5 个账户，控制后台时间预算）
@@ -66,7 +67,7 @@ enum AppNotifications {
                 }
             }
         }
-        try? context.save()
+        SafeCache.perform("Zone 状态回写") { try context.save() }
 
         guard !changes.isEmpty else { return }
         if changes.count == 1, let change = changes.first {

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/BackgroundRefresh.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/BackgroundRefresh.swift
@@ -54,7 +54,7 @@ enum BackgroundRefresh {
         let account = accounts.first { $0.id == targetId } ?? accounts[0]
         guard let zones = try? await ZoneService(client: client).listZones(accountId: account.id) else { return }
         let context = ModelContext(CacheContainer.shared)
-        try? CacheSync.syncZones(zones, accountId: account.id, accountName: account.name, context: context)
+        CacheSync.syncZones(zones, accountId: account.id, accountName: account.name, context: context)
         // Widget 账号目录（选择账号 picker 数据源）后台也保持最新
         if let sessionId = authManager.currentSessionId {
             WidgetDataStore.mergeAccounts(

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -117036,6 +117036,234 @@
         }
       }
     },
+    "规则按从上到下的顺序执行，点按可编辑，左滑可删除。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُنفَّذ القواعد من الأعلى إلى الأسفل. انقر للتعديل، واسحب لليسار للحذف."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regeln werden von oben nach unten ausgeführt. Zum Bearbeiten antippen, zum Löschen nach links wischen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules run top to bottom. Tap to edit, swipe left to delete."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las reglas se ejecutan de arriba abajo. Toca para editar, desliza a la izquierda para eliminar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les règles s’exécutent de haut en bas. Touchez pour modifier, balayez vers la gauche pour supprimer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルールは上から順に実行されます。タップで編集、左にスワイプで削除できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "규칙은 위에서 아래로 실행됩니다. 탭하여 편집하고 왼쪽으로 밀어 삭제하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras são executadas de cima para baixo. Toque para editar, deslize para a esquerda para excluir."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras são executadas de cima para baixo. Toque para editar, deslize para a esquerda para eliminar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurallar yukarıdan aşağıya çalışır. Düzenlemek için dokunun, silmek için sola kaydırın."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則按從上到下的順序執行，點按可編輯，左滑可刪除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則按從上到下的順序執行，點按可編輯，左滑可刪除。"
+          }
+        }
+      }
+    },
+    "暂不支持编辑" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التعديل غير مدعوم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bearbeiten nicht unterstützt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editing Not Supported"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edición no disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modification non prise en charge"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集には未対応"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집 미지원"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edição não suportada"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edição não suportada"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Düzenleme desteklenmiyor"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不支援編輯"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不支援編輯"
+          }
+        }
+      }
+    },
+    "「跳过」等带额外参数的规则暂不支持在 App 内编辑，请在 Cloudflare Dashboard 中修改。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "القواعد التي تتضمن معلمات إضافية (مثل التخطي) لا يمكن تعديلها داخل التطبيق حالياً. يُرجى تعديلها من لوحة تحكم Cloudflare."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regeln mit zusätzlichen Parametern (z. B. Überspringen) können in der App noch nicht bearbeitet werden. Bitte im Cloudflare-Dashboard ändern."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules with extra parameters (such as Skip) can’t be edited in the app yet. Please modify them in the Cloudflare Dashboard."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las reglas con parámetros adicionales (como Omitir) aún no se pueden editar en la app. Modifícalas en el panel de Cloudflare."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les règles avec des paramètres supplémentaires (comme Ignorer) ne peuvent pas encore être modifiées dans l’app. Veuillez les modifier dans le tableau de bord Cloudflare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「スキップ」など追加パラメータを持つルールはアプリ内では編集できません。Cloudflare ダッシュボードで変更してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「건너뛰기」 등 추가 매개변수가 있는 규칙은 아직 앱에서 편집할 수 없습니다. Cloudflare 대시보드에서 수정해 주세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas no app. Modifique-as no painel da Cloudflare."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas na app. Modifique-as no painel da Cloudflare."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ek parametreler içeren kurallar (ör. Atla) şimdilik uygulama içinde düzenlenemez. Lütfen Cloudflare panosundan değiştirin."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。"
+          }
+        }
+      }
+    },
     "规则按从上到下的顺序执行，左滑可删除。" : {
       "localizations" : {
         "ar" : {

--- a/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
@@ -33,6 +33,8 @@ struct Orange_CloudApp: App {
         let manager = AuthManager()
         _authManager = State(initialValue: manager)
         CrashReporter.recordBreadcrumb("AppStart auth manager created")
+        // 串行预热缓存库实体解析（iOS 17.x 冷启动首次并发 fetch 竞态，Sentry APPLE-IOS-Y）
+        CacheContainer.warmUp()
         WhatsNewGate.wasLoggedInAtLaunch = manager.isLoggedIn
         BackgroundRefresh.register(authManager: manager)
         // iOS 26 连续后台任务（R2 大对象 copy/move 续传），须在启动时注册处理器

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WAFService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WAFService.swift
@@ -2,7 +2,7 @@
 //  WAFService.swift
 //  Orange Cloud
 //
-//  WAF 自定义规则：读 entrypoint ruleset；启停单条规则（PATCH）。
+//  WAF 自定义规则：读 entrypoint ruleset；新建 / 编辑 / 删除 / 启停单条规则。
 //
 
 import Foundation
@@ -47,6 +47,23 @@ struct WAFService {
         let response: CFAPIResponse<WAFRuleset> = try await client.patch(
             "zones/\(zoneId)/rulesets/\(rulesetId)/rules/\(ruleId)",
             body: WAFRuleToggle(enabled: enabled)
+        )
+        guard response.success, let ruleset = response.result else {
+            throw response.toAPIError()
+        }
+        return ruleset
+    }
+
+    /// 整条更新规则（动作 / 表达式 / 名称 / 启用），返回更新后的 ruleset
+    func updateRule(
+        zoneId: String,
+        rulesetId: String,
+        ruleId: String,
+        rule: WAFRuleCreate
+    ) async throws -> WAFRuleset {
+        let response: CFAPIResponse<WAFRuleset> = try await client.patch(
+            "zones/\(zoneId)/rulesets/\(rulesetId)/rules/\(ruleId)",
+            body: rule
         )
         guard response.success, let ruleset = response.result else {
             throw response.toAPIError()

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/AddZoneViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/AddZoneViewModel.swift
@@ -43,12 +43,14 @@ final class AddZoneViewModel {
 
     private func upsert(_ zone: Zone, accountId: String, context: ModelContext) {
         let zoneId = zone.id
-        let descriptor = FetchDescriptor<CachedZone>(predicate: #Predicate { $0.id == zoneId })
-        if let existing = try? context.fetch(descriptor).first {
-            existing.update(from: zone)
-        } else {
-            context.insert(CachedZone(from: zone, accountId: accountId))
+        SafeCache.perform("新 Zone 缓存 upsert") {
+            let descriptor = FetchDescriptor<CachedZone>(predicate: #Predicate { $0.id == zoneId })
+            if let existing = try context.fetch(descriptor).first {
+                existing.update(from: zone)
+            } else {
+                context.insert(CachedZone(from: zone, accountId: accountId))
+            }
+            try context.save()
         }
-        try? context.save()
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DNSListViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DNSListViewModel.swift
@@ -53,7 +53,7 @@ final class DNSListViewModel {
         error = nil
         do {
             let records = try await dnsService.listRecords(zoneId: zoneId)
-            try sync(records: records, context: context)
+            sync(records: records, context: context)
             SpotlightIndexer.indexDNSRecords(records, zoneId: zoneId, zoneName: zoneName)
         } catch is CancellationError {
             // 任务取消属正常生命周期，不算加载失败
@@ -77,7 +77,7 @@ final class DNSListViewModel {
             } else {
                 saved = try await dnsService.createRecord(zoneId: zoneId, record: record)
             }
-            try upsert(saved, context: context)
+            upsert(saved, context: context)
             didSave.toggle()
             return true
         } catch {
@@ -110,52 +110,58 @@ final class DNSListViewModel {
         error = nil
         do {
             try await dnsService.deleteRecord(zoneId: zoneId, recordId: recordId)
-            let descriptor = FetchDescriptor<CachedDNSRecord>(
-                predicate: #Predicate { $0.id == recordId }
-            )
-            for cached in try context.fetch(descriptor) {
-                context.delete(cached)
+            SafeCache.perform("DNS 缓存删除") {
+                let descriptor = FetchDescriptor<CachedDNSRecord>(
+                    predicate: #Predicate { $0.id == recordId }
+                )
+                for cached in try context.fetch(descriptor) {
+                    context.delete(cached)
+                }
+                try context.save()
             }
-            try context.save()
         } catch {
             self.error = error.localizedDescription
         }
     }
 
-    // MARK: - 缓存同步
+    // MARK: - 缓存同步（写失败静默放弃：API 数据已在手，UI 不受影响）
 
-    private func sync(records: [DNSRecord], context: ModelContext) throws {
+    private func sync(records: [DNSRecord], context: ModelContext) {
         let zoneId = self.zoneId
-        let descriptor = FetchDescriptor<CachedDNSRecord>(
-            predicate: #Predicate { $0.zoneId == zoneId }
-        )
-        let existing = try context.fetch(descriptor)
-        let fetchedIDs = Set(records.map(\.id))
+        SafeCache.perform("DNS 缓存同步") {
+            let descriptor = FetchDescriptor<CachedDNSRecord>(
+                predicate: #Predicate { $0.zoneId == zoneId }
+            )
+            let existing = try context.fetch(descriptor)
+            let fetchedIDs = Set(records.map(\.id))
 
-        for cached in existing where !fetchedIDs.contains(cached.id) {
-            context.delete(cached)
+            for cached in existing where !fetchedIDs.contains(cached.id) {
+                context.delete(cached)
+            }
+            let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+            for record in records {
+                if let cached = existingByID[record.id] {
+                    cached.update(from: record)
+                } else {
+                    context.insert(CachedDNSRecord(from: record, zoneId: zoneId))
+                }
+            }
+            try context.save()
         }
-        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
-        for record in records {
-            if let cached = existingByID[record.id] {
+    }
+
+    private func upsert(_ record: DNSRecord, context: ModelContext) {
+        let recordId = record.id
+        SafeCache.perform("DNS 缓存 upsert") {
+            let descriptor = FetchDescriptor<CachedDNSRecord>(
+                predicate: #Predicate { $0.id == recordId }
+            )
+            if let cached = try context.fetch(descriptor).first {
                 cached.update(from: record)
             } else {
                 context.insert(CachedDNSRecord(from: record, zoneId: zoneId))
             }
+            try context.save()
         }
-        try context.save()
-    }
-
-    private func upsert(_ record: DNSRecord, context: ModelContext) throws {
-        let recordId = record.id
-        let descriptor = FetchDescriptor<CachedDNSRecord>(
-            predicate: #Predicate { $0.id == recordId }
-        )
-        if let cached = try context.fetch(descriptor).first {
-            cached.update(from: record)
-        } else {
-            context.insert(CachedDNSRecord(from: record, zoneId: zoneId))
-        }
-        try context.save()
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
@@ -121,10 +121,10 @@ final class DashboardViewModel {
             loadFailed = true
             return
         }
-        try? CacheSync.syncZones(zones, accountId: accountId, accountName: accountName, context: context)
+        CacheSync.syncZones(zones, accountId: accountId, accountName: accountName, context: context)
 
         if canReadWorkers, let scripts = try? await workerService.listScripts(accountId: accountId) {
-            try? CacheSync.syncWorkers(scripts, accountId: accountId, context: context)
+            CacheSync.syncWorkers(scripts, accountId: accountId, context: context)
         }
 
         if canReadDNS {
@@ -148,14 +148,16 @@ final class DashboardViewModel {
             } else if !counts.isEmpty {
                 dnsRecordTotal = counts.reduce(0) { $0 + $1.count }
                 // 分域名回写缓存：域名详情页首屏直显记录数（不再默认 0 条等进列表刷新）
-                let rows = (try? context.fetch(
-                    FetchDescriptor<CachedZone>(predicate: #Predicate { $0.accountId == accountId })
-                )) ?? []
-                let byId = Dictionary(rows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
-                for (zoneId, count) in counts {
-                    byId[zoneId]?.dnsRecordCount = count
+                SafeCache.perform("dnsRecordCount 回写") {
+                    let rows = try context.fetch(
+                        FetchDescriptor<CachedZone>(predicate: #Predicate { $0.accountId == accountId })
+                    )
+                    let byId = Dictionary(rows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+                    for (zoneId, count) in counts {
+                        byId[zoneId]?.dnsRecordCount = count
+                    }
+                    try context.save()
                 }
-                try? context.save()
             }
         }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/TunnelWAFViewModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/TunnelWAFViewModels.swift
@@ -338,6 +338,23 @@ final class WAFRulesViewModel {
         }
     }
 
+    /// 编辑既有规则（整条 PATCH）。成功返回 true。
+    func updateRule(ruleId: String, draft: WAFRuleCreate) async -> Bool {
+        guard let rulesetId = ruleset?.id, !isSaving else { return false }
+        isSaving = true
+        error = nil
+        defer { isSaving = false }
+        do {
+            ruleset = try await service.updateRule(
+                zoneId: zoneId, rulesetId: rulesetId, ruleId: ruleId, rule: draft
+            )
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
     func delete(rule: WAFRule) async {
         guard let rulesetId = ruleset?.id else { return }
         error = nil

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerListViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerListViewModel.swift
@@ -46,7 +46,7 @@ final class WorkerListViewModel {
         error = nil
         do {
             let scripts = try await workerService.listScripts(accountId: accountId)
-            try CacheSync.syncWorkers(scripts, accountId: accountId, context: context)
+            CacheSync.syncWorkers(scripts, accountId: accountId, context: context)
         } catch is CancellationError {
             // 任务取消属正常生命周期，不算加载失败
         } catch let urlError as URLError where urlError.code == .cancelled {

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZoneListViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZoneListViewModel.swift
@@ -52,7 +52,7 @@ final class ZoneListViewModel {
         error = nil
         do {
             let zones = try await zoneService.listZones(accountId: accountId)
-            try CacheSync.syncZones(zones, accountId: accountId, accountName: accountName, context: context)
+            CacheSync.syncZones(zones, accountId: accountId, accountName: accountName, context: context)
         } catch is CancellationError {
             // 任务取消属正常生命周期，不算加载失败
         } catch let urlError as URLError where urlError.code == .cancelled {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/WAF/WAFRuleListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/WAF/WAFRuleListView.swift
@@ -2,7 +2,7 @@
 //  WAFRuleListView.swift
 //  Orange Cloud
 //
-//  WAF 自定义规则：查看 / 新建 / 删除 / 启停，写操作按 zone-waf.write 门控。
+//  WAF 自定义规则：查看 / 新建 / 编辑 / 删除 / 启停，写操作按 zone-waf.write 门控。
 //
 
 import SwiftUI
@@ -15,6 +15,8 @@ struct WAFRuleListView: View {
     @State private var viewModel: WAFRulesViewModel
     @State private var showDenied = false
     @State private var showForm = false
+    @State private var editingRule: WAFRule?
+    @State private var showUnsupportedEdit = false
     @State private var ruleToDelete: WAFRule?
     @State private var searchText = ""
 
@@ -68,6 +70,16 @@ struct WAFRuleListView: View {
                                 },
                                 onDenied: { showDenied = true }
                             )
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                guard canWrite else { return }
+                                // skip 等带额外参数的动作不在表单支持范围，改动会丢参数
+                                if WAFRuleAction(rawValue: rule.action ?? "") != nil {
+                                    editingRule = rule
+                                } else {
+                                    showUnsupportedEdit = true
+                                }
+                            }
                             .swipeActions(edge: .trailing) {
                                 Button(role: .destructive) {
                                     if canWrite {
@@ -82,7 +94,7 @@ struct WAFRuleListView: View {
                         }
                     } footer: {
                         Text(canWrite
-                             ? String(localized: "规则按从上到下的顺序执行，左滑可删除。")
+                             ? String(localized: "规则按从上到下的顺序执行，点按可编辑，左滑可删除。")
                              : String(localized: "当前授权仅限读取（zone-waf.read），无法修改规则。"))
                     }
                     .glassRow()
@@ -107,7 +119,10 @@ struct WAFRuleListView: View {
             }
         }
         .sheet(isPresented: $showForm) {
-            WAFRuleFormView(viewModel: viewModel)
+            WAFRuleFormView(viewModel: viewModel, rule: nil)
+        }
+        .sheet(item: $editingRule) { rule in
+            WAFRuleFormView(viewModel: viewModel, rule: rule)
         }
         .task { await viewModel.load() }
         .confirmationDialog(
@@ -126,13 +141,18 @@ struct WAFRuleListView: View {
         } message: {
             Text("此操作不可撤销，规则将立即停止生效。")
         }
+        .alert("暂不支持编辑", isPresented: $showUnsupportedEdit) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("「跳过」等带额外参数的规则暂不支持在 App 内编辑，请在 Cloudflare Dashboard 中修改。")
+        }
         .alert("权限不足", isPresented: $showDenied) {
             Button("好", role: .cancel) {}
         } message: {
             Text("当前授权未包含 WAF 编辑权限（zone-waf.write）。\n请在设置中退出登录后重新授权以启用此功能。")
         }
         .alert("出错了", isPresented: .init(
-            get: { viewModel.error != nil && !showForm },
+            get: { viewModel.error != nil && !showForm && editingRule == nil },
             set: { if !$0 { viewModel.error = nil } }
         )) {
             Button("好", role: .cancel) {}
@@ -142,11 +162,13 @@ struct WAFRuleListView: View {
     }
 }
 
-// MARK: - 新建规则表单
+// MARK: - 新建 / 编辑规则表单
 
 private struct WAFRuleFormView: View {
 
     let viewModel: WAFRulesViewModel
+    /// 非 nil 为编辑模式：预填并以表达式编辑器打开（表达式反解回条件行不可靠）
+    let rule: WAFRule?
 
     @Environment(\.dismiss) private var dismiss
 
@@ -178,6 +200,18 @@ private struct WAFRuleFormView: View {
     // 设备端 AI 生成
     @State private var nlPrompt = ""
     @State private var readback: String?
+
+    init(viewModel: WAFRulesViewModel, rule: WAFRule?) {
+        self.viewModel = viewModel
+        self.rule = rule
+        if let rule {
+            _name = State(initialValue: rule.description ?? "")
+            _action = State(initialValue: WAFRuleAction(rawValue: rule.action ?? "") ?? .block)
+            _enabled = State(initialValue: rule.enabled ?? true)
+            _expression = State(initialValue: rule.expression ?? "")
+            _mode = State(initialValue: .expression)
+        }
+    }
 
     /// 由条件行实时生成的表达式
     private var generatedExpression: String {
@@ -248,7 +282,7 @@ private struct WAFRuleFormView: View {
                     }
                 }
             }
-            .navigationTitle("新建规则")
+            .navigationTitle(rule == nil ? String(localized: "新建规则") : String(localized: "编辑规则"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -442,7 +476,13 @@ private struct WAFRuleFormView: View {
             description: name.trimmingCharacters(in: .whitespaces),
             enabled: enabled
         )
-        if await viewModel.addRule(draft) {
+        let saved: Bool
+        if let rule {
+            saved = await viewModel.updateRule(ruleId: rule.id, draft: draft)
+        } else {
+            saved = await viewModel.addRule(draft)
+        }
+        if saved {
             dismiss()
         }
     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
@@ -294,7 +294,7 @@ struct ZoneDetailView: View {
                     withAnimation(.smooth) {
                         zone.pinned.toggle()
                     }
-                    try? modelContext.save()
+                    SafeCache.perform("pin 状态保存") { try modelContext.save() }
                 }
                 .contentTransition(.symbolEffect(.replace))
             }
@@ -312,7 +312,7 @@ struct ZoneDetailView: View {
             if zone.dnsRecordCount == nil, records.isEmpty, auth.hasScope("dns.read"),
                let count = try? await session.dnsService.recordCount(zoneId: zone.id) {
                 zone.dnsRecordCount = count
-                try? modelContext.save()
+                SafeCache.perform("dnsRecordCount 保存") { try modelContext.save() }
             }
         }
         .refreshable {


### PR DESCRIPTION
## 变更

### WAF 自定义规则支持编辑（用户反馈）
- `WAFService.updateRule`：PATCH 整条规则（动作/表达式/名称/启用）
- 规则行点按进入编辑表单，预填后以表达式编辑器打开
- `skip` 等带额外参数的动作禁止 App 内编辑（避免整条 PATCH 丢 `action_parameters`），提示去 Dashboard
- 3 个新文案 key 已补齐 13 语

### SwiftData 缓存读写全量收口（Sentry APPLE-IOS-Y）
- iOS 17.x 冷启动实体解析 NSException（Swift 接不住）在 1.8.3(30) 仍有漏网崩溃
- 新增 `SafeCache`（fetch 守卫 + 整段写守卫），9 处裸调用点全部接入
- `CacheContainer.warmUp()` 启动串行预热实体解析
- ZoneEntity 查询 sortBy → 内存排序

## 验证
- `xcodebuild -scheme "Orange Cloud"` 构建通过（Xcode-beta），无新增 warning
- 计划随下一个版本（1.8.4）发 TestFlight 后真机 iOS 17.0 回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)