### PR TITLE
release(android): 1.6.3(12) direct——WAF 规则编辑

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         // 实况通知促升(API36) 均 if-guard 渐进增强，Android 8–11 落固定品牌调色板与常驻通知回退。
         minSdk = 26
         targetSdk = 36
-        versionCode = 11
-        versionName = "1.6.2"
+        versionCode = 12
+        versionName = "1.6.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/Scopes.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/auth/Scopes.kt
@@ -2,7 +2,8 @@ package jiamin.chen.orangecloud.core.auth
 
 /**
  * OAuth scope ID（来自 GET /client/v4/oauth/scopes 的 id 字段，与 iOS PermissionModels 一致）。
- * 注意：Cloudflare 的 authorization_code 授权默认返回 refresh_token，**不需要** offline_access。
+ * 注意：CF dash OAuth（Hydra 系）只在请求 offline_access 时才签发 refresh token（issue #44 踩坑实证），
+ * 该 scope 由 AuthRepository.buildAuthorizationUri 在咽喉点统一追加，此处无需（也勿）列入目录。
  */
 object Scopes {
     const val ACCOUNT_READ = "account-settings.read"

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/SecurityRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/SecurityRepository.kt
@@ -35,6 +35,10 @@ class SecurityRepository @Inject constructor(
     suspend fun setRuleEnabled(zoneId: String, rulesetId: String, rule: WafRule, enabled: Boolean): WafRuleset =
         api.patch("zones/$zoneId/rulesets/$rulesetId/rules/${rule.id}", WafRuleToggle(enabled))
 
+    /** 整条更新规则（动作 / 表达式 / 名称 / 启用），返回更新后的 ruleset。 */
+    suspend fun updateRule(zoneId: String, rulesetId: String, ruleId: String, rule: WafRuleCreate): WafRuleset =
+        api.patch("zones/$zoneId/rulesets/$rulesetId/rules/$ruleId", rule)
+
     /** 向已有规则集追加规则，返回更新后的 ruleset。 */
     suspend fun addRule(zoneId: String, rulesetId: String, rule: WafRuleCreate): WafRuleset =
         api.post("zones/$zoneId/rulesets/$rulesetId/rules", rule)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/waf/WafRulesScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/waf/WafRulesScreen.kt
@@ -90,6 +90,8 @@ fun WafRulesScreen(
     val onSky = phase.onSky
     val snackbarHostState = remember { SnackbarHostState() }
     var showForm by remember { mutableStateOf(false) }
+    var editingRule by remember { mutableStateOf<WafRule?>(null) }
+    var showUnsupportedEdit by remember { mutableStateOf(false) }
     var ruleToDelete by remember { mutableStateOf<WafRule?>(null) }
 
     val savedMsg = stringResource(R.string.waf_saved)
@@ -98,7 +100,7 @@ fun WafRulesScreen(
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
-                WafEvent.Saved -> { showForm = false; snackbarHostState.showSnackbar(savedMsg) }
+                WafEvent.Saved -> { showForm = false; editingRule = null; snackbarHostState.showSnackbar(savedMsg) }
                 WafEvent.Deleted -> snackbarHostState.showSnackbar(deletedMsg)
                 is WafEvent.Error -> snackbarHostState.showSnackbar(event.message ?: "")
             }
@@ -149,6 +151,14 @@ fun WafRulesScreen(
                                 canWrite = state.canWrite,
                                 onToggle = { viewModel.toggle(rule, it) },
                                 onDelete = { ruleToDelete = rule },
+                                onClick = {
+                                    // skip 等带额外参数的动作不在表单支持范围，整条 PATCH 会丢参数
+                                    if (WafCreateAction.entries.any { it.value == rule.action }) {
+                                        editingRule = rule
+                                    } else {
+                                        showUnsupportedEdit = true
+                                    }
+                                },
                             )
                         }
                     }
@@ -181,6 +191,32 @@ fun WafRulesScreen(
         }
     }
 
+    editingRule?.let { rule ->
+        ModalBottomSheet(
+            onDismissRequest = { if (!state.isSaving) editingRule = null },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            WafRuleForm(
+                isSaving = state.isSaving,
+                initial = rule,
+                onSave = { action, expression, name, enabled ->
+                    viewModel.updateRule(rule.id, action, expression, name, enabled)
+                },
+            )
+        }
+    }
+
+    if (showUnsupportedEdit) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { showUnsupportedEdit = false },
+            title = { Text(stringResource(R.string.waf_edit_unsupported_title)) },
+            text = { Text(stringResource(R.string.waf_edit_unsupported_msg)) },
+            confirmButton = {
+                TextButton(onClick = { showUnsupportedEdit = false }) { Text(stringResource(R.string.common_confirm)) }
+            },
+        )
+    }
+
     ruleToDelete?.let { rule ->
         androidx.compose.material3.AlertDialog(
             onDismissRequest = { ruleToDelete = null },
@@ -199,8 +235,16 @@ fun WafRulesScreen(
 }
 
 @Composable
-private fun WafRuleRow(rule: WafRule, canWrite: Boolean, onToggle: (Boolean) -> Unit, onDelete: () -> Unit) {
+private fun WafRuleRow(
+    rule: WafRule,
+    canWrite: Boolean,
+    onToggle: (Boolean) -> Unit,
+    onDelete: () -> Unit,
+    onClick: () -> Unit,
+) {
     Surface(
+        onClick = onClick,
+        enabled = canWrite,
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         shape = RoundedCornerShape(16.dp),
         modifier = Modifier.fillMaxWidth(),
@@ -246,12 +290,15 @@ private fun WafRuleRow(rule: WafRule, canWrite: Boolean, onToggle: (Boolean) -> 
 @Composable
 private fun WafRuleForm(
     isSaving: Boolean,
+    initial: WafRule? = null,
     onSave: (action: String, expression: String, name: String, enabled: Boolean) -> Unit,
 ) {
-    var name by rememberSaveable { mutableStateOf("") }
-    var expression by rememberSaveable { mutableStateOf("") }
-    var enabled by rememberSaveable { mutableStateOf(true) }
-    var action by rememberSaveable { mutableStateOf(WafCreateAction.BLOCK) }
+    var name by rememberSaveable { mutableStateOf(initial?.description.orEmpty()) }
+    var expression by rememberSaveable { mutableStateOf(initial?.expression.orEmpty()) }
+    var enabled by rememberSaveable { mutableStateOf(initial?.enabled ?: true) }
+    var action by rememberSaveable {
+        mutableStateOf(WafCreateAction.entries.firstOrNull { it.value == initial?.action } ?: WafCreateAction.BLOCK)
+    }
     var expanded by remember { mutableStateOf(false) }
     var showBuilder by remember { mutableStateOf(false) }
 
@@ -265,7 +312,7 @@ private fun WafRuleForm(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text(
-            stringResource(R.string.waf_add_title),
+            stringResource(if (initial == null) R.string.waf_add_title else R.string.waf_edit_title),
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/waf/WafRulesViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/waf/WafRulesViewModel.kt
@@ -116,6 +116,25 @@ class WafRulesViewModel @Inject constructor(
         }
     }
 
+    /** 编辑既有规则（整条 PATCH：动作 / 表达式 / 名称 / 启用）。 */
+    fun updateRule(ruleId: String, action: String, expression: String, description: String, enabled: Boolean) {
+        val rulesetId = _uiState.value.rulesetId ?: return
+        if (!canWrite) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                val rule = WafRuleCreate(action, expression.trim(), description.trim().ifBlank { null }, enabled)
+                val updated = securityRepository.updateRule(zoneId, rulesetId, ruleId, rule)
+                _uiState.update { it.copy(rules = updated.rules.orEmpty(), rulesetId = updated.id) }
+                eventChannel.send(WafEvent.Saved)
+            } catch (e: Exception) {
+                eventChannel.send(WafEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
     fun deleteRule(rule: WafRule) {
         val rulesetId = _uiState.value.rulesetId ?: return
         if (!canWrite) return

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -356,6 +356,9 @@
     <string name="waf_deleted">تم الحذف</string>
     <string name="waf_delete_confirm_title">حذف هذه القاعدة؟</string>
     <string name="waf_delete_confirm_msg">لا يمكن التراجع؛ تتوقف القاعدة عن العمل فورًا.</string>
+    <string name="waf_edit_title">تعديل القاعدة</string>
+    <string name="waf_edit_unsupported_title">التعديل غير مدعوم</string>
+    <string name="waf_edit_unsupported_msg">القواعد التي تتضمن معلمات إضافية (مثل التخطي) لا يمكن تعديلها داخل التطبيق حالياً. يُرجى تعديلها من لوحة تحكم Cloudflare.</string>
     <string name="tunnel_title">الأنفاق</string>
     <string name="tunnel_empty">لا توجد أنفاق بعد</string>
     <string name="tunnel_connections">%1$d اتصالات نشطة</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -356,6 +356,9 @@
     <string name="waf_deleted">Gelöscht</string>
     <string name="waf_delete_confirm_title">Diese Regel löschen?</string>
     <string name="waf_delete_confirm_msg">Dies kann nicht rückgängig gemacht werden; die Regel gilt sofort nicht mehr.</string>
+    <string name="waf_edit_title">Regel bearbeiten</string>
+    <string name="waf_edit_unsupported_title">Bearbeiten nicht unterstützt</string>
+    <string name="waf_edit_unsupported_msg">Regeln mit zusätzlichen Parametern (z. B. Überspringen) können in der App noch nicht bearbeitet werden. Bitte im Cloudflare-Dashboard ändern.</string>
     <string name="tunnel_title">Tunnel</string>
     <string name="tunnel_empty">Noch keine Tunnel</string>
     <string name="tunnel_connections">%1$d aktive Verbindungen</string>

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -261,6 +261,9 @@
     <string name="waf_deleted">Deleted</string>
     <string name="waf_delete_confirm_title">Delete this rule?</string>
     <string name="waf_delete_confirm_msg">This can\'t be undone; the rule stops applying immediately.</string>
+    <string name="waf_edit_title">Edit rule</string>
+    <string name="waf_edit_unsupported_title">Editing not supported</string>
+    <string name="waf_edit_unsupported_msg">Rules with extra parameters (such as Skip) can’t be edited in the app yet. Please modify them in the Cloudflare Dashboard.</string>
 
     <!-- Tunnel -->
     <string name="tunnel_title">Tunnels</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -245,6 +245,9 @@
     <string name="waf_deleted">Eliminado</string>
     <string name="waf_delete_confirm_title">¿Eliminar esta regla?</string>
     <string name="waf_delete_confirm_msg">No se puede deshacer; la regla deja de aplicarse de inmediato.</string>
+    <string name="waf_edit_title">Editar regla</string>
+    <string name="waf_edit_unsupported_title">Edición no disponible</string>
+    <string name="waf_edit_unsupported_msg">Las reglas con parámetros adicionales (como Omitir) aún no se pueden editar en la app. Modifícalas en el panel de Cloudflare.</string>
 
     <string name="tunnel_title">Túneles</string>
     <string name="tunnel_empty">Aún no hay túneles</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -356,6 +356,9 @@
     <string name="waf_deleted">Supprimé</string>
     <string name="waf_delete_confirm_title">Supprimer cette règle ?</string>
     <string name="waf_delete_confirm_msg">Action irréversible ; la règle cesse de s’appliquer immédiatement.</string>
+    <string name="waf_edit_title">Modifier la règle</string>
+    <string name="waf_edit_unsupported_title">Modification non prise en charge</string>
+    <string name="waf_edit_unsupported_msg">Les règles avec des paramètres supplémentaires (comme Ignorer) ne peuvent pas encore être modifiées dans l’app. Veuillez les modifier dans le tableau de bord Cloudflare.</string>
     <string name="tunnel_title">Tunnels</string>
     <string name="tunnel_empty">Aucun tunnel pour l’instant</string>
     <string name="tunnel_connections">%1$d connexions actives</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -244,6 +244,9 @@
     <string name="waf_deleted">削除しました</string>
     <string name="waf_delete_confirm_title">このルールを削除しますか？</string>
     <string name="waf_delete_confirm_msg">この操作は元に戻せません。ルールは直ちに適用停止されます。</string>
+    <string name="waf_edit_title">ルールを編集</string>
+    <string name="waf_edit_unsupported_title">編集には未対応</string>
+    <string name="waf_edit_unsupported_msg">「スキップ」など追加パラメータを持つルールはアプリ内では編集できません。Cloudflare ダッシュボードで変更してください。</string>
 
     <string name="tunnel_title">トンネル</string>
     <string name="tunnel_empty">トンネルがありません</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -244,6 +244,9 @@
     <string name="waf_deleted">삭제됨</string>
     <string name="waf_delete_confirm_title">이 규칙을 삭제할까요?</string>
     <string name="waf_delete_confirm_msg">되돌릴 수 없으며, 규칙이 즉시 적용 중지됩니다.</string>
+    <string name="waf_edit_title">규칙 편집</string>
+    <string name="waf_edit_unsupported_title">편집 미지원</string>
+    <string name="waf_edit_unsupported_msg">「건너뛰기」 등 추가 매개변수가 있는 규칙은 아직 앱에서 편집할 수 없습니다. Cloudflare 대시보드에서 수정해 주세요.</string>
 
     <string name="tunnel_title">터널</string>
     <string name="tunnel_empty">아직 터널이 없습니다</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -244,6 +244,9 @@
     <string name="waf_deleted">Excluído</string>
     <string name="waf_delete_confirm_title">Excluir esta regra?</string>
     <string name="waf_delete_confirm_msg">Não pode ser desfeito; a regra para de valer imediatamente.</string>
+    <string name="waf_edit_title">Editar regra</string>
+    <string name="waf_edit_unsupported_title">Edição não suportada</string>
+    <string name="waf_edit_unsupported_msg">Regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas no app. Modifique-as no painel da Cloudflare.</string>
 
     <string name="tunnel_title">Túneis</string>
     <string name="tunnel_empty">Ainda não há túneis</string>

--- a/apps/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -245,6 +245,9 @@
     <string name="waf_deleted">Excluído</string>
     <string name="waf_delete_confirm_title">Eliminar esta regra?</string>
     <string name="waf_delete_confirm_msg">Não pode ser desfeito; a regra para de valer imediatamente.</string>
+    <string name="waf_edit_title">Editar regra</string>
+    <string name="waf_edit_unsupported_title">Edição não suportada</string>
+    <string name="waf_edit_unsupported_msg">As regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas na app. Modifique-as no painel da Cloudflare.</string>
 
     <string name="tunnel_title">Túneis</string>
     <string name="tunnel_empty">Ainda não há túneis</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -356,6 +356,9 @@
     <string name="waf_deleted">Silindi</string>
     <string name="waf_delete_confirm_title">Bu kural silinsin mi?</string>
     <string name="waf_delete_confirm_msg">Bu geri alınamaz; kural hemen uygulanmayı durdurur.</string>
+    <string name="waf_edit_title">Kuralı düzenle</string>
+    <string name="waf_edit_unsupported_title">Düzenleme desteklenmiyor</string>
+    <string name="waf_edit_unsupported_msg">Ek parametreler içeren kurallar (ör. Atla) şimdilik uygulama içinde düzenlenemez. Lütfen Cloudflare panosundan değiştirin.</string>
     <string name="tunnel_title">Tüneller</string>
     <string name="tunnel_empty">Henüz tünel yok</string>
     <string name="tunnel_connections">%1$d etkin bağlantı</string>

--- a/apps/android/app/src/main/res/values-zh-rHK/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/strings.xml
@@ -244,6 +244,9 @@
     <string name="waf_deleted">已刪除</string>
     <string name="waf_delete_confirm_title">刪除此規則？</string>
     <string name="waf_delete_confirm_msg">此操作無法復原，規則將立即停止生效。</string>
+    <string name="waf_edit_title">編輯規則</string>
+    <string name="waf_edit_unsupported_title">暫不支援編輯</string>
+    <string name="waf_edit_unsupported_msg">「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。</string>
 
     <string name="tunnel_title">隧道</string>
     <string name="tunnel_empty">還沒有隧道</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -244,6 +244,9 @@
     <string name="waf_deleted">已刪除</string>
     <string name="waf_delete_confirm_title">刪除此規則？</string>
     <string name="waf_delete_confirm_msg">此操作無法復原，規則將立即停止生效。</string>
+    <string name="waf_edit_title">編輯規則</string>
+    <string name="waf_edit_unsupported_title">暫不支援編輯</string>
+    <string name="waf_edit_unsupported_msg">「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。</string>
 
     <string name="tunnel_title">隧道</string>
     <string name="tunnel_empty">還沒有隧道</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -429,6 +429,9 @@
     <string name="waf_deleted">已删除</string>
     <string name="waf_delete_confirm_title">删除此规则？</string>
     <string name="waf_delete_confirm_msg">此操作不可撤销，规则将立即停止生效。</string>
+    <string name="waf_edit_title">编辑规则</string>
+    <string name="waf_edit_unsupported_title">暂不支持编辑</string>
+    <string name="waf_edit_unsupported_msg">「跳过」等带额外参数的规则暂不支持在 App 内编辑，请在 Cloudflare Dashboard 中修改。</string>
 
     <!-- Tunnel -->
     <string name="tunnel_title">隧道</string>


### PR DESCRIPTION
## 变更
- WAF 自定义规则支持编辑（对齐 iOS 同批修复；点按规则卡进编辑表单，skip 等带额外参数动作提示去 Dashboard）
- 3 个新 string key 补齐 13 locale
- Scopes.kt 的 offline_access 过时注释修正
- versionCode 11→12，versionName 1.6.2→1.6.3

## 验证
- `./gradlew assembleDebug` 三风味全绿
- direct 渠道经 release-direct.sh 出签名包并部署官网

🤖 Generated with [Claude Code](https://claude.com/claude-code)