### PR TITLE
feat(ios): 1.8.5 — Worker 部署历史/就地编辑删除 + D1 删表

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -997,8 +997,8 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
-				SWIFT_OBJC_BRIDGING_HEADER = "Orange Cloud/OrangeCloud-Bridging-Header.h";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Orange Cloud/OrangeCloud-Bridging-Header.h";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1041,8 +1041,8 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
-				SWIFT_OBJC_BRIDGING_HEADER = "Orange Cloud/OrangeCloud-Bridging-Header.h";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Orange Cloud/OrangeCloud-Bridging-Header.h";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/ios/Orange Cloud/Orange Cloud/AppShortcuts.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/AppShortcuts.xcstrings
@@ -2,7 +2,6 @@
   "sourceLanguage" : "en",
   "strings" : {
     "打开 ${applicationName}" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -156,7 +155,6 @@
       }
     },
     "用 ${applicationName} 查域名" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -1369,6 +1369,82 @@
         }
       }
     },
+    "Worker 部署历史": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker deployment history"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 部署歷史"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 部署歷史"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker のデプロイ履歴"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial de despliegues de Worker"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 배포 기록"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico de implantações do Worker"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico de implementações do Worker"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker-Bereitstellungsverlauf"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique des déploiements Worker"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجل عمليات نشر Worker"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker dağıtım geçmişi"
+          }
+        }
+      }
+    },
     "Workers 与 Pages 列表新增排序：默认（名称）、创建日期、最近更新，选择会被记住。": {
       "localizations": {
         "en": {
@@ -2585,6 +2661,82 @@
         }
       }
     },
+    "删除 D1 数据表": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete D1 tables"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除 D1 資料表"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除 D1 資料表"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 テーブルを削除"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tablas de D1"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 테이블 삭제"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir tabelas do D1"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tabelas do D1"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1-Tabellen löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer des tables D1"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف جداول D1"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 tablolarını silme"
+          }
+        }
+      }
+    },
     "刷新失败不再弹窗打断，下拉刷新更稳定可靠。": {
       "localizations": {
         "en": {
@@ -3269,6 +3421,82 @@
         }
       }
     },
+    "在查询控制台长按任意表即可删除，需输入表名二次确认。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Long-press any table in the query console to drop it, with a type-the-name confirmation."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在查詢主控台長按任一表即可刪除，需輸入表名二次確認。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在查詢控制台長按任一表即可刪除，需輸入表名二次確認。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クエリコンソールでテーブルを長押しすると削除できます。テーブル名の入力による確認付きです。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén pulsada cualquier tabla en la consola de consultas para eliminarla, con confirmación escribiendo su nombre."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쿼리 콘솔에서 테이블을 길게 눌러 삭제할 수 있으며 이름을 입력해 확인합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque e segure qualquer tabela no console de consultas para excluí-la, com confirmação digitando o nome."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque sem soltar em qualquer tabela na consola de consultas para a eliminar, com confirmação escrevendo o nome."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Halte in der Abfragekonsole eine Tabelle gedrückt, um sie zu löschen – mit Bestätigung durch Eingabe des Namens."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appuyez longuement sur une table dans la console de requêtes pour la supprimer, avec confirmation en saisissant son nom."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط مطوّلاً على أي جدول في وحدة الاستعلام لحذفه، مع تأكيد بكتابة الاسم."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorgu konsolunda bir tabloya uzun basarak silin; adını yazarak onaylayın."
+          }
+        }
+      }
+    },
     "域名与路由": {
       "localizations": {
         "en": {
@@ -3569,6 +3797,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cron Tetikleyicileri"
+          }
+        }
+      }
+    },
+    "就地编辑与删除 Worker": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit and delete Workers in place"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "就地編輯與刪除 Worker"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "就地編輯與刪除 Worker"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker をその場で編集・削除"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edita y elimina Workers directamente"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker를 바로 편집·삭제"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edite e exclua Workers diretamente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edite e elimine Workers diretamente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker direkt bearbeiten und löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier et supprimer des Workers sur place"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعديل وحذف Workers مباشرةً"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker’ları yerinde düzenleyin ve silin"
           }
         }
       }
@@ -5701,6 +6005,82 @@
         }
       }
     },
+    "查看每个 Worker 的历次部署记录，并可删除不再需要的旧部署。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See every past deployment of a Worker and delete older ones you no longer need."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視每個 Worker 的歷次部署記錄，並可刪除不再需要的舊部署。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看每個 Worker 的歷次部署記錄，並可刪除不再需要的舊部署。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各 Worker の過去のデプロイを確認し、不要になった古いデプロイを削除できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta cada despliegue anterior de un Worker y elimina los que ya no necesites."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 Worker의 과거 배포를 확인하고 더 이상 필요 없는 이전 배포를 삭제할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja todas as implantações anteriores de um Worker e exclua as antigas que não precisa mais."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja todas as implementações anteriores de um Worker e elimine as antigas de que já não precisa."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sieh dir alle bisherigen Bereitstellungen eines Workers an und lösche nicht mehr benötigte alte Bereitstellungen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultez tous les déploiements passés d’un Worker et supprimez les anciens dont vous n’avez plus besoin."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اطّلع على كل عمليات نشر Worker السابقة واحذف القديمة التي لم تعد بحاجة إليها."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir Worker’ın geçmiş tüm dağıtımlarını görün ve artık ihtiyaç duymadığınız eskileri silin."
+          }
+        }
+      }
+    },
     "根治 iOS 17.0 上概览页、资源列表与域名详情的多处闪退与冻结；同时修复 Tunnel 页面卡死与冷启动请求翻倍的问题。": {
       "localizations": {
         "en": {
@@ -6609,6 +6989,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "R2 paketlerini, KV ad alanlarını, Pages projelerini, Queues, Hyperdrive ve AI Gateway'i doğrudan uygulamada oluşturun ve silin."
+          }
+        }
+      }
+    },
+    "直接载入线上源码修改后重新部署，变量、密钥与绑定自动保留；也可从 .js 文件导入，或删除整个 Worker。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Load the live source, edit it and redeploy — your variables, secrets and bindings are kept. You can also import from a .js file or delete the whole Worker."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接載入線上原始碼修改後重新部署，變數、密鑰與繫結自動保留；也可從 .js 檔案匯入，或刪除整個 Worker。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接載入線上原始碼修改後重新部署，變數、密鑰與綁定自動保留；也可從 .js 檔案匯入，或刪除整個 Worker。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稼働中のソースを読み込んで編集し、再デプロイできます。変数・シークレット・バインディングは保持されます。.js ファイルからの読み込みや Worker 全体の削除にも対応します。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carga el código en producción, edítalo y vuelve a desplegar; se conservan tus variables, secretos y enlaces. También puedes importar desde un archivo .js o eliminar todo el Worker."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 중인 소스를 불러와 수정한 뒤 다시 배포할 수 있으며 변수, 비밀, 바인딩이 유지됩니다. .js 파일에서 가져오거나 Worker 전체를 삭제할 수도 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregue o código em produção, edite e reimplante — suas variáveis, segredos e bindings são mantidos. Também dá para importar de um arquivo .js ou excluir o Worker inteiro."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregue o código em produção, edite e reimplante — as suas variáveis, segredos e ligações são mantidos. Também pode importar de um ficheiro .js ou eliminar o Worker inteiro."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lade den Live-Quellcode, bearbeite ihn und stelle neu bereit – Variablen, Secrets und Bindings bleiben erhalten. Du kannst auch aus einer .js-Datei importieren oder den ganzen Worker löschen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargez le code en production, modifiez-le et redéployez ; vos variables, secrets et liaisons sont conservés. Vous pouvez aussi importer depuis un fichier .js ou supprimer le Worker entier."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حمّل الشيفرة المباشرة وعدّلها وأعد النشر مع الحفاظ على المتغيرات والأسرار والارتباطات. يمكنك أيضًا الاستيراد من ملف ‎.js‎ أو حذف Worker بالكامل."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canlı kaynağı yükleyip düzenleyin ve yeniden dağıtın; değişkenleriniz, gizli anahtarlarınız ve bağlamalarınız korunur. Ayrıca bir .js dosyasından içe aktarabilir veya Worker’ın tamamını silebilirsiniz."
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,23 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "1.8.5", items: [
+            WhatsNewItem(
+                icon:   "clock.arrow.circlepath",
+                title:  String(localized: "Worker 部署历史", table: "WhatsNew"),
+                detail: String(localized: "查看每个 Worker 的历次部署记录，并可删除不再需要的旧部署。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "square.and.pencil",
+                title:  String(localized: "就地编辑与删除 Worker", table: "WhatsNew"),
+                detail: String(localized: "直接载入线上源码修改后重新部署，变量、密钥与绑定自动保留；也可从 .js 文件导入，或删除整个 Worker。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "tablecells",
+                title:  String(localized: "删除 D1 数据表", table: "WhatsNew"),
+                detail: String(localized: "在查询控制台长按任意表即可删除，需输入表名二次确认。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "1.8.4", items: [
             WhatsNewItem(
                 icon:   "shield.lefthalf.filled",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -915,6 +915,82 @@
         }
       }
     },
+    "「跳过」等带额外参数的规则暂不支持在 App 内编辑，请在 Cloudflare Dashboard 中修改。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "القواعد التي تتضمن معلمات إضافية (مثل التخطي) لا يمكن تعديلها داخل التطبيق حالياً. يُرجى تعديلها من لوحة تحكم Cloudflare."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regeln mit zusätzlichen Parametern (z. B. Überspringen) können in der App noch nicht bearbeitet werden. Bitte im Cloudflare-Dashboard ändern."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules with extra parameters (such as Skip) can’t be edited in the app yet. Please modify them in the Cloudflare Dashboard."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las reglas con parámetros adicionales (como Omitir) aún no se pueden editar en la app. Modifícalas en el panel de Cloudflare."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les règles avec des paramètres supplémentaires (comme Ignorer) ne peuvent pas encore être modifiées dans l’app. Veuillez les modifier dans le tableau de bord Cloudflare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「スキップ」など追加パラメータを持つルールはアプリ内では編集できません。Cloudflare ダッシュボードで変更してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「건너뛰기」 등 추가 매개변수가 있는 규칙은 아직 앱에서 편집할 수 없습니다. Cloudflare 대시보드에서 수정해 주세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas no app. Modifique-as no painel da Cloudflare."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas na app. Modifique-as no painel da Cloudflare."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ek parametreler içeren kurallar (ör. Atla) şimdilik uygulama içinde düzenlenemez. Lütfen Cloudflare panosundan değiştirin."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。"
+          }
+        }
+      }
+    },
     "*/5 * * * *" : {
       "localizations" : {
         "ar" : {
@@ -6193,6 +6269,82 @@
         }
       }
     },
+    "301/308 为永久跳转，302/303/307 为临时跳转；307/308 保留原 HTTP 方法。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 لإعادة توجيه دائمة، و302/303/307 لإعادة توجيه مؤقتة؛ يحافظ 307/308 على طريقة HTTP الأصلية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 sind permanente, 302/303/307 temporäre Weiterleitungen; 307/308 behalten die ursprüngliche HTTP-Methode bei."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 are permanent redirects, 302/303/307 are temporary; 307/308 preserve the original HTTP method."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 son redirecciones permanentes, 302/303/307 son temporales; 307/308 conservan el método HTTP original."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 sont des redirections permanentes, 302/303/307 des temporaires ; 307/308 conservent la méthode HTTP d'origine."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 は恒久的、302/303/307 は一時的なリダイレクトです。307/308 は元の HTTP メソッドを保持します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308은 영구 리디렉션, 302/303/307은 임시 리디렉션입니다. 307/308은 원래 HTTP 메서드를 유지합니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 são redirecionamentos permanentes, 302/303/307 são temporários; 307/308 preservam o método HTTP original."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 são redirecionamentos permanentes, 302/303/307 são temporários; 307/308 preservam o método HTTP original."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 kalıcı, 302/303/307 geçici yönlendirmelerdir; 307/308 özgün HTTP yöntemini korur."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 為永久跳轉，302/303/307 為暫時跳轉；307/308 保留原 HTTP 方法。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "301/308 為永久跳轉，302/303/307 為臨時跳轉；307/308 保留原 HTTP 方法。"
+          }
+        }
+      }
+    },
     "302 临时" : {
       "localizations" : {
         "ar" : {
@@ -9011,6 +9163,7 @@
       }
     },
     "Cloudflare 不允许第三方授权读取 Worker 源码，因此只能整体替换、无法在原代码上修改。现有变量 / 密钥 / 绑定会自动保留。" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9158,6 +9311,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cloudflare Proxy"
+          }
+        }
+      }
+    },
+    "Cloudflare 使用列表中访客浏览器支持的第一个算法；none 表示不压缩，auto/default 交给 Cloudflare 决定。长按拖动排序。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تستخدم Cloudflare أول خوارزمية في القائمة يدعمها متصفح الزائر؛ تعني none عدم الضغط، بينما تترك auto/default القرار لـ Cloudflare. اضغط مطولًا واسحب لإعادة الترتيب."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare verwendet den ersten Algorithmus der Liste, den der Browser des Besuchers unterstützt; none = keine Komprimierung, auto/default überlässt die Wahl Cloudflare. Zum Sortieren gedrückt halten und ziehen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare uses the first algorithm in the list that the visitor's browser supports; none means no compression, auto/default lets Cloudflare decide. Long-press and drag to reorder."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare usa el primer algoritmo de la lista que admita el navegador del visitante; none significa sin compresión y auto/default deja la decisión a Cloudflare. Mantén presionado y arrastra para reordenar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare utilise le premier algorithme de la liste pris en charge par le navigateur du visiteur ; none signifie aucune compression, auto/default laisse Cloudflare décider. Maintenez et faites glisser pour réordonner."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare は、訪問者のブラウザが対応するリスト内の最初のアルゴリズムを使用します。none は非圧縮、auto/default は Cloudflare に任せます。長押しでドラッグして並べ替え。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare는 방문자의 브라우저가 지원하는 목록의 첫 번째 알고리즘을 사용합니다. none은 압축 안 함, auto/default는 Cloudflare에 맡깁니다. 길게 눌러 드래그하여 순서를 바꾸세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A Cloudflare usa o primeiro algoritmo da lista compatível com o navegador do visitante; none significa sem compressão, auto/default deixa a decisão para a Cloudflare. Toque e segure para reordenar."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A Cloudflare usa o primeiro algoritmo da lista suportado pelo navegador do visitante; none significa sem compressão, auto/default deixa a decisão à Cloudflare. Toque sem soltar e arraste para reordenar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare, listede ziyaretçinin tarayıcısının desteklediği ilk algoritmayı kullanır; none sıkıştırma yok demektir, auto/default kararı Cloudflare'e bırakır. Yeniden sıralamak için basılı tutup sürükleyin."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 使用清單中訪客瀏覽器支援的第一個演算法；none 表示不壓縮，auto/default 交給 Cloudflare 決定。長按拖曳排序。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 使用列表入面訪客瀏覽器支援嘅第一個算法；none 表示唔壓縮，auto/default 交畀 Cloudflare 決定。長按拖動排序。"
           }
         }
       }
@@ -9999,6 +10228,7 @@
         }
       }
     },
+    "concat(\"https://example.com\", http.request.uri.path)" : {},
     "Content-Type" : {
       "localizations" : {
         "ar" : {
@@ -11902,6 +12132,82 @@
         }
       }
     },
+    "Email 混淆" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إخفاء عناوين البريد الإلكتروني"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-Mail-Verschleierung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email Obfuscation"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ofuscación de correo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obfuscation des e-mails"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メール難読化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이메일 난독화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ofuscação de e-mail"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ofuscação de e-mail"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-posta Gizleme"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email 混淆"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email 混淆"
+          }
+        }
+      }
+    },
     "ES Module" : {
       "localizations" : {
         "ar" : {
@@ -12742,6 +13048,158 @@
       },
       "shouldTranslate" : false
     },
+    "Host 标头覆盖（可选）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تجاوز ترويسة Host (اختياري)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host-Header-Override (optional)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host header override (optional)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anulación del encabezado Host (opcional)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacement de l'en-tête Host (facultatif)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host ヘッダーの上書き（任意）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host 헤더 재정의(선택 사항)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Substituição do cabeçalho Host (opcional)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Substituição do cabeçalho Host (opcional)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host üstbilgisi geçersiz kılma (isteğe bağlı)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host 標頭覆寫（選填）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host 標頭覆蓋（可選）"
+          }
+        }
+      }
+    },
+    "Host：%@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المضيف: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host: %@"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôte : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스트: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host: %@"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host：%@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host：%@"
+          }
+        }
+      }
+    },
     "hostname，如 app.example.com" : {
       "localizations" : {
         "ar" : {
@@ -13198,6 +13656,7 @@
         }
       }
     },
+    "https://example.com/new/" : {},
     "Hyperdrive" : {
       "localizations" : {
         "ar" : {
@@ -16247,6 +16706,159 @@
         }
       }
     },
+    "Page Rules" : {},
+    "Page Rules 为传统功能，仅支持查看、启停与删除；其余规则类型支持在 App 内创建与编辑。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُعد Page Rules ميزة قديمة وتدعم العرض والتفعيل/الإيقاف والحذف فقط؛ أما بقية أنواع القواعد فيمكن إنشاؤها وتحريرها داخل التطبيق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules sind eine Legacy-Funktion und unterstützen nur Anzeigen, Umschalten und Löschen; alle anderen Regeltypen lassen sich in der App erstellen und bearbeiten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules are a legacy feature and only support viewing, toggling, and deleting; all other rule types can be created and edited in the app."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las Page Rules son una función heredada y solo permiten ver, activar/desactivar y eliminar; los demás tipos de reglas se pueden crear y editar en la app."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les Page Rules sont une fonctionnalité héritée et ne permettent que consulter, activer/désactiver et supprimer ; les autres types de règles peuvent être créés et modifiés dans l'app."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules はレガシー機能のため表示・有効／無効・削除のみ対応です。その他のルールタイプはアプリ内で作成・編集できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules는 레거시 기능으로 보기, 활성화/비활성화, 삭제만 지원합니다. 다른 규칙 유형은 앱에서 만들고 편집할 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As Page Rules são um recurso legado e permitem apenas ver, ativar/desativar e excluir; os demais tipos de regras podem ser criados e editados no app."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As Page Rules são uma funcionalidade legada e permitem apenas ver, ativar/desativar e eliminar; os restantes tipos de regras podem ser criados e editados na app."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules eski bir özelliktir ve yalnızca görüntüleme, açma/kapatma ve silmeyi destekler; diğer tüm kural türleri uygulamada oluşturulup düzenlenebilir."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules 為傳統功能，僅支援查看、啟停與刪除；其餘規則類型支援在 App 內建立與編輯。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules 係傳統功能，僅支援查看、啟停同刪除；其餘規則類型支援喺 App 內建立同編輯。"
+          }
+        }
+      }
+    },
+    "Page Rules 是传统功能，Cloudflare 建议迁移到新的规则产品；已有规则可在此查看、启停与删除。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُعد Page Rules ميزة قديمة وتوصي Cloudflare بالانتقال إلى منتجات القواعد الجديدة؛ يمكنك هنا عرض القواعد الموجودة وتفعيلها/إيقافها وحذفها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules sind eine Legacy-Funktion; Cloudflare empfiehlt die Migration zu den neuen Regelprodukten. Bestehende Regeln kannst du hier anzeigen, umschalten und löschen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules are a legacy feature; Cloudflare recommends migrating to the new rules products. Existing rules can be viewed, toggled, and deleted here."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las Page Rules son una función heredada; Cloudflare recomienda migrar a los nuevos productos de reglas. Aquí puedes ver, activar/desactivar y eliminar las reglas existentes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les Page Rules sont une fonctionnalité héritée ; Cloudflare recommande de migrer vers les nouveaux produits de règles. Les règles existantes peuvent être consultées, activées/désactivées et supprimées ici."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules はレガシー機能です。Cloudflare は新しいルール製品への移行を推奨しています。既存のルールはここで表示・有効／無効・削除できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules는 레거시 기능입니다. Cloudflare는 새 규칙 제품으로의 마이그레이션을 권장합니다. 기존 규칙은 여기에서 보기, 활성화/비활성화, 삭제할 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As Page Rules são um recurso legado; a Cloudflare recomenda migrar para os novos produtos de regras. As regras existentes podem ser vistas, ativadas/desativadas e excluídas aqui."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As Page Rules são uma funcionalidade legada; a Cloudflare recomenda migrar para os novos produtos de regras. As regras existentes podem ser vistas, ativadas/desativadas e eliminadas aqui."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules eski bir özelliktir; Cloudflare yeni kural ürünlerine geçilmesini önerir. Mevcut kuralları burada görüntüleyebilir, açıp kapatabilir ve silebilirsiniz."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules 是傳統功能，Cloudflare 建議遷移到新的規則產品；既有規則可在此查看、啟停與刪除。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules 係傳統功能，Cloudflare 建議遷移到新嘅規則產品；現有規則可以喺度查看、啟停同刪除。"
+          }
+        }
+      }
+    },
     "Paid" : {
       "localizations" : {
         "ar" : {
@@ -17385,6 +17997,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Service 繫結"
+          }
+        }
+      }
+    },
+    "SNI 覆盖（可选，仅企业版）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تجاوز SNI (اختياري، خطة Enterprise فقط)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI-Override (optional, nur Enterprise)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI override (optional, Enterprise only)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anulación de SNI (opcional, solo Enterprise)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacement SNI (facultatif, Enterprise uniquement)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI の上書き（任意、Enterprise のみ）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI 재정의(선택 사항, Enterprise 전용)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Substituição de SNI (opcional, somente Enterprise)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Substituição de SNI (opcional, apenas Enterprise)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI geçersiz kılma (isteğe bağlı, yalnızca Enterprise)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI 覆寫（選填，僅 Enterprise）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SNI 覆蓋（可選，僅 Enterprise）"
           }
         }
       }
@@ -19289,6 +19977,158 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL 模式，可用 * 萬用字元，如 example.com/*。"
+          }
+        }
+      }
+    },
+    "URL 规范化" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسوية عناوين URL"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL-Normalisierung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL Normalization"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalización de URL"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalisation des URL"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 正規化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 정규화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalização de URL"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalização de URL"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL Normalleştirme"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 正規化"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 規範化"
+          }
+        }
+      }
+    },
+    "URL 规范化影响所有规则的表达式匹配方式，修改立即生效。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تؤثر تسوية عناوين URL في طريقة مطابقة تعبيرات جميع القواعد، وتسري التغييرات فورًا."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die URL-Normalisierung beeinflusst, wie Ausdrücke aller Regeln abgeglichen werden; Änderungen gelten sofort."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL normalization affects how expressions match across all rules; changes take effect immediately."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La normalización de URL afecta cómo coinciden las expresiones de todas las reglas; los cambios surten efecto de inmediato."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La normalisation des URL influe sur la correspondance des expressions de toutes les règles ; les modifications prennent effet immédiatement."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 正規化はすべてのルールの式マッチングに影響します。変更は直ちに有効になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 정규화는 모든 규칙의 표현식 일치 방식에 영향을 줍니다. 변경 사항은 즉시 적용됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A normalização de URL afeta como as expressões de todas as regras são correspondidas; as alterações entram em vigor imediatamente."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A normalização de URL afeta a correspondência das expressões de todas as regras; as alterações entram em vigor imediatamente."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL normalleştirme, tüm kuralların ifade eşleştirmesini etkiler; değişiklikler hemen geçerli olur."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 正規化影響所有規則的運算式比對方式，修改立即生效。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 規範化影響所有規則嘅表達式匹配方式，修改即時生效。"
           }
         }
       }
@@ -23251,6 +24091,82 @@
         }
       }
     },
+    "不填状态码则沿用原响应状态。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إذا تركت رمز الحالة فارغًا فسيُستخدم رمز الاستجابة الأصلي."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ohne Statuscode wird der ursprüngliche Antwortstatus beibehalten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leave the status code empty to keep the original response status."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si no indicas un código de estado, se mantiene el de la respuesta original."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sans code d'état, le statut de la réponse d'origine est conservé."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータスコードを空にすると元のレスポンスのステータスを維持します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상태 코드를 비워 두면 원래 응답 상태가 유지됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deixe o código de status vazio para manter o status da resposta original."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deixe o código de estado vazio para manter o estado da resposta original."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durum kodunu boş bırakırsanız özgün yanıt durumu korunur."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不填狀態碼則沿用原回應狀態。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唔填狀態碼就沿用原響應狀態。"
+          }
+        }
+      }
+    },
     "不扫描" : {
       "localizations" : {
         "ar" : {
@@ -23703,6 +24619,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不等於"
+          }
+        }
+      }
+    },
+    "不规范化" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بدون تسوية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Normalisierung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No normalization"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin normalización"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune normalisation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正規化しない"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정규화 안 함"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem normalização"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem normalização"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalleştirme yok"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不正規化"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不規範化"
           }
         }
       }
@@ -25987,6 +26979,82 @@
         }
       }
     },
+    "仅入站 URL" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عناوين URL الواردة فقط"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur eingehende URLs"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incoming URLs only"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo URL entrantes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL entrantes uniquement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受信 URL のみ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수신 URL만"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Somente URLs de entrada"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apenas URLs de entrada"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca gelen URL'ler"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅傳入 URL"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅入站 URL"
+          }
+        }
+      }
+    },
     "仅必选" : {
       "localizations" : {
         "ar" : {
@@ -26667,6 +27735,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仍然啟用端點"
+          }
+        }
+      }
+    },
+    "仍要执行" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التنفيذ على أي حال"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trotzdem ausführen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run Anyway"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejecutar de todos modos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter quand même"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "そのまま実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그래도 실행"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Executar mesmo assim"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Executar mesmo assim"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yine de çalıştır"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍要執行"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍要執行"
           }
         }
       }
@@ -27659,6 +28803,82 @@
         }
       }
     },
+    "传统与全局" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "القديمة والعامة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legacy & Global"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legacy & Global"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heredadas y globales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Héritées et globales"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レガシーとグローバル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레거시 및 전역"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legado e global"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legado e global"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eski ve Genel"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傳統與全域"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傳統與全局"
+          }
+        }
+      }
+    },
     "位置" : {
       "localizations" : {
         "ar" : {
@@ -27963,6 +29183,82 @@
         }
       }
     },
+    "体验者计划" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برنامج تحسين التطبيق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider-Programm"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider Program"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programa Insider"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programme Insider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インサイダープログラム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인사이더 프로그램"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programa Insider"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programa Insider"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider Programı"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "體驗者計畫"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "體驗者計劃"
+          }
+        }
+      }
+    },
     "作为密钥写入，逐个保存；同名将被覆盖，保存后不可读取。" : {
       "localizations" : {
         "ar" : {
@@ -28111,6 +29407,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "以明文變數一次性寫入；同名會被覆寫，不影響其他繫結。"
+          }
+        }
+      }
+    },
+    "作用范围" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "النطاق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geltungsbereich"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scope"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alcance"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用範囲"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "적용 범위"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escopo"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Âmbito"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapsam"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用範圍"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作用範圍"
           }
         }
       }
@@ -29407,6 +30779,234 @@
         }
       }
     },
+    "停用 Pay Per Crawl" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعطيل Pay Per Crawl"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay Per Crawl deaktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Pay Per Crawl"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar Pay Per Crawl"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver Pay Per Crawl"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay Per Crawl を無効化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay Per Crawl 비활성화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar Pay Per Crawl"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar Pay Per Crawl"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay Per Crawl'ı devre dışı bırak"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 Pay Per Crawl"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 Pay Per Crawl"
+          }
+        }
+      }
+    },
+    "停用 RUM" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعطيل RUM"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RUM deaktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable RUM"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar RUM"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver RUM"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RUM を無効化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RUM 비활성화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar RUM"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar RUM"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RUM'u devre dışı bırak"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 RUM"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 RUM"
+          }
+        }
+      }
+    },
+    "停用 Zaraz" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعطيل Zaraz"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaraz deaktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Zaraz"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar Zaraz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver Zaraz"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaraz を無効化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaraz 비활성화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar Zaraz"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar Zaraz"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaraz'ı devre dışı bırak"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 Zaraz"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 Zaraz"
+          }
+        }
+      }
+    },
     "健康监测" : {
       "localizations" : {
         "ar" : {
@@ -30391,6 +31991,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進入點模組即 main_module，負責匯出 fetch 等處理函式。"
+          }
+        }
+      }
+    },
+    "入站与规则匹配" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الواردة ومطابقة القواعد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingehend & Regelabgleich"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incoming & rule matching"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrantes y coincidencia de reglas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrantes et correspondance des règles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受信とルールマッチング"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수신 및 규칙 일치"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrada e correspondência de regras"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrada e correspondência de regras"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gelen ve kural eşleştirme"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傳入與規則比對"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入站與規則匹配"
           }
         }
       }
@@ -33056,6 +34732,82 @@
         }
       }
     },
+    "内容类型" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوع المحتوى"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inhaltstyp"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Content type"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de contenido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type de contenu"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンテンツタイプ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "콘텐츠 유형"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de conteúdo"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de conteúdo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İçerik türü"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內容類型"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內容類型"
+          }
+        }
+      }
+    },
     "最低 TLS 版本" : {
       "localizations" : {
         "ar" : {
@@ -33128,6 +34880,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最低 TLS 版本"
+          }
+        }
+      }
+    },
+    "最大 10 KB。将按上方内容类型原样返回给访客。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بحد أقصى 10 كيلوبايت. سيُعاد للزائر كما هو وفق نوع المحتوى أعلاه."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximal 10 KB. Wird dem Besucher unverändert mit dem obigen Inhaltstyp zurückgegeben."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Up to 10 KB. Returned to visitors as-is with the content type above."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máximo 10 KB. Se devuelve al visitante tal cual con el tipo de contenido anterior."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 Ko maximum. Renvoyé tel quel au visiteur avec le type de contenu ci-dessus."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大 10 KB。上記のコンテンツタイプでそのまま訪問者に返されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최대 10 KB. 위의 콘텐츠 유형으로 방문자에게 그대로 반환됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máximo de 10 KB. Retornado ao visitante como está, com o tipo de conteúdo acima."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máximo de 10 KB. Devolvido ao visitante tal como está, com o tipo de conteúdo acima."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En fazla 10 KB. Yukarıdaki içerik türüyle ziyaretçiye olduğu gibi döndürülür."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大 10 KB。將按上方內容類型原樣回傳給訪客。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大 10 KB。將按上方內容類型原樣返畀訪客。"
           }
         }
       }
@@ -37773,13 +39601,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "حذف هذا النشر؟"
+            "value" : "حذف عملية النشر هذه؟"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieses Deployment löschen?"
+            "value" : "Diese Bereitstellung löschen?"
           }
         },
         "en" : {
@@ -40202,6 +42030,158 @@
         }
       }
     },
+    "加入" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انضمام"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teilnehmen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Join"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unirme"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejoindre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "참여"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Participar"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aderir"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katıl"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
+          }
+        }
+      }
+    },
+    "加入体验者计划？" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل تريد الانضمام إلى برنامج تحسين التطبيق؟"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Am Insider-Programm teilnehmen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Join the Insider Program?"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Unirte al programa Insider?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejoindre le programme Insider ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インサイダープログラムに参加しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인사이더 프로그램에 참여하시겠습니까?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Participar do Programa Insider?"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aderir ao Programa Insider?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insider Programı'na katılmak ister misiniz?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入體驗者計畫？"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入體驗者計劃？"
+          }
+        }
+      }
+    },
     "加密" : {
       "localizations" : {
         "ar" : {
@@ -41040,6 +43020,82 @@
         }
       }
     },
+    "动作参数" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معلمات الإجراء"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktionsparameter"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action parameters"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parámetros de acción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres d'action"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクションパラメータ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 매개변수"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parâmetros de ação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parâmetros de ação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eylem parametreleri"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作參數"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作參數"
+          }
+        }
+      }
+    },
     "动态延迟" : {
       "localizations" : {
         "ar" : {
@@ -41112,6 +43168,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "動態延遲"
+          }
+        }
+      }
+    },
+    "动态表达式" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعبير ديناميكي"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamischer Ausdruck"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamic expression"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expresión dinámica"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expression dynamique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動的な式"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동적 표현식"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expressão dinâmica"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expressão dinâmica"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinamik ifade"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態運算式"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態表達式"
           }
         }
       }
@@ -42408,6 +44540,234 @@
         }
       }
     },
+    "单条重定向" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمليات إعادة التوجيه الفردية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einzelweiterleitungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redirecciones individuales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redirections unitaires"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シングルリダイレクト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 리디렉션"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redirecionamentos individuais"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redirecionamentos individuais"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekil Yönlendirmeler"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單條重新導向"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單條重定向"
+          }
+        }
+      }
+    },
+    "单条重定向、源站 / 配置 / 压缩规则、自定义错误与 Page Rules 的查看、启停与删除属于 Orange Cloud Pro。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عرض القواعد وتفعيلها/إيقافها وحذفها - عمليات إعادة التوجيه الفردية وقواعد المصدر/التكوين/الضغط والأخطاء المخصصة وPage Rules - من ميزات Orange Cloud Pro."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anzeigen, Umschalten und Löschen von Einzelweiterleitungen, Origin-/Konfigurations-/Komprimierungsregeln, benutzerdefinierten Fehlern und Page Rules gehören zu Orange Cloud Pro."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Viewing, toggling, and deleting Single Redirects, Origin/Configuration/Compression Rules, Custom Errors, and Page Rules is part of Orange Cloud Pro."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver, activar/desactivar y eliminar redirecciones individuales, reglas de origen/configuración/compresión, errores personalizados y Page Rules es parte de Orange Cloud Pro."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La consultation, l'activation/désactivation et la suppression des redirections unitaires, des règles d'origine/de configuration/de compression, des erreurs personnalisées et des Page Rules font partie d'Orange Cloud Pro."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シングルリダイレクト、オリジン／構成／圧縮ルール、カスタムエラー、Page Rules の表示・有効／無効・削除は Orange Cloud Pro の機能です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 리디렉션, 오리진/구성/압축 규칙, 사용자 지정 오류 및 Page Rules의 보기, 활성화/비활성화, 삭제는 Orange Cloud Pro에 포함됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver, ativar/desativar e excluir redirecionamentos individuais, regras de origem/configuração/compressão, erros personalizados e Page Rules faz parte do Orange Cloud Pro."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver, ativar/desativar e eliminar redirecionamentos individuais, regras de origem/configuração/compressão, erros personalizados e Page Rules faz parte do Orange Cloud Pro."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekil Yönlendirmeleri, Kaynak/Yapılandırma/Sıkıştırma Kurallarını, Özel Hataları ve Page Rules'u görüntüleme, açma/kapatma ve silme Orange Cloud Pro kapsamındadır."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單條重新導向、來源／設定／壓縮規則、自訂錯誤與 Page Rules 的查看、啟停與刪除屬於 Orange Cloud Pro。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單條重定向、源站／配置／壓縮規則、自訂錯誤同 Page Rules 嘅查看、啟停同刪除屬於 Orange Cloud Pro。"
+          }
+        }
+      }
+    },
+    "单条重定向、源站、配置、压缩、自定义错误与 Page Rules" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة التوجيه الفردية والمصدر والتكوين والضغط والأخطاء المخصصة وPage Rules"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects, Origin-, Konfigurations-, Komprimierungs-, Custom-Error- und Page Rules"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects, Origin, Configuration, Compression, Custom Error, and Page Rules"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects, reglas de origen, configuración, compresión, errores personalizados y Page Rules"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects, règles d'origine, de configuration, de compression, d'erreurs personnalisées et Page Rules"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単一リダイレクト、オリジン、構成、圧縮、カスタムエラー、Page Rules"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 리디렉션, 오리진, 구성, 압축, 사용자 지정 오류 및 Page Rules"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects, regras de origem, configuração, compressão, erros personalizados e Page Rules"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Redirects, regras de origem, configuração, compressão, erros personalizados e Page Rules"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekli Yönlendirmeler, Kaynak, Yapılandırma, Sıkıştırma, Özel Hata ve Page Rules"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單條重新導向、來源、設定、壓縮、自訂錯誤與 Page Rules"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單條重新導向、源站、設定、壓縮、自訂錯誤同 Page Rules"
+          }
+        }
+      }
+    },
     "单次最多 %lld 个" : {
       "localizations" : {
         "ar" : {
@@ -42632,6 +44992,158 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "危險操作"
+          }
+        }
+      }
+    },
+    "压缩算法（按偏好排序）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خوارزميات الضغط (حسب الأفضلية)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komprimierungsalgorithmen (nach Präferenz)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compression algorithms (in order of preference)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algoritmos de compresión (por preferencia)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algorithmes de compression (par ordre de préférence)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圧縮アルゴリズム（優先順）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "압축 알고리즘(선호 순서)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algoritmos de compressão (por preferência)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algoritmos de compressão (por preferência)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sıkıştırma algoritmaları (tercih sırasına göre)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壓縮演算法（依偏好排序）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壓縮算法（按偏好排序）"
+          }
+        }
+      }
+    },
+    "压缩规则" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قواعد الضغط"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komprimierungsregeln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compression Rules"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas de compresión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Règles de compression"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圧縮ルール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "압축 규칙"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de compressão"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de compressão"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sıkıştırma Kuralları"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壓縮規則"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壓縮規則"
           }
         }
       }
@@ -46130,6 +48642,158 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "命名空間名稱"
+          }
+        }
+      }
+    },
+    "响应体缓冲" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تخزين نص الاستجابة مؤقتًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Response-Body-Pufferung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Response body buffering"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almacenamiento en búfer del cuerpo de la respuesta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mise en tampon du corps de réponse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスボディのバッファリング"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "응답 본문 버퍼링"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buffer do corpo da resposta"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buffer do corpo da resposta"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yanıt gövdesi arabelleğe alma"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回應本文緩衝"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "響應體緩衝"
+          }
+        }
+      }
+    },
+    "响应内容" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "محتوى الاستجابة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antwortinhalt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Response content"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenido de la respuesta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenu de la réponse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "応答コンテンツ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "응답 콘텐츠"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conteúdo da resposta"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conteúdo da resposta"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yanıt içeriği"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回應內容"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "響應內容"
           }
         }
       }
@@ -51612,6 +54276,82 @@
         }
       }
     },
+    "大表可能返回大量行，造成等待和内存占用。建议加 LIMIT 后执行。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قد تُرجع الجداول الكبيرة عددًا كبيرًا من الصفوف، مما يسبب الانتظار واستهلاك الذاكرة. يُنصح بإضافة LIMIT قبل التنفيذ."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Große Tabellen können sehr viele Zeilen zurückgeben und so Wartezeiten und hohen Speicherverbrauch verursachen. Empfohlen: mit LIMIT ausführen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Large tables may return a huge number of rows, causing long waits and high memory use. Adding a LIMIT is recommended."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las tablas grandes pueden devolver muchas filas, lo que causa esperas y alto uso de memoria. Se recomienda agregar LIMIT antes de ejecutar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les grandes tables peuvent renvoyer un très grand nombre de lignes, entraînant attente et forte consommation de mémoire. Il est conseillé d'ajouter LIMIT avant d'exécuter."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大きなテーブルでは大量の行が返され、待ち時間やメモリ消費の原因になります。LIMIT を付けて実行することをおすすめします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "큰 테이블은 많은 행을 반환해 대기 시간과 메모리 사용이 늘어날 수 있습니다. LIMIT를 추가한 뒤 실행하는 것을 권장합니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabelas grandes podem retornar muitas linhas, causando espera e alto uso de memória. Recomenda-se adicionar LIMIT antes de executar."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabelas grandes podem devolver muitas linhas, causando espera e utilização elevada de memória. Recomenda-se adicionar LIMIT antes de executar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Büyük tablolar çok sayıda satır döndürerek bekleme ve yüksek bellek kullanımına yol açabilir. LIMIT ekleyip çalıştırmanız önerilir."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大型資料表可能回傳大量列，造成等待與記憶體佔用。建議加上 LIMIT 後執行。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大表可能返回大量行，造成等待和記憶體佔用。建議加 LIMIT 後執行。"
+          }
+        }
+      }
+    },
     "大面积中断" : {
       "localizations" : {
         "ar" : {
@@ -53056,6 +55796,82 @@
         }
       }
     },
+    "字段过大（%lld 字符），请在查询控制台修改" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحقل كبير جدًا (%lld حرفًا)، يُرجى تعديله في وحدة الاستعلام"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feld zu groß (%lld Zeichen). Bitte in der Abfragekonsole bearbeiten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Field too large (%lld characters). Edit it in the query console."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El campo es demasiado grande (%lld caracteres). Edítalo en la consola de consultas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Champ trop volumineux (%lld caractères). Modifiez-le dans la console de requête."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィールドが大きすぎます（%lld 文字）。クエリコンソールで編集してください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "필드가 너무 큽니다(%lld자). 쿼리 콘솔에서 수정하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campo muito grande (%lld caracteres). Edite no console de consultas."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campo demasiado grande (%lld caracteres). Edite na consola de consultas."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alan çok büyük (%lld karakter). Sorgu konsolunda düzenleyin."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位過大（%lld 字元），請在查詢主控台修改"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位過大（%lld 字符），請在查詢主控台修改"
+          }
+        }
+      }
+    },
     "字母、数字、下划线，且不以数字开头。" : {
       "localizations" : {
         "ar" : {
@@ -53888,6 +56704,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "安全搜尋"
+          }
+        }
+      }
+    },
+    "安全级别" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مستوى الأمان"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sicherheitsstufe"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security Level"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel de seguridad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau de sécurité"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティレベル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보안 수준"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nível de segurança"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nível de segurança"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güvenlik Düzeyi"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全性層級"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全級別"
           }
         }
       }
@@ -58377,6 +61269,82 @@
         }
       }
     },
+    "左滑启停，右滑删除。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اسحب لليسار للتفعيل/الإيقاف، ولليمين للحذف."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach links wischen zum Aktivieren/Deaktivieren, nach rechts zum Löschen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swipe left to enable/disable, swipe right to delete."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desliza a la izquierda para activar/desactivar y a la derecha para eliminar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balayez vers la gauche pour activer/désactiver, vers la droite pour supprimer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左スワイプで有効／無効、右スワイプで削除。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "왼쪽으로 스와이프하여 활성화/비활성화, 오른쪽으로 스와이프하여 삭제합니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deslize para a esquerda para ativar/desativar e para a direita para excluir."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deslize para a esquerda para ativar/desativar e para a direita para eliminar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etkinleştirmek/devre dışı bırakmak için sola, silmek için sağa kaydırın."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左滑啟停，右滑刪除。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左滑啟停，右滑刪除。"
+          }
+        }
+      }
+    },
     "已代理" : {
       "localizations" : {
         "ar" : {
@@ -58525,6 +61493,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已停用"
+          }
+        }
+      }
+    },
+    "已加载 %lld 行，请在查询控制台用 WHERE 条件继续筛选" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم تحميل %lld صفوف، يُرجى المتابعة بالتصفية بشرط WHERE في وحدة الاستعلام"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Zeilen geladen. In der Abfragekonsole mit einer WHERE-Bedingung weiter eingrenzen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loaded %lld rows. Use a WHERE clause in the query console to narrow down."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se cargaron %lld filas. Usa una condición WHERE en la consola de consultas para filtrar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld lignes chargées. Affinez avec une condition WHERE dans la console de requête."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 行を読み込みました。クエリコンソールで WHERE 条件を使って絞り込んでください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개 행을 불러왔습니다. 쿼리 콘솔에서 WHERE 조건으로 계속 필터링하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld linhas carregadas. Use uma condição WHERE no console de consultas para filtrar."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Foram carregadas %lld linhas. Use uma condição WHERE na consola de consultas para filtrar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld satır yüklendi. Sorgu konsolunda WHERE koşuluyla daraltmaya devam edin."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已載入 %lld 列，請在查詢主控台用 WHERE 條件繼續篩選"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已載入 %lld 行，請在查詢主控台用 WHERE 條件繼續篩選"
           }
         }
       }
@@ -60435,6 +63479,82 @@
         }
       }
     },
+    "已载入当前线上源码，可直接修改后部署。现有变量 / 密钥 / 绑定会自动保留。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current live source loaded. Edit and deploy directly. Existing variables, secrets and bindings are kept automatically."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已載入目前線上原始碼，可直接修改後部署。現有變數 / 密鑰 / 綁定會自動保留。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已載入目前線上原始碼，可直接修改後部署。現有變數 / 密鑰 / 綁定會自動保留。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の本番ソースを読み込みました。そのまま編集してデプロイできます。既存の変数・シークレット・バインディングは自動的に保持されます。"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se cargó el código fuente en producción. Edítalo y despliégalo directamente. Las variables, secretos y enlaces existentes se conservan automáticamente."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 라이브 소스를 불러왔습니다. 바로 수정해 배포할 수 있습니다. 기존 변수·시크릿·바인딩은 자동으로 유지됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código-fonte em produção carregado. Edite e implante diretamente. Variáveis, segredos e vinculações existentes são mantidos automaticamente."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código-fonte em produção carregado. Edite e implemente diretamente. As variáveis, segredos e ligações existentes são mantidos automaticamente."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktueller Live-Quellcode geladen. Direkt bearbeiten und bereitstellen. Vorhandene Variablen, Secrets und Bindings bleiben automatisch erhalten."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code source en production chargé. Modifiez et déployez directement. Les variables, secrets et liaisons existants sont conservés automatiquement."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم تحميل الشيفرة المصدرية الحالية المباشرة. يمكنك تعديلها ونشرها مباشرةً. تُحفظ المتغيرات والأسرار والارتباطات الحالية تلقائيًا."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçerli canlı kaynak yüklendi. Doğrudan düzenleyip dağıtabilirsiniz. Mevcut değişkenler, gizli anahtarlar ve bağlamalar otomatik olarak korunur."
+          }
+        }
+      }
+    },
     "已过期" : {
       "localizations" : {
         "ar" : {
@@ -62335,6 +65455,82 @@
         }
       }
     },
+    "开启后，App 会上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。可随时在设置中关闭。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عند التفعيل، يرسل التطبيق سجلات تشخيص مجهولة الهوية ومعلومات الأعطال (لا تتضمن أبدًا رموزك أو بيانات حسابك أو أي معلومات شخصية) لمساعدتنا في تحديد مشكلات تسجيل الدخول والاستقرار بشكل أسرع. يمكنك إيقافه في أي وقت من الإعدادات."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn aktiviert, sendet die App anonyme Diagnoseprotokolle und Absturzberichte (niemals deine Tokens, Kontodaten oder persönliche Informationen), damit wir Anmelde- und Stabilitätsprobleme schneller eingrenzen können. Du kannst dies jederzeit in den Einstellungen deaktivieren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, the app reports anonymous diagnostic logs and crash data (never your tokens, account data, or any personal information) to help us track down sign-in and stability issues faster. You can turn this off anytime in Settings."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al activarlo, la app envía registros de diagnóstico anónimos e informes de fallos (nunca tus tokens, datos de cuenta ni información personal) para ayudarnos a identificar más rápido los problemas de inicio de sesión y estabilidad. Puedes desactivarlo en cualquier momento en Ajustes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une fois activé, l'app envoie des journaux de diagnostic anonymes et des rapports de plantage (jamais vos jetons, données de compte ni aucune information personnelle) pour nous aider à identifier plus vite les problèmes de connexion et de stabilité. Vous pouvez désactiver cela à tout moment dans les réglages."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、匿名の診断ログとクラッシュ情報（トークン、アカウントデータ、個人情報は一切含まれません）を送信し、ログインや安定性の問題の特定に役立てます。設定でいつでもオフにできます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화하면 익명 진단 로그와 충돌 정보(토큰, 계정 데이터, 개인정보는 포함되지 않음)를 전송하여 로그인 및 안정성 문제를 더 빠르게 파악하는 데 도움이 됩니다. 설정에서 언제든지 끌 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, o app envia registros de diagnóstico anônimos e relatórios de falhas (nunca seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rápido problemas de login e estabilidade. Você pode desativar a qualquer momento nos Ajustes."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, a app envia registos de diagnóstico anónimos e relatórios de falhas (nunca os seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rapidamente problemas de início de sessão e estabilidade. Pode desativar a qualquer momento nas Definições."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etkinleştirildiğinde uygulama, oturum açma ve kararlılık sorunlarını daha hızlı bulmamıza yardımcı olmak için anonim tanılama günlükleri ve çökme bilgileri gönderir (belirteçleriniz, hesap verileriniz veya hiçbir kişisel bilgi asla dahil edilmez). Ayarlar'dan istediğiniz zaman kapatabilirsiniz."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後，App 會回報匿名診斷日誌與當機資訊（不含權杖、帳號資料或任何個人資訊），協助我們更快定位登入與穩定性問題。可隨時在設定中關閉。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後，App 會上報匿名診斷日誌與崩潰資訊（不含權杖、帳戶資料或任何個人資料），協助我們更快定位登入與穩定性問題。可隨時在設定中關閉。"
+          }
+        }
+      }
+    },
     "开启后，未匹配到文件的请求回退到 index.html（适合前端路由）。" : {
       "localizations" : {
         "ar" : {
@@ -62560,6 +65756,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟後：登入身分經 iCloud 鑰匙串在你的裝置間同步（端對端加密），帳單日與計劃預設等偏好經 iCloud 同步。關閉將把登入資料從 iCloud 移除，僅保留本機。"
+          }
+        }
+      }
+    },
+    "开启后上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عند التفعيل، تُرسَل سجلات تشخيص مجهولة الهوية ومعلومات الأعطال (لا تتضمن أبدًا رموزك أو بيانات حسابك أو أي معلومات شخصية) لمساعدتنا في تحديد مشكلات تسجيل الدخول والاستقرار بشكل أسرع."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn aktiviert, werden anonyme Diagnoseprotokolle und Absturzberichte gesendet (niemals deine Tokens, Kontodaten oder persönliche Informationen), damit wir Anmelde- und Stabilitätsprobleme schneller eingrenzen können."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, reports anonymous diagnostic logs and crash data (never your tokens, account data, or any personal information) to help us track down sign-in and stability issues faster."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al activarlo, se envían registros de diagnóstico anónimos e informes de fallos (nunca tus tokens, datos de cuenta ni información personal) para ayudarnos a identificar más rápido los problemas de inicio de sesión y estabilidad."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une fois activé, envoie des journaux de diagnostic anonymes et des rapports de plantage (jamais vos jetons, données de compte ni aucune information personnelle) pour nous aider à identifier plus vite les problèmes de connexion et de stabilité."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、匿名の診断ログとクラッシュ情報（トークン、アカウントデータ、個人情報は一切含まれません）を送信し、ログインや安定性の問題の特定に役立てます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화하면 익명 진단 로그와 충돌 정보(토큰, 계정 데이터, 개인정보는 포함되지 않음)를 전송하여 로그인 및 안정성 문제를 더 빠르게 파악하는 데 도움이 됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, envia registros de diagnóstico anônimos e relatórios de falhas (nunca seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rápido problemas de login e estabilidade."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando ativado, envia registos de diagnóstico anónimos e relatórios de falhas (nunca os seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rapidamente problemas de início de sessão e estabilidade."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etkinleştirildiğinde, oturum açma ve kararlılık sorunlarını daha hızlı bulmamıza yardımcı olmak için anonim tanılama günlükleri ve çökme bilgileri gönderilir (belirteçleriniz, hesap verileriniz veya hiçbir kişisel bilgi asla dahil edilmez)."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後回報匿名診斷日誌與當機資訊（不含權杖、帳號資料或任何個人資訊），協助我們更快定位登入與穩定性問題。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟後上報匿名診斷日誌與崩潰資訊（不含權杖、帳戶資料或任何個人資料），協助我們更快定位登入與穩定性問題。"
           }
         }
       }
@@ -63856,6 +67128,82 @@
         }
       }
     },
+    "当前授权仅限读取（%@），无法修改规则。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التفويض الحالي للقراءة فقط (%@)، ولا يمكن تعديل القواعد."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle Autorisierung ist schreibgeschützt (%@); Regeln können nicht geändert werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current authorization is read-only (%@); rules cannot be modified."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autorización actual es de solo lectura (%@); no se pueden modificar las reglas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'autorisation actuelle est en lecture seule (%@) ; les règles ne peuvent pas être modifiées."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の認可は読み取り専用（%@）のため、ルールを変更できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 권한은 읽기 전용(%@)이라 규칙을 수정할 수 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual é somente leitura (%@); as regras não podem ser modificadas."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual é apenas de leitura (%@); as regras não podem ser modificadas."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçerli yetkilendirme salt okunur (%@); kurallar değiştirilemez."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權僅限讀取（%@），無法修改規則。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權僅限讀取（%@），無法修改規則。"
+          }
+        }
+      }
+    },
     "当前授权仅限读取（cache-settings.read），无法修改规则。" : {
       "localizations" : {
         "ar" : {
@@ -63928,6 +67276,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前授權僅限讀取（cache-settings.read），無法修改規則。"
+          }
+        }
+      }
+    },
+    "当前授权仅限读取（config-settings.read），无法修改。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التفويض الحالي للقراءة فقط (config-settings.read)، ولا يمكن تعديل القواعد."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle Autorisierung ist schreibgeschützt (config-settings.read); Regeln können nicht geändert werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current authorization is read-only (config-settings.read); rules cannot be modified."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autorización actual es de solo lectura (config-settings.read); no se pueden modificar las reglas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'autorisation actuelle est en lecture seule (config-settings.read) ; les règles ne peuvent pas être modifiées."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の認可は読み取り専用（config-settings.read）のため、ルールを変更できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 권한은 읽기 전용(config-settings.read)이라 규칙을 수정할 수 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual é somente leitura (config-settings.read); as regras não podem ser modificadas."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual é apenas de leitura (config-settings.read); as regras não podem ser modificadas."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçerli yetkilendirme salt okunur (config-settings.read); kurallar değiştirilemez."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權僅限讀取（config-settings.read），無法修改規則。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權僅限讀取（config-settings.read），無法修改規則。"
           }
         }
       }
@@ -64156,6 +67580,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前授權僅限讀取（load-balancers.read）。"
+          }
+        }
+      }
+    },
+    "当前授权仅限读取（page-rules.read），无法修改规则。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التفويض الحالي للقراءة فقط (page-rules.read)، ولا يمكن تعديل القواعد."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle Autorisierung ist schreibgeschützt (page-rules.read); Regeln können nicht geändert werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current authorization is read-only (page-rules.read); rules cannot be modified."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autorización actual es de solo lectura (page-rules.read); no se pueden modificar las reglas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'autorisation actuelle est en lecture seule (page-rules.read) ; les règles ne peuvent pas être modifiées."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の認可は読み取り専用（page-rules.read）のため、ルールを変更できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 권한은 읽기 전용(page-rules.read)이라 규칙을 수정할 수 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual é somente leitura (page-rules.read); as regras não podem ser modificadas."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual é apenas de leitura (page-rules.read); as regras não podem ser modificadas."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçerli yetkilendirme salt okunur (page-rules.read); kurallar değiştirilemez."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權僅限讀取（page-rules.read），無法修改規則。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權僅限讀取（page-rules.read），無法修改規則。"
           }
         }
       }
@@ -64916,6 +68416,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前授權未包含 KV 編輯權限（workers-kv-storage.write）。\n請在設定中登出後重新授權以啟用此功能。"
+          }
+        }
+      }
+    },
+    "当前授权未包含 Page Rules 编辑权限（page-rules.write）。点「一键重授权」补齐，无需退出登录。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التفويض الحالي لا يتضمن إذن تحرير Page Rules ‏(page-rules.write). انقر على «إعادة التفويض» لإضافته دون تسجيل الخروج."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle Autorisierung enthält keine Bearbeitung von Page Rules (page-rules.write). Tippe auf „Neu autorisieren“, um sie hinzuzufügen – ohne Abmelden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current authorization doesn't include editing for Page Rules (page-rules.write). Tap “Re-authorize” to add it — no sign-out needed."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autorización actual no incluye la edición de las Page Rules (page-rules.write). Toca “Reautorizar” para agregarla, sin cerrar sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'autorisation actuelle n'inclut pas la modification de des Page Rules (page-rules.write). Touchez « Réautoriser » pour l'ajouter, sans déconnexion."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の認可にはPage Rules の編集権限（page-rules.write）が含まれていません。「再認可」をタップして追加できます（ログアウト不要）。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 승인에는 Page Rules 편집 권한(page-rules.write)이 포함되어 있지 않습니다. '재승인'을 탭하여 추가할 수 있습니다(로그아웃 불필요)."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual não inclui a edição das Page Rules (page-rules.write). Toque em “Reautorizar” para adicioná-la, sem sair da conta."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual não inclui a edição das Page Rules (page-rules.write). Toque em “Reautorizar” para a adicionar, sem terminar sessão."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mevcut yetkilendirme Page Rules düzenleme iznini (page-rules.write) içermiyor. Eklemek için “Yeniden yetkilendir”e dokunun — çıkış yapmanız gerekmez."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權未包含Page Rules 編輯權限（page-rules.write）。點「一鍵重新授權」補齊，無需登出。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權未包含Page Rules 編輯權限（page-rules.write）。點「一鍵重新授權」補齊，無需登出。"
           }
         }
       }
@@ -66216,6 +69792,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前授權未包含此操作所需權限（%@）。點「一鍵重新授權」補齊，無需登出。"
+          }
+        }
+      }
+    },
+    "当前授权未包含此规则的编辑权限（%@）。点「一键重授权」补齐，无需退出登录。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التفويض الحالي لا يتضمن إذن تحرير هذا النوع من القواعد (%@). انقر على «إعادة التفويض» لإضافته دون تسجيل الخروج."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle Autorisierung enthält keine Bearbeitung dieses Regeltyps (%@). Tippe auf „Neu autorisieren“, um sie hinzuzufügen – ohne Abmelden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current authorization doesn't include editing for this rule type (%@). Tap “Re-authorize” to add it — no sign-out needed."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autorización actual no incluye la edición de este tipo de regla (%@). Toca “Reautorizar” para agregarla, sin cerrar sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'autorisation actuelle n'inclut pas la modification de ce type de règle (%@). Touchez « Réautoriser » pour l'ajouter, sans déconnexion."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の認可にはこのルールの編集権限（%@）が含まれていません。「再認可」をタップして追加できます（ログアウト不要）。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 승인에는 이 규칙의 편집 권한(%@)이 포함되어 있지 않습니다. '재승인'을 탭하여 추가할 수 있습니다(로그아웃 불필요)."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual não inclui a edição deste tipo de regra (%@). Toque em “Reautorizar” para adicioná-la, sem sair da conta."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autorização atual não inclui a edição deste tipo de regra (%@). Toque em “Reautorizar” para a adicionar, sem terminar sessão."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mevcut yetkilendirme bu kural türü için düzenleme iznini (%@) içermiyor. Eklemek için “Yeniden yetkilendir”e dokunun — çıkış yapmanız gerekmez."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權未包含此規則的編輯權限（%@）。點「一鍵重新授權」補齊，無需登出。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前授權未包含此規則嘅編輯權限（%@）。點「一鍵重新授權」補齊，無需登出。"
           }
         }
       }
@@ -68274,7 +71926,6 @@
       }
     },
     "打开 ${module}" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -72836,9 +76487,7 @@
         }
       }
     },
-    "推送" : {
-
-    },
+    "推送" : {},
     "推送中心" : {
       "localizations" : {
         "ar" : {
@@ -74811,6 +78460,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "收集記錄"
+          }
+        }
+      }
+    },
+    "改写与缓存" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة الكتابة والتخزين المؤقت"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umschreiben & Cache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rewrite & Cache"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reescritura y caché"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réécriture et cache"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書き換えとキャッシュ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재작성 및 캐시"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reescrita e cache"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reescrita e cache"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeniden Yazma ve Önbellek"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改寫與快取"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改寫與緩存"
           }
         }
       }
@@ -77780,6 +81505,83 @@
         }
       }
     },
+    "新类型规则目前支持查看、启停与删除；创建和编辑请在 Cloudflare Dashboard 完成。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تدعم أنواع القواعد الجديدة حاليًا العرض والتفعيل/الإيقاف والحذف؛ يُرجى إنشاء القواعد وتحريرها في لوحة تحكم Cloudflare."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Regeltypen unterstützen derzeit Anzeigen, Aktivieren/Deaktivieren und Löschen; erstellen und bearbeiten kannst du Regeln im Cloudflare Dashboard."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New rule types currently support viewing, toggling, and deleting; create and edit rules in the Cloudflare Dashboard."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los tipos de regla nuevos actualmente permiten ver, activar/desactivar y eliminar; crea y edita reglas en el panel de Cloudflare."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les nouveaux types de règles permettent pour l'instant de consulter, d'activer/désactiver et de supprimer ; créez et modifiez les règles dans le tableau de bord Cloudflare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいタイプのルールは現在、表示・有効／無効・削除に対応しています。作成と編集は Cloudflare ダッシュボードで行ってください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 규칙 유형은 현재 보기, 활성화/비활성화, 삭제를 지원합니다. 규칙 생성과 편집은 Cloudflare 대시보드에서 하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os novos tipos de regra atualmente permitem ver, ativar/desativar e excluir; crie e edite regras no painel da Cloudflare."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os novos tipos de regra permitem atualmente ver, ativar/desativar e eliminar; crie e edite regras no painel da Cloudflare."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeni kural türleri şu anda görüntüleme, etkinleştirme/devre dışı bırakma ve silmeyi destekler; kuralları Cloudflare panosunda oluşturup düzenleyin."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新類型規則目前支援查看、啟停與刪除；建立和編輯請在 Cloudflare 儀表板完成。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新類型規則目前支援查看、啟停與刪除；建立同編輯請喺 Cloudflare 儀表板完成。"
+          }
+        }
+      }
+    },
     "新路径，如 /new-path" : {
       "localizations" : {
         "ar" : {
@@ -80364,6 +84166,82 @@
         }
       }
     },
+    "暂不" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ليس الآن"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt nicht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Now"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahora no"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus tard"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今はしない"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "나중에"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agora não"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agora não"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şimdi değil"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不"
+          }
+        }
+      }
+    },
     "暂不支持 Zip64（超大压缩包）" : {
       "localizations" : {
         "ar" : {
@@ -80436,6 +84314,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫不支援 Zip64（超大型壓縮檔）"
+          }
+        }
+      }
+    },
+    "暂不支持编辑" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التعديل غير مدعوم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bearbeiten nicht unterstützt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editing Not Supported"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edición no disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modification non prise en charge"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集には未対応"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집 미지원"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edição não suportada"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edição não suportada"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Düzenleme desteklenmiyor"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不支援編輯"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不支援編輯"
           }
         }
       }
@@ -81661,61 +85615,61 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا توجد عمليات نشر بعد"
+            "value" : "لا توجد عمليات نشر"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Noch keine Deployments"
+            "value" : "Keine Bereitstellungen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No deployments yet"
+            "value" : "No deployments"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aún no hay despliegues"
+            "value" : "Sin despliegues"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aucun déploiement pour l'instant"
+            "value" : "Aucun déploiement"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "デプロイはまだありません"
+            "value" : "デプロイがありません"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "아직 배포 없음"
+            "value" : "배포 없음"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ainda não há implantações"
+            "value" : "Nenhuma implantação"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ainda não há implementações"
+            "value" : "Nenhuma implementação"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Henüz dağıtım yok"
+            "value" : "Dağıtım yok"
           }
         },
         "zh-Hant" : {
@@ -85074,6 +89028,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本月 %@ 次操作"
+          }
+        }
+      }
+    },
+    "机会性加密" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التشفير الانتهازي"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opportunistische Verschlüsselung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opportunistic Encryption"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cifrado oportunista"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiffrement opportuniste"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日和見暗号化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기회적 암호화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criptografia oportunista"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encriptação oportunista"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fırsatçı Şifreleme"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機會性加密"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機會性加密"
           }
         }
       }
@@ -89191,6 +93221,82 @@
         }
       }
     },
+    "查看详情" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عرض التفاصيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Details anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View details"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir les détails"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세부 정보 보기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalhes"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalhes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayrıntıları görüntüle"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看詳細資訊"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看詳情"
+          }
+        }
+      }
+    },
     "查看账号与域名的流量和安全分析" : {
       "localizations" : {
         "ar" : {
@@ -89725,7 +93831,6 @@
       }
     },
     "查询 ${zone} 的状态" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -90177,6 +94282,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查詢字串"
+          }
+        }
+      }
+    },
+    "查询未带 LIMIT" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاستعلام بدون LIMIT"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abfrage ohne LIMIT"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query Has No LIMIT"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La consulta no tiene LIMIT"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requête sans LIMIT"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LIMIT のないクエリ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LIMIT 없는 쿼리"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A consulta não tem LIMIT"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A consulta não tem LIMIT"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sorguda LIMIT yok"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢未帶 LIMIT"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢未帶 LIMIT"
           }
         }
       }
@@ -92012,6 +96193,82 @@
         }
       }
     },
+    "正在读取源码…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading source…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在讀取原始碼…"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在讀取原始碼…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソースを読み込み中…"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando código fuente…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소스 불러오는 중…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carregando código-fonte…"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A carregar código-fonte…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quellcode wird geladen…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement du code source…"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جارٍ تحميل الشيفرة المصدرية…"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak kodu yükleniyor…"
+          }
+        }
+      }
+    },
     "正常" : {
       "localizations" : {
         "ar" : {
@@ -92616,6 +96873,235 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此域名暫時沒有邊緣證書。"
+          }
+        }
+      }
+    },
+    "此域名还没有这类规则。当前授权仅限读取（%@），无法创建。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يحتوي هذا النطاق على قواعد من هذا النوع بعد. التفويض الحالي للقراءة فقط (%@) ولا يمكنه الإنشاء."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Domain hat noch keine Regeln dieses Typs. Die aktuelle Autorisierung ist schreibgeschützt (%@); Erstellen nicht möglich."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This domain doesn't have rules of this type yet. The current authorization is read-only (%@) and can't create rules."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este dominio aún no tiene reglas de este tipo. La autorización actual es de solo lectura (%@) y no permite crearlas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce domaine n'a pas encore de règles de ce type. L'autorisation actuelle est en lecture seule (%@) et ne permet pas d'en créer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このドメインにはまだこのタイプのルールがありません。現在の認可は読み取り専用（%@）のため作成できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 도메인에는 아직 이 유형의 규칙이 없습니다. 현재 승인은 읽기 전용(%@)이라 만들 수 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio ainda não tem regras deste tipo. A autorização atual é somente leitura (%@) e não permite criá-las."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio ainda não tem regras deste tipo. A autorização atual é apenas de leitura (%@) e não permite criá-las."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu alan adında henüz bu türde kural yok. Mevcut yetkilendirme salt okunur (%@) olduğundan oluşturamaz."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此網域還沒有這類規則。目前授權僅限讀取（%@），無法建立。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此域名仲未有呢類規則。目前授權僅限讀取（%@），無法建立。"
+          }
+        }
+      }
+    },
+    "此域名还没有这类规则。点右上角 + 创建第一条。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يحتوي هذا النطاق على قواعد من هذا النوع بعد. انقر على + في الأعلى لإنشاء أول قاعدة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Domain hat noch keine Regeln dieses Typs. Tippe oben rechts auf +, um die erste zu erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This domain doesn't have rules of this type yet. Tap + in the top corner to create the first one."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este dominio aún no tiene reglas de este tipo. Toca + arriba a la derecha para crear la primera."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce domaine n'a pas encore de règles de ce type. Touchez + en haut à droite pour créer la première."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このドメインにはまだこのタイプのルールがありません。右上の + から最初のルールを作成できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 도메인에는 아직 이 유형의 규칙이 없습니다. 오른쪽 위 +를 탭하여 첫 규칙을 만드세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio ainda não tem regras deste tipo. Toque em + no canto superior para criar a primeira."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio ainda não tem regras deste tipo. Toque em + no canto superior para criar a primeira."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu alan adında henüz bu türde kural yok. İlkini oluşturmak için sağ üstteki + simgesine dokunun."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此網域還沒有這類規則。點右上角 + 建立第一條。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此域名仲未有呢類規則。點右上角 + 建立第一條。"
+          }
+        }
+      }
+    },
+    "此域名还没有这类规则。规则创建请在 Cloudflare Dashboard 完成，创建后这里可查看、启停与删除。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يحتوي هذا النطاق على قواعد من هذا النوع بعد. أنشئ القواعد في لوحة تحكم Cloudflare، وبعد الإنشاء يمكنك هنا عرضها وتفعيلها/إيقافها وحذفها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Domain hat noch keine Regeln dieses Typs. Erstelle Regeln im Cloudflare Dashboard; danach kannst du sie hier anzeigen, umschalten und löschen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This domain doesn't have rules of this type yet. Create rules in the Cloudflare Dashboard; once created, you can view, toggle, and delete them here."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este dominio aún no tiene reglas de este tipo. Crea reglas en el panel de Cloudflare; una vez creadas, aquí podrás verlas, activarlas/desactivarlas y eliminarlas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce domaine n'a pas encore de règles de ce type. Créez-les dans le tableau de bord Cloudflare ; vous pourrez ensuite les consulter, les activer/désactiver et les supprimer ici."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このドメインにはまだこのタイプのルールがありません。Cloudflare ダッシュボードで作成すると、ここで表示・有効／無効・削除ができます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 도메인에는 아직 이 유형의 규칙이 없습니다. Cloudflare 대시보드에서 규칙을 만들면 여기에서 보기, 활성화/비활성화, 삭제할 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio ainda não tem regras deste tipo. Crie regras no painel da Cloudflare; depois de criadas, você pode vê-las, ativar/desativar e excluí-las aqui."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este domínio ainda não tem regras deste tipo. Crie regras no painel da Cloudflare; depois de criadas, pode vê-las, ativar/desativar e eliminá-las aqui."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu alan adında henüz bu türde kural yok. Kuralları Cloudflare panosunda oluşturun; oluşturulduktan sonra burada görüntüleyebilir, açıp kapatabilir ve silebilirsiniz."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此網域還沒有這類規則。請在 Cloudflare 儀表板建立規則，建立後可在此查看、啟停與刪除。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此域名仲未有呢類規則。請喺 Cloudflare 儀表板建立規則，建立後可以喺度查看、啟停同刪除。"
           }
         }
       }
@@ -95965,6 +100451,82 @@
         }
       }
     },
+    "没有 Page Rules" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد Page Rules"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Page Rules"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Page Rules"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin Page Rules"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune Page Rule"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules はありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem Page Rules"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem Page Rules"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rules yok"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有 Page Rules"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有 Page Rules"
+          }
+        }
+      }
+    },
     "没有 Pages 项目" : {
       "localizations" : {
         "ar" : {
@@ -96113,6 +100675,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有 Workers"
+          }
+        }
+      }
+    },
+    "没有%@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No %@"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune règle : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@はありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem %@"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ yok"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有%@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有%@"
           }
         }
       }
@@ -98170,6 +102808,82 @@
         }
       }
     },
+    "流量与内容" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حركة المرور والمحتوى"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traffic & Inhalt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traffic & Content"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tráfico y contenido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trafic et contenu"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トラフィックとコンテンツ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "트래픽 및 콘텐츠"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tráfego e conteúdo"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tráfego e conteúdo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trafik ve İçerik"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流量與內容"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流量與內容"
+          }
+        }
+      }
+    },
     "流量分析" : {
       "localizations" : {
         "ar" : {
@@ -98852,6 +103566,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瀏覽器：%@"
+          }
+        }
+      }
+    },
+    "浏览器完整性检查" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فحص سلامة المتصفح"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser Integrity Check"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser Integrity Check"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprobación de integridad del navegador"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contrôle d'intégrité du navigateur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブラウザ整合性チェック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "브라우저 무결성 검사"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificação de integridade do navegador"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificação de integridade do navegador"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarayıcı Bütünlük Denetimi"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏覽器完整性檢查"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏覽器完整性檢查"
           }
         }
       }
@@ -100452,6 +105242,82 @@
         }
       }
     },
+    "添加算法" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة خوارزمية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algorithmus hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add algorithm"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar algoritmo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un algorithme"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルゴリズムを追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알고리즘 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar algoritmo"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar algoritmo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algoritma ekle"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入演算法"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增算法"
+          }
+        }
+      }
+    },
     "添加规则" : {
       "localizations" : {
         "ar" : {
@@ -100752,6 +105618,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增記錄"
+          }
+        }
+      }
+    },
+    "添加设置" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة إعداد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellung hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add setting"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar ajuste"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un réglage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定を追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar configuração"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar definição"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayar ekle"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入設定"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增設定"
           }
         }
       }
@@ -102353,6 +107295,158 @@
         }
       }
     },
+    "源站：%@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المصدر: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin: %@"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origen: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origine : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オリジン：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오리진: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origem: %@"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origem: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源：%@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源站：%@"
+          }
+        }
+      }
+    },
+    "源站主机（可选）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مضيف المصدر (اختياري)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin-Host (optional)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin host (optional)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host de origen (opcional)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôte d'origine (facultatif)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オリジンホスト（任意）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오리진 호스트(선택 사항)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host de origem (opcional)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host de origem (opcional)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak ana bilgisayarı (isteğe bağlı)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源主機（選填）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源站主機（可選）"
+          }
+        }
+      }
+    },
     "源站无指令则不缓存" : {
       "localizations" : {
         "ar" : {
@@ -102729,6 +107823,310 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "源站離線時提供緩存快照"
+          }
+        }
+      }
+    },
+    "源站端口：%lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منفذ المصدر: %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin-Port: %lld"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin port: %lld"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puerto de origen: %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Port d'origine : %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オリジンポート：%lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오리진 포트: %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porta de origem: %lld"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porta de origem: %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak bağlantı noktası: %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源連接埠：%lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源站連接埠：%lld"
+          }
+        }
+      }
+    },
+    "源站端口（可选）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منفذ المصدر (اختياري)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin-Port (optional)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin port (optional)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puerto de origen (opcional)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Port d'origine (facultatif)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オリジンポート（任意）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오리진 포트(선택 사항)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porta de origem (opcional)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porta de origem (opcional)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak bağlantı noktası (isteğe bağlı)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源連接埠（選填）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源站連接埠（可選）"
+          }
+        }
+      }
+    },
+    "源站覆盖" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تجاوزات المصدر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin-Overrides"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin overrides"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anulaciones de origen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacements d'origine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オリジンの上書き"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오리진 재정의"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Substituições de origem"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Substituições de origem"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak geçersiz kılmaları"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源覆寫"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源站覆蓋"
+          }
+        }
+      }
+    },
+    "源站规则" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قواعد المصدر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin-Regeln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origin Rules"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas de origen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Règles d'origine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オリジンルール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오리진 규칙"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de origem"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de origem"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak Kuralları"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源規則"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源站規則"
           }
         }
       }
@@ -104405,6 +109803,82 @@
         }
       }
     },
+    "热链保护" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حماية الروابط الساخنة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotlink-Schutz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotlink Protection"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protección contra hotlinks"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protection contre le hotlinking"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホットリンク保護"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "핫링크 보호"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proteção contra hotlink"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proteção contra hotlink"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotlink Koruması"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "熱連結保護"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "熱鏈保護"
+          }
+        }
+      }
+    },
     "版本" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -104858,6 +110332,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "狀態碼"
+          }
+        }
+      }
+    },
+    "状态码（可选，400–999）" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمز الحالة (اختياري، 400–999)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statuscode (optional, 400–999)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status code (optional, 400–999)"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código de estado (opcional, 400–999)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code d'état (facultatif, 400–999)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータスコード（任意、400–999）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상태 코드(선택 사항, 400–999)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código de status (opcional, 400–999)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código de estado (opcional, 400–999)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durum kodu (isteğe bağlı, 400–999)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態碼（選填，400–999）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態碼（可選，400–999）"
           }
         }
       }
@@ -107902,6 +113452,82 @@
         }
       }
     },
+    "目标为 Rules 表达式，求值结果作为跳转地址。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الهدف هو تعبير بلغة Rules، وتُستخدم نتيجة تقييمه كعنوان لإعادة التوجيه."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Ziel ist ein Rules-Ausdruck; das Auswertungsergebnis wird als Weiterleitungsadresse verwendet."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The target is a Rules expression; its evaluated result is used as the redirect URL."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El destino es una expresión del lenguaje Rules; el resultado evaluado se usa como URL de redirección."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La cible est une expression Rules ; le résultat de son évaluation sert d'URL de redirection."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ターゲットは Rules 式で、評価結果がリダイレクト先 URL になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대상은 Rules 표현식이며, 평가 결과가 리디렉션 URL로 사용됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O destino é uma expressão Rules; o resultado avaliado é usado como URL de redirecionamento."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O destino é uma expressão Rules; o resultado avaliado é usado como URL de redirecionamento."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef bir Rules ifadesidir; değerlendirme sonucu yönlendirme URL'si olarak kullanılır."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標為 Rules 運算式，求值結果作為跳轉位址。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標為 Rules 表達式，求值結果作為跳轉地址。"
+          }
+        }
+      }
+    },
     "目标国家" : {
       "localizations" : {
         "ar" : {
@@ -108126,6 +113752,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目標端口"
+          }
+        }
+      }
+    },
+    "目标类型" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوع الهدف"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zieltyp"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Target type"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de destino"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type de cible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ターゲットタイプ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대상 유형"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de destino"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de destino"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef türü"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標類型"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標類型"
           }
         }
       }
@@ -112244,9 +117946,7 @@
         }
       }
     },
-    "给自己的端点 curl 即推到手机；登录后还能把 Cloudflare 告警的 webhook 指过来。" : {
-
-    },
+    "给自己的端点 curl 即推到手机；登录后还能把 Cloudflare 告警的 webhook 指过来。" : {},
     "继续" : {
       "localizations" : {
         "ar" : {
@@ -115667,6 +121367,82 @@
         }
       }
     },
+    "自动压缩源码" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التصغير التلقائي"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Minify"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Minify"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minificación automática"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minification automatique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動ミニファイ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 최소화"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minificação automática"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minificação automática"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otomatik Küçültme"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動壓縮原始碼"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動壓縮源碼"
+          }
+        }
+      }
+    },
     "自定义 Cron（UTC）" : {
       "localizations" : {
         "ar" : {
@@ -115971,6 +121747,158 @@
         }
       }
     },
+    "自定义资产" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أصل مخصص"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefiniertes Asset"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom asset"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recurso personalizado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ressource personnalisée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタムアセット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정 자산"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativo personalizado"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recurso personalizado"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özel varlık"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂資產"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂資產"
+          }
+        }
+      }
+    },
+    "自定义错误" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أخطاء مخصصة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierte Fehler"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Errors"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errores personalizados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreurs personnalisées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタムエラー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정 오류"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erros personalizados"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erros personalizados"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özel Hatalar"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂錯誤"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂錯誤"
+          }
+        }
+      }
+    },
     "自托管" : {
       "localizations" : {
         "ar" : {
@@ -116196,6 +122124,158 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自架應用程式可保護多個公開主機名稱（及路徑），第一個為主域名。左滑刪除。"
+          }
+        }
+      }
+    },
+    "至少一项。仅列出的设置会被此规则覆盖；左滑移除。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عنصر واحد على الأقل. القاعدة تتجاوز الإعدادات المدرجة فقط؛ اسحب لليسار للإزالة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mindestens eine Einstellung. Nur gelistete Einstellungen werden überschrieben; zum Entfernen nach links wischen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "At least one setting. Only listed settings are overridden by this rule; swipe left to remove."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al menos un ajuste. Solo los ajustes listados serán anulados por esta regla; desliza a la izquierda para quitar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Au moins un réglage. Seuls les réglages listés sont remplacés par cette règle ; balayez vers la gauche pour retirer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "少なくとも 1 件。このルールで上書きされるのはリストの設定のみです。左スワイプで削除。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최소 1개. 나열된 설정만 이 규칙으로 재정의됩니다. 왼쪽으로 스와이프하여 제거하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pelo menos uma configuração. Apenas as configurações listadas são substituídas por esta regra; deslize para a esquerda para remover."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pelo menos uma definição. Apenas as definições listadas são substituídas por esta regra; deslize para a esquerda para remover."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En az bir ayar. Bu kural yalnızca listelenen ayarları geçersiz kılar; kaldırmak için sola kaydırın."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "至少一項。僅列出的設定會被此規則覆寫；左滑移除。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "至少一項。僅列出嘅設定會被此規則覆蓋；左滑移除。"
+          }
+        }
+      }
+    },
+    "至少设置一项。匹配的请求将按此覆盖回源目标。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عيّن عنصرًا واحدًا على الأقل. ستُوجَّه الطلبات المطابقة إلى المصدر وفق هذه التجاوزات."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mindestens ein Feld setzen. Passende Anfragen gehen mit diesen Overrides zum Origin."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set at least one field. Matching requests go to the origin with these overrides."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configura al menos un campo. Las solicitudes coincidentes irán al origen con estas anulaciones."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définissez au moins un champ. Les requêtes correspondantes iront à l'origine avec ces remplacements."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "少なくとも 1 項目を設定してください。一致したリクエストはこの上書きでオリジンへ送られます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하나 이상 설정하세요. 일치하는 요청은 이 재정의에 따라 오리진으로 전달됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defina pelo menos um campo. As solicitações correspondentes irão à origem com essas substituições."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defina pelo menos um campo. Os pedidos correspondentes irão à origem com estas substituições."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En az bir alan ayarlayın. Eşleşen istekler bu geçersiz kılmalarla kaynağa gider."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "至少設定一項。相符的請求將按此覆寫回源目標。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "至少設置一項。匹配嘅請求將按此覆蓋回源目標。"
           }
         }
       }
@@ -116732,6 +122812,82 @@
         }
       }
     },
+    "要覆盖的设置" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإعدادات المراد تجاوزها"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zu überschreibende Einstellungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings to override"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes a anular"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réglages à remplacer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上書きする設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재정의할 설정"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurações a substituir"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Definições a substituir"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçersiz kılınacak ayarlar"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要覆寫的設定"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要覆蓋嘅設定"
+          }
+        }
+      }
+    },
     "覆盖" : {
       "localizations" : {
         "ar" : {
@@ -116960,6 +123116,82 @@
         }
       }
     },
+    "规则中心" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مركز القواعد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regelzentrum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules Hub"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Centro de reglas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Centre de règles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルールセンター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "규칙 센터"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Central de regras"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Centro de regras"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kural Merkezi"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則中心"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則中心"
+          }
+        }
+      }
+    },
     "规则名称" : {
       "localizations" : {
         "ar" : {
@@ -117036,235 +123268,8 @@
         }
       }
     },
-    "规则按从上到下的顺序执行，点按可编辑，左滑可删除。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تُنفَّذ القواعد من الأعلى إلى الأسفل. انقر للتعديل، واسحب لليسار للحذف."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regeln werden von oben nach unten ausgeführt. Zum Bearbeiten antippen, zum Löschen nach links wischen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rules run top to bottom. Tap to edit, swipe left to delete."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las reglas se ejecutan de arriba abajo. Toca para editar, desliza a la izquierda para eliminar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les règles s’exécutent de haut en bas. Touchez pour modifier, balayez vers la gauche pour supprimer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ルールは上から順に実行されます。タップで編集、左にスワイプで削除できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "규칙은 위에서 아래로 실행됩니다. 탭하여 편집하고 왼쪽으로 밀어 삭제하세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As regras são executadas de cima para baixo. Toque para editar, deslize para a esquerda para excluir."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As regras são executadas de cima para baixo. Toque para editar, deslize para a esquerda para eliminar."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kurallar yukarıdan aşağıya çalışır. Düzenlemek için dokunun, silmek için sola kaydırın."
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規則按從上到下的順序執行，點按可編輯，左滑可刪除。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規則按從上到下的順序執行，點按可編輯，左滑可刪除。"
-          }
-        }
-      }
-    },
-    "暂不支持编辑" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التعديل غير مدعوم"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bearbeiten nicht unterstützt"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editing Not Supported"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edición no disponible"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modification non prise en charge"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "編集には未対応"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "편집 미지원"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edição não suportada"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edição não suportada"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Düzenleme desteklenmiyor"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫不支援編輯"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫不支援編輯"
-          }
-        }
-      }
-    },
-    "「跳过」等带额外参数的规则暂不支持在 App 内编辑，请在 Cloudflare Dashboard 中修改。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "القواعد التي تتضمن معلمات إضافية (مثل التخطي) لا يمكن تعديلها داخل التطبيق حالياً. يُرجى تعديلها من لوحة تحكم Cloudflare."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regeln mit zusätzlichen Parametern (z. B. Überspringen) können in der App noch nicht bearbeitet werden. Bitte im Cloudflare-Dashboard ändern."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rules with extra parameters (such as Skip) can’t be edited in the app yet. Please modify them in the Cloudflare Dashboard."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las reglas con parámetros adicionales (como Omitir) aún no se pueden editar en la app. Modifícalas en el panel de Cloudflare."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les règles avec des paramètres supplémentaires (comme Ignorer) ne peuvent pas encore être modifiées dans l’app. Veuillez les modifier dans le tableau de bord Cloudflare."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「スキップ」など追加パラメータを持つルールはアプリ内では編集できません。Cloudflare ダッシュボードで変更してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「건너뛰기」 등 추가 매개변수가 있는 규칙은 아직 앱에서 편집할 수 없습니다. Cloudflare 대시보드에서 수정해 주세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas no app. Modifique-as no painel da Cloudflare."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As regras com parâmetros adicionais (como Ignorar) ainda não podem ser editadas na app. Modifique-as no painel da Cloudflare."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ek parametreler içeren kurallar (ör. Atla) şimdilik uygulama içinde düzenlenemez. Lütfen Cloudflare panosundan değiştirin."
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「跳過」等帶額外參數的規則暫不支援在 App 內編輯，請在 Cloudflare Dashboard 中修改。"
-          }
-        }
-      }
-    },
     "规则按从上到下的顺序执行，左滑可删除。" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -117336,6 +123341,159 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "規則按從上到下的順序執行，左滑可刪除。"
+          }
+        }
+      }
+    },
+    "规则按从上到下的顺序执行，点按可编辑，左滑可删除。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُنفَّذ القواعد من الأعلى إلى الأسفل. انقر للتعديل، واسحب لليسار للحذف."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regeln werden von oben nach unten ausgeführt. Zum Bearbeiten antippen, zum Löschen nach links wischen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules run top to bottom. Tap to edit, swipe left to delete."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las reglas se ejecutan de arriba abajo. Toca para editar, desliza a la izquierda para eliminar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les règles s’exécutent de haut en bas. Touchez pour modifier, balayez vers la gauche pour supprimer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルールは上から順に実行されます。タップで編集、左にスワイプで削除できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "규칙은 위에서 아래로 실행됩니다. 탭하여 편집하고 왼쪽으로 밀어 삭제하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras são executadas de cima para baixo. Toque para editar, deslize para a esquerda para excluir."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras são executadas de cima para baixo. Toque para editar, deslize para a esquerda para eliminar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurallar yukarıdan aşağıya çalışır. Düzenlemek için dokunun, silmek için sola kaydırın."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則按從上到下的順序執行，點按可編輯，左滑可刪除。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則按從上到下的順序執行，點按可編輯，左滑可刪除。"
+          }
+        }
+      }
+    },
+    "规则按从上到下顺序执行；点按查看详情，左滑启停，右滑删除。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُنفَّذ القواعد من الأعلى إلى الأسفل. اضغط للتحرير، اسحب لليسار للتفعيل/التعطيل، ولليمين للحذف."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regeln werden von oben nach unten ausgeführt. Tippe für Details, nach links wischen zum Aktivieren/Deaktivieren, nach rechts zum Löschen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules run top to bottom. Tap for details, swipe left to enable/disable, swipe right to delete."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las reglas se ejecutan de arriba abajo. Toca para ver detalles, desliza a la izquierda para activar/desactivar, a la derecha para eliminar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les règles s'exécutent de haut en bas. Touchez pour voir les détails, balayez vers la gauche pour activer/désactiver, vers la droite pour supprimer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルールは上から下へ順に実行されます。タップして詳細を表示、左スワイプで有効／無効、右スワイプで削除。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "규칙은 위에서 아래로 실행됩니다. 눌러서 편집, 왼쪽으로 밀어 켜기/끄기, 오른쪽으로 밀어 삭제."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras são executadas de cima para baixo. Toque para ver detalhes, deslize para a esquerda para ativar/desativar, para a direita para excluir."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As regras são executadas de cima para baixo. Toque para ver detalhes, deslize para a esquerda para ativar/desativar, para a direita para eliminar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurallar yukarıdan aşağıya çalışır. Düzenlemek için dokunun, etkinleştirmek/devre dışı bırakmak için sola, silmek için sağa kaydırın."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則由上至下依序執行；點按查看詳細資訊，左滑啟停，右滑刪除。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則由上至下依序執行；點按查看詳情，左滑啟停，右滑刪除。"
           }
         }
       }
@@ -117492,6 +123650,82 @@
         }
       }
     },
+    "规则管理需要 Pro" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إدارة القواعد تتطلب Pro"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regelverwaltung erfordert Pro"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rules management requires Pro"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La gestión de reglas requiere Pro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La gestion des règles nécessite Pro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルール管理には Pro が必要です"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "규칙 관리에는 Pro가 필요합니다"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O gerenciamento de regras requer o Pro"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A gestão de regras requer o Pro"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kural yönetimi Pro gerektirir"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則管理需要 Pro"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則管理需要 Pro"
+          }
+        }
+      }
+    },
     "规则说明（可选）" : {
       "localizations" : {
         "ar" : {
@@ -117564,6 +123798,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "規則說明（選填）"
+          }
+        }
+      }
+    },
+    "规范化类型" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوع التسوية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalisierungstyp"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalization type"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de normalización"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type de normalisation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正規化タイプ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정규화 유형"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de normalização"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de normalização"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normalleştirme türü"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正規化類型"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規範化類型"
           }
         }
       }
@@ -120380,6 +126690,158 @@
         }
       }
     },
+    "该规则基于批量列表（from_list），请在 Cloudflare Dashboard 编辑。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تستند هذه القاعدة إلى قائمة مجمّعة (from_list)؛ يُرجى تحريرها في لوحة تحكم Cloudflare."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Regel basiert auf einer Massenliste (from_list); bitte im Cloudflare Dashboard bearbeiten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This rule is based on a bulk list (from_list); edit it in the Cloudflare Dashboard."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta regla se basa en una lista masiva (from_list); edítala en el panel de Cloudflare."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette règle repose sur une liste en masse (from_list) ; modifiez-la dans le tableau de bord Cloudflare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このルールは一括リスト（from_list）に基づいています。Cloudflare ダッシュボードで編集してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 규칙은 대량 목록(from_list)을 기반으로 합니다. Cloudflare 대시보드에서 편집하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta regra é baseada em uma lista em massa (from_list); edite-a no painel da Cloudflare."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta regra baseia-se numa lista em massa (from_list); edite-a no painel da Cloudflare."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu kural bir toplu listeye (from_list) dayanır; Cloudflare panosunda düzenleyin."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此規則基於批次清單（from_list），請在 Cloudflare 儀表板編輯。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此規則基於批量列表（from_list），請喺 Cloudflare 儀表板編輯。"
+          }
+        }
+      }
+    },
+    "该规则的内容由自定义资产提供，App 内不改动资产本身。" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يوفَّر محتوى هذه القاعدة من أصل مخصص؛ لا يعدّل التطبيق الأصل نفسه."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Inhalt dieser Regel stammt aus einem benutzerdefinierten Asset; das Asset selbst wird in der App nicht geändert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This rule's content comes from a custom asset; the asset itself isn't modified in the app."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El contenido de esta regla proviene de un recurso personalizado; la app no modifica el recurso en sí."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le contenu de cette règle provient d'une ressource personnalisée ; l'app ne modifie pas la ressource elle-même."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このルールの内容はカスタムアセットから提供されます。アセット自体はアプリ内で変更されません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 규칙의 콘텐츠는 사용자 지정 자산에서 제공됩니다. 자산 자체는 앱에서 수정되지 않습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O conteúdo desta regra vem de um ativo personalizado; o ativo em si não é modificado no app."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O conteúdo desta regra provém de um recurso personalizado; o recurso em si não é modificado na app."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu kuralın içeriği özel bir varlıktan gelir; varlığın kendisi uygulamada değiştirilmez."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此規則的內容由自訂資產提供，App 內不變更資產本身。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此規則嘅內容由自訂資產提供，App 內唔會改動資產本身。"
+          }
+        }
+      }
+    },
     "该账号下还没有 AI Gateway。" : {
       "localizations" : {
         "ar" : {
@@ -121668,6 +128130,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請求 · 24h"
+          }
+        }
+      }
+    },
+    "请求体缓冲" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تخزين نص الطلب مؤقتًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request-Body-Pufferung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request body buffering"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almacenamiento en búfer del cuerpo de la solicitud"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mise en tampon du corps de requête"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストボディのバッファリング"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요청 본문 버퍼링"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buffer do corpo da solicitação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buffer do corpo do pedido"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İstek gövdesi arabelleğe alma"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要求本文緩衝"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請求體緩衝"
           }
         }
       }
@@ -128588,6 +135126,82 @@
         }
       }
     },
+    "这是多模块打包 Worker，无法在此原地编辑（会丢失其它模块）。可在「新建」里用多模块方式整体替换。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is a multi-module (bundled) Worker and can't be edited in place here (other modules would be lost). Use multi-module upload under New to replace it entirely."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這是多模組打包 Worker，無法在此原地編輯（會遺失其他模組）。可在「新增」裡用多模組方式整體取代。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這是多模組打包 Worker，無法在此原地編輯（會遺失其他模組）。可在「新增」裡用多模組方式整體取代。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これは複数モジュールのバンドル Worker で、ここでは直接編集できません（他のモジュールが失われます）。「新規」の複数モジュールアップロードで全体を置き換えてください。"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este Worker es de múltiples módulos (empaquetado) y no se puede editar aquí (se perderían los demás módulos). Usa la carga de múltiples módulos en Nuevo para reemplazarlo por completo."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 Worker는 다중 모듈(번들) 형식이라 여기서 직접 편집할 수 없습니다(다른 모듈이 사라집니다). '새로 만들기'의 다중 모듈 업로드로 전체를 교체하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este Worker é de múltiplos módulos (empacotado) e não pode ser editado aqui (os outros módulos seriam perdidos). Use o envio de múltiplos módulos em Novo para substituí-lo por completo."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este Worker é de múltiplos módulos (empacotado) e não pode ser editado aqui (os outros módulos seriam perdidos). Utilize o carregamento de múltiplos módulos em Novo para o substituir por completo."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dies ist ein Worker mit mehreren Modulen (gebündelt) und kann hier nicht direkt bearbeitet werden (andere Module gingen verloren). Ersetze ihn über „Neu“ per Mehrmodul-Upload vollständig."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce Worker est multi-module (regroupé) et ne peut pas être modifié ici (les autres modules seraient perdus). Utilisez l'envoi multi-module dans « Nouveau » pour le remplacer entièrement."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏هذا Worker متعدد الوحدات (مُجمَّع) ولا يمكن تعديله هنا مباشرةً (ستُفقد الوحدات الأخرى). استخدم رفع الوحدات المتعددة من «جديد» لاستبداله بالكامل."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu, çok modüllü (paketlenmiş) bir Worker'dır ve burada yerinde düzenlenemez (diğer modüller kaybolur). Tamamen değiştirmek için Yeni'deki çok modüllü yüklemeyi kullanın."
+          }
+        }
+      }
+    },
     "这条描述被安全过滤拦下了，换个说法再试。" : {
       "localizations" : {
         "ar" : {
@@ -132388,6 +139002,82 @@
         }
       }
     },
+    "配置规则" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قواعد التكوين"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurationsregeln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration Rules"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas de configuración"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Règles de configuration"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "構成ルール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구성 규칙"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de configuração"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de configuração"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yapılandırma Kuralları"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定規則"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置規則"
+          }
+        }
+      }
+    },
     "重写为" : {
       "localizations" : {
         "ar" : {
@@ -134133,6 +140823,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "錯誤"
+          }
+        }
+      }
+    },
+    "错误响应" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استجابة الخطأ"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehlerantwort"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error response"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuesta de error"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponse d'erreur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー応答"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오류 응답"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resposta de erro"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resposta de erro"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hata yanıtı"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤回應"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤響應"
           }
         }
       }
@@ -136493,6 +143259,82 @@
         }
       }
     },
+    "静态 URL" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عنوان URL ثابت"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statische URL"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Static URL"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL estática"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL statique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "静的 URL"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정적 URL"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL estática"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL estática"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statik URL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靜態 URL"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靜態 URL"
+          }
+        }
+      }
+    },
     "静态文件" : {
       "localizations" : {
         "ar" : {
@@ -137861,6614 +144703,990 @@
         }
       }
     },
-    "加入体验者计划？" : {
+    "永久删除 Worker" : {
       "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل تريد الانضمام إلى برنامج تحسين التطبيق؟"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Am Insider-Programm teilnehmen?"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Join the Insider Program?"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Unirte al programa Insider?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rejoindre le programme Insider ?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インサイダープログラムに参加しますか？"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인사이더 프로그램에 참여하시겠습니까?"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Participar do Programa Insider?"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aderir ao Programa Insider?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insider Programı'na katılmak ister misiniz?"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入體驗者計畫？"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入體驗者計劃？"
-          }
-        }
-      }
-    },
-    "加入" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انضمام"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teilnehmen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Join"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unirme"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rejoindre"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "참여"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Participar"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aderir"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Katıl"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入"
-          }
-        }
-      }
-    },
-    "暂不" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ليس الآن"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jetzt nicht"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Now"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ahora no"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plus tard"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今はしない"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "나중에"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agora não"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agora não"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Şimdi değil"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫不"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫不"
-          }
-        }
-      }
-    },
-    "开启后，App 会上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。可随时在设置中关闭。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عند التفعيل، يرسل التطبيق سجلات تشخيص مجهولة الهوية ومعلومات الأعطال (لا تتضمن أبدًا رموزك أو بيانات حسابك أو أي معلومات شخصية) لمساعدتنا في تحديد مشكلات تسجيل الدخول والاستقرار بشكل أسرع. يمكنك إيقافه في أي وقت من الإعدادات."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, sendet die App anonyme Diagnoseprotokolle und Absturzberichte (niemals deine Tokens, Kontodaten oder persönliche Informationen), damit wir Anmelde- und Stabilitätsprobleme schneller eingrenzen können. Du kannst dies jederzeit in den Einstellungen deaktivieren."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, the app reports anonymous diagnostic logs and crash data (never your tokens, account data, or any personal information) to help us track down sign-in and stability issues faster. You can turn this off anytime in Settings."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al activarlo, la app envía registros de diagnóstico anónimos e informes de fallos (nunca tus tokens, datos de cuenta ni información personal) para ayudarnos a identificar más rápido los problemas de inicio de sesión y estabilidad. Puedes desactivarlo en cualquier momento en Ajustes."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une fois activé, l'app envoie des journaux de diagnostic anonymes et des rapports de plantage (jamais vos jetons, données de compte ni aucune information personnelle) pour nous aider à identifier plus vite les problèmes de connexion et de stabilité. Vous pouvez désactiver cela à tout moment dans les réglages."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンにすると、匿名の診断ログとクラッシュ情報（トークン、アカウントデータ、個人情報は一切含まれません）を送信し、ログインや安定性の問題の特定に役立てます。設定でいつでもオフにできます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "활성화하면 익명 진단 로그와 충돌 정보(토큰, 계정 데이터, 개인정보는 포함되지 않음)를 전송하여 로그인 및 안정성 문제를 더 빠르게 파악하는 데 도움이 됩니다. 설정에서 언제든지 끌 수 있습니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quando ativado, o app envia registros de diagnóstico anônimos e relatórios de falhas (nunca seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rápido problemas de login e estabilidade. Você pode desativar a qualquer momento nos Ajustes."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quando ativado, a app envia registos de diagnóstico anónimos e relatórios de falhas (nunca os seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rapidamente problemas de início de sessão e estabilidade. Pode desativar a qualquer momento nas Definições."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etkinleştirildiğinde uygulama, oturum açma ve kararlılık sorunlarını daha hızlı bulmamıza yardımcı olmak için anonim tanılama günlükleri ve çökme bilgileri gönderir (belirteçleriniz, hesap verileriniz veya hiçbir kişisel bilgi asla dahil edilmez). Ayarlar'dan istediğiniz zaman kapatabilirsiniz."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟後，App 會回報匿名診斷日誌與當機資訊（不含權杖、帳號資料或任何個人資訊），協助我們更快定位登入與穩定性問題。可隨時在設定中關閉。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟後，App 會上報匿名診斷日誌與崩潰資訊（不含權杖、帳戶資料或任何個人資料），協助我們更快定位登入與穩定性問題。可隨時在設定中關閉。"
-          }
-        }
-      }
-    },
-    "体验者计划" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برنامج تحسين التطبيق"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insider-Programm"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insider Program"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programa Insider"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programme Insider"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インサイダープログラム"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인사이더 프로그램"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programa Insider"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programa Insider"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insider Programı"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "體驗者計畫"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "體驗者計劃"
-          }
-        }
-      }
-    },
-    "开启后上报匿名诊断日志与崩溃信息（不含令牌、账号数据或任何个人信息），帮助我们更快定位登录与稳定性问题。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عند التفعيل، تُرسَل سجلات تشخيص مجهولة الهوية ومعلومات الأعطال (لا تتضمن أبدًا رموزك أو بيانات حسابك أو أي معلومات شخصية) لمساعدتنا في تحديد مشكلات تسجيل الدخول والاستقرار بشكل أسرع."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, werden anonyme Diagnoseprotokolle und Absturzberichte gesendet (niemals deine Tokens, Kontodaten oder persönliche Informationen), damit wir Anmelde- und Stabilitätsprobleme schneller eingrenzen können."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, reports anonymous diagnostic logs and crash data (never your tokens, account data, or any personal information) to help us track down sign-in and stability issues faster."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al activarlo, se envían registros de diagnóstico anónimos e informes de fallos (nunca tus tokens, datos de cuenta ni información personal) para ayudarnos a identificar más rápido los problemas de inicio de sesión y estabilidad."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une fois activé, envoie des journaux de diagnostic anonymes et des rapports de plantage (jamais vos jetons, données de compte ni aucune information personnelle) pour nous aider à identifier plus vite les problèmes de connexion et de stabilité."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンにすると、匿名の診断ログとクラッシュ情報（トークン、アカウントデータ、個人情報は一切含まれません）を送信し、ログインや安定性の問題の特定に役立てます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "활성화하면 익명 진단 로그와 충돌 정보(토큰, 계정 데이터, 개인정보는 포함되지 않음)를 전송하여 로그인 및 안정성 문제를 더 빠르게 파악하는 데 도움이 됩니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quando ativado, envia registros de diagnóstico anônimos e relatórios de falhas (nunca seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rápido problemas de login e estabilidade."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quando ativado, envia registos de diagnóstico anónimos e relatórios de falhas (nunca os seus tokens, dados de conta ou informações pessoais) para nos ajudar a identificar mais rapidamente problemas de início de sessão e estabilidade."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etkinleştirildiğinde, oturum açma ve kararlılık sorunlarını daha hızlı bulmamıza yardımcı olmak için anonim tanılama günlükleri ve çökme bilgileri gönderilir (belirteçleriniz, hesap verileriniz veya hiçbir kişisel bilgi asla dahil edilmez)."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟後回報匿名診斷日誌與當機資訊（不含權杖、帳號資料或任何個人資訊），協助我們更快定位登入與穩定性問題。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟後上報匿名診斷日誌與崩潰資訊（不含權杖、帳戶資料或任何個人資料），協助我們更快定位登入與穩定性問題。"
-          }
-        }
-      }
-    },
-    "当前授权仅限读取（%@），无法修改规则。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التفويض الحالي للقراءة فقط (%@)، ولا يمكن تعديل القواعد."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die aktuelle Autorisierung ist schreibgeschützt (%@); Regeln können nicht geändert werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The current authorization is read-only (%@); rules cannot be modified."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La autorización actual es de solo lectura (%@); no se pueden modificar las reglas."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'autorisation actuelle est en lecture seule (%@) ; les règles ne peuvent pas être modifiées."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の認可は読み取り専用（%@）のため、ルールを変更できません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 권한은 읽기 전용(%@)이라 규칙을 수정할 수 없습니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual é somente leitura (%@); as regras não podem ser modificadas."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual é apenas de leitura (%@); as regras não podem ser modificadas."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geçerli yetkilendirme salt okunur (%@); kurallar değiştirilemez."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權僅限讀取（%@），無法修改規則。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權僅限讀取（%@），無法修改規則。"
-          }
-        }
-      }
-    },
-    "当前授权仅限读取（page-rules.read），无法修改规则。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التفويض الحالي للقراءة فقط (page-rules.read)، ولا يمكن تعديل القواعد."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die aktuelle Autorisierung ist schreibgeschützt (page-rules.read); Regeln können nicht geändert werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The current authorization is read-only (page-rules.read); rules cannot be modified."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La autorización actual es de solo lectura (page-rules.read); no se pueden modificar las reglas."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'autorisation actuelle est en lecture seule (page-rules.read) ; les règles ne peuvent pas être modifiées."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の認可は読み取り専用（page-rules.read）のため、ルールを変更できません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 권한은 읽기 전용(page-rules.read)이라 규칙을 수정할 수 없습니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual é somente leitura (page-rules.read); as regras não podem ser modificadas."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual é apenas de leitura (page-rules.read); as regras não podem ser modificadas."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geçerli yetkilendirme salt okunur (page-rules.read); kurallar değiştirilemez."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權僅限讀取（page-rules.read），無法修改規則。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權僅限讀取（page-rules.read），無法修改規則。"
-          }
-        }
-      }
-    },
-    "当前授权仅限读取（config-settings.read），无法修改。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التفويض الحالي للقراءة فقط (config-settings.read)، ولا يمكن تعديل القواعد."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die aktuelle Autorisierung ist schreibgeschützt (config-settings.read); Regeln können nicht geändert werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The current authorization is read-only (config-settings.read); rules cannot be modified."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La autorización actual es de solo lectura (config-settings.read); no se pueden modificar las reglas."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'autorisation actuelle est en lecture seule (config-settings.read) ; les règles ne peuvent pas être modifiées."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の認可は読み取り専用（config-settings.read）のため、ルールを変更できません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 권한은 읽기 전용(config-settings.read)이라 규칙을 수정할 수 없습니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual é somente leitura (config-settings.read); as regras não podem ser modificadas."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual é apenas de leitura (config-settings.read); as regras não podem ser modificadas."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geçerli yetkilendirme salt okunur (config-settings.read); kurallar değiştirilemez."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權僅限讀取（config-settings.read），無法修改規則。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權僅限讀取（config-settings.read），無法修改規則。"
-          }
-        }
-      }
-    },
-    "规则按从上到下顺序执行；点按查看详情，左滑启停，右滑删除。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تُنفَّذ القواعد من الأعلى إلى الأسفل. اضغط للتحرير، اسحب لليسار للتفعيل/التعطيل، ولليمين للحذف."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regeln werden von oben nach unten ausgeführt. Tippe für Details, nach links wischen zum Aktivieren/Deaktivieren, nach rechts zum Löschen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rules run top to bottom. Tap for details, swipe left to enable/disable, swipe right to delete."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las reglas se ejecutan de arriba abajo. Toca para ver detalles, desliza a la izquierda para activar/desactivar, a la derecha para eliminar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les règles s'exécutent de haut en bas. Touchez pour voir les détails, balayez vers la gauche pour activer/désactiver, vers la droite pour supprimer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ルールは上から下へ順に実行されます。タップして詳細を表示、左スワイプで有効／無効、右スワイプで削除。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "규칙은 위에서 아래로 실행됩니다. 눌러서 편집, 왼쪽으로 밀어 켜기/끄기, 오른쪽으로 밀어 삭제."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As regras são executadas de cima para baixo. Toque para ver detalhes, deslize para a esquerda para ativar/desativar, para a direita para excluir."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As regras são executadas de cima para baixo. Toque para ver detalhes, deslize para a esquerda para ativar/desativar, para a direita para eliminar."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kurallar yukarıdan aşağıya çalışır. Düzenlemek için dokunun, etkinleştirmek/devre dışı bırakmak için sola, silmek için sağa kaydırın."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規則由上至下依序執行；點按查看詳細資訊，左滑啟停，右滑刪除。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規則由上至下依序執行；點按查看詳情，左滑啟停，右滑刪除。"
-          }
-        }
-      }
-    },
-    "当前授权未包含此规则的编辑权限（%@）。点「一键重授权」补齐，无需退出登录。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التفويض الحالي لا يتضمن إذن تحرير هذا النوع من القواعد (%@). انقر على «إعادة التفويض» لإضافته دون تسجيل الخروج."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die aktuelle Autorisierung enthält keine Bearbeitung dieses Regeltyps (%@). Tippe auf „Neu autorisieren“, um sie hinzuzufügen – ohne Abmelden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The current authorization doesn't include editing for this rule type (%@). Tap “Re-authorize” to add it — no sign-out needed."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La autorización actual no incluye la edición de este tipo de regla (%@). Toca “Reautorizar” para agregarla, sin cerrar sesión."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'autorisation actuelle n'inclut pas la modification de ce type de règle (%@). Touchez « Réautoriser » pour l'ajouter, sans déconnexion."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の認可にはこのルールの編集権限（%@）が含まれていません。「再認可」をタップして追加できます（ログアウト不要）。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 승인에는 이 규칙의 편집 권한(%@)이 포함되어 있지 않습니다. '재승인'을 탭하여 추가할 수 있습니다(로그아웃 불필요)."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual não inclui a edição deste tipo de regra (%@). Toque em “Reautorizar” para adicioná-la, sem sair da conta."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual não inclui a edição deste tipo de regra (%@). Toque em “Reautorizar” para a adicionar, sem terminar sessão."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mevcut yetkilendirme bu kural türü için düzenleme iznini (%@) içermiyor. Eklemek için “Yeniden yetkilendir”e dokunun — çıkış yapmanız gerekmez."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權未包含此規則的編輯權限（%@）。點「一鍵重新授權」補齊，無需登出。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權未包含此規則嘅編輯權限（%@）。點「一鍵重新授權」補齊，無需登出。"
-          }
-        }
-      }
-    },
-    "当前授权未包含 Page Rules 编辑权限（page-rules.write）。点「一键重授权」补齐，无需退出登录。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التفويض الحالي لا يتضمن إذن تحرير Page Rules ‏(page-rules.write). انقر على «إعادة التفويض» لإضافته دون تسجيل الخروج."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die aktuelle Autorisierung enthält keine Bearbeitung von Page Rules (page-rules.write). Tippe auf „Neu autorisieren“, um sie hinzuzufügen – ohne Abmelden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The current authorization doesn't include editing for Page Rules (page-rules.write). Tap “Re-authorize” to add it — no sign-out needed."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La autorización actual no incluye la edición de las Page Rules (page-rules.write). Toca “Reautorizar” para agregarla, sin cerrar sesión."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'autorisation actuelle n'inclut pas la modification de des Page Rules (page-rules.write). Touchez « Réautoriser » pour l'ajouter, sans déconnexion."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の認可にはPage Rules の編集権限（page-rules.write）が含まれていません。「再認可」をタップして追加できます（ログアウト不要）。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 승인에는 Page Rules 편집 권한(page-rules.write)이 포함되어 있지 않습니다. '재승인'을 탭하여 추가할 수 있습니다(로그아웃 불필요)."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual não inclui a edição das Page Rules (page-rules.write). Toque em “Reautorizar” para adicioná-la, sem sair da conta."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A autorização atual não inclui a edição das Page Rules (page-rules.write). Toque em “Reautorizar” para a adicionar, sem terminar sessão."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mevcut yetkilendirme Page Rules düzenleme iznini (page-rules.write) içermiyor. Eklemek için “Yeniden yetkilendir”e dokunun — çıkış yapmanız gerekmez."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權未包含Page Rules 編輯權限（page-rules.write）。點「一鍵重新授權」補齊，無需登出。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前授權未包含Page Rules 編輯權限（page-rules.write）。點「一鍵重新授權」補齊，無需登出。"
-          }
-        }
-      }
-    },
-    "单条重定向" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عمليات إعادة التوجيه الفردية"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einzelweiterleitungen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Single Redirects"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redirecciones individuales"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redirections unitaires"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シングルリダイレクト"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "단일 리디렉션"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redirecionamentos individuais"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redirecionamentos individuais"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekil Yönlendirmeler"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "單條重新導向"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "單條重定向"
-          }
-        }
-      }
-    },
-    "源站规则" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قواعد المصدر"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin-Regeln"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin Rules"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reglas de origen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Règles d'origine"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オリジンルール"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오리진 규칙"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras de origem"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras de origem"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaynak Kuralları"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源規則"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源站規則"
-          }
-        }
-      }
-    },
-    "配置规则" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قواعد التكوين"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurationsregeln"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration Rules"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reglas de configuración"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Règles de configuration"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "構成ルール"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구성 규칙"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras de configuração"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras de configuração"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yapılandırma Kuralları"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定規則"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配置規則"
-          }
-        }
-      }
-    },
-    "压缩规则" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قواعد الضغط"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komprimierungsregeln"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compression Rules"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reglas de compresión"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Règles de compression"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圧縮ルール"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "압축 규칙"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras de compressão"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regras de compressão"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sıkıştırma Kuralları"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "壓縮規則"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "壓縮規則"
-          }
-        }
-      }
-    },
-    "自定义错误" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أخطاء مخصصة"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Fehler"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom Errors"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errores personalizados"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreurs personnalisées"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カスタムエラー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용자 지정 오류"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erros personalizados"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erros personalizados"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Özel Hatalar"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自訂錯誤"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自訂錯誤"
-          }
-        }
-      }
-    },
-    "查看详情" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عرض التفاصيل"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View details"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver detalles"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir les détails"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "詳細を表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "세부 정보 보기"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver detalhes"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver detalhes"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayrıntıları görüntüle"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查看詳細資訊"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查看詳情"
-          }
-        }
-      }
-    },
-    "Host：%@" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "المضيف: %@"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host: %@"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host: %@"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host: %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hôte : %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ホスト：%@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "호스트: %@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host: %@"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host: %@"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host: %@"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host：%@"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host：%@"
-          }
-        }
-      }
-    },
-    "源站：%@" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "المصدر: %@"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin: %@"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin: %@"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origen: %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origine : %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オリジン：%@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오리진: %@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origem: %@"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origem: %@"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaynak: %@"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源：%@"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源站：%@"
-          }
-        }
-      }
-    },
-    "源站端口：%lld" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منفذ المصدر: %lld"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin-Port: %lld"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin port: %lld"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puerto de origen: %lld"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Port d'origine : %lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オリジンポート：%lld"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오리진 포트: %lld"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Porta de origem: %lld"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Porta de origem: %lld"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaynak bağlantı noktası: %lld"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源連接埠：%lld"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源站連接埠：%lld"
-          }
-        }
-      }
-    },
-    "流量与内容" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حركة المرور والمحتوى"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traffic & Inhalt"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traffic & Content"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tráfico y contenido"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trafic et contenu"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トラフィックとコンテンツ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "트래픽 및 콘텐츠"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tráfego e conteúdo"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tráfego e conteúdo"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trafik ve İçerik"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "流量與內容"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "流量與內容"
-          }
-        }
-      }
-    },
-    "改写与缓存" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة الكتابة والتخزين المؤقت"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umschreiben & Cache"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rewrite & Cache"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reescritura y caché"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réécriture et cache"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "書き換えとキャッシュ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "재작성 및 캐시"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reescrita e cache"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reescrita e cache"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeniden Yazma ve Önbellek"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "改寫與快取"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "改寫與緩存"
-          }
-        }
-      }
-    },
-    "传统与全局" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "القديمة والعامة"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legacy & Global"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legacy & Global"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heredadas y globales"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Héritées et globales"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レガシーとグローバル"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "레거시 및 전역"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legado e global"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legado e global"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eski ve Genel"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "傳統與全域"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "傳統與全局"
-          }
-        }
-      }
-    },
-    "新类型规则目前支持查看、启停与删除；创建和编辑请在 Cloudflare Dashboard 完成。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تدعم أنواع القواعد الجديدة حاليًا العرض والتفعيل/الإيقاف والحذف؛ يُرجى إنشاء القواعد وتحريرها في لوحة تحكم Cloudflare."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neue Regeltypen unterstützen derzeit Anzeigen, Aktivieren/Deaktivieren und Löschen; erstellen und bearbeiten kannst du Regeln im Cloudflare Dashboard."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New rule types currently support viewing, toggling, and deleting; create and edit rules in the Cloudflare Dashboard."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los tipos de regla nuevos actualmente permiten ver, activar/desactivar y eliminar; crea y edita reglas en el panel de Cloudflare."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les nouveaux types de règles permettent pour l'instant de consulter, d'activer/désactiver et de supprimer ; créez et modifiez les règles dans le tableau de bord Cloudflare."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しいタイプのルールは現在、表示・有効／無効・削除に対応しています。作成と編集は Cloudflare ダッシュボードで行ってください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새 규칙 유형은 현재 보기, 활성화/비활성화, 삭제를 지원합니다. 규칙 생성과 편집은 Cloudflare 대시보드에서 하세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Os novos tipos de regra atualmente permitem ver, ativar/desativar e excluir; crie e edite regras no painel da Cloudflare."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Os novos tipos de regra permitem atualmente ver, ativar/desativar e eliminar; crie e edite regras no painel da Cloudflare."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeni kural türleri şu anda görüntüleme, etkinleştirme/devre dışı bırakma ve silmeyi destekler; kuralları Cloudflare panosunda oluşturup düzenleyin."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新類型規則目前支援查看、啟停與刪除；建立和編輯請在 Cloudflare 儀表板完成。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新類型規則目前支援查看、啟停與刪除；建立同編輯請喺 Cloudflare 儀表板完成。"
-          }
-        }
-      }
-    },
-    "没有%@" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا توجد %@"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine %@"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No %@"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune règle : %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@はありません"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 없음"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem %@"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem %@"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ yok"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有%@"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有%@"
-          }
-        }
-      }
-    },
-    "此域名还没有这类规则。规则创建请在 Cloudflare Dashboard 完成，创建后这里可查看、启停与删除。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا يحتوي هذا النطاق على قواعد من هذا النوع بعد. أنشئ القواعد في لوحة تحكم Cloudflare، وبعد الإنشاء يمكنك هنا عرضها وتفعيلها/إيقافها وحذفها."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Domain hat noch keine Regeln dieses Typs. Erstelle Regeln im Cloudflare Dashboard; danach kannst du sie hier anzeigen, umschalten und löschen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This domain doesn't have rules of this type yet. Create rules in the Cloudflare Dashboard; once created, you can view, toggle, and delete them here."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este dominio aún no tiene reglas de este tipo. Crea reglas en el panel de Cloudflare; una vez creadas, aquí podrás verlas, activarlas/desactivarlas y eliminarlas."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce domaine n'a pas encore de règles de ce type. Créez-les dans le tableau de bord Cloudflare ; vous pourrez ensuite les consulter, les activer/désactiver et les supprimer ici."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このドメインにはまだこのタイプのルールがありません。Cloudflare ダッシュボードで作成すると、ここで表示・有効／無効・削除ができます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 도메인에는 아직 이 유형의 규칙이 없습니다. Cloudflare 대시보드에서 규칙을 만들면 여기에서 보기, 활성화/비활성화, 삭제할 수 있습니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este domínio ainda não tem regras deste tipo. Crie regras no painel da Cloudflare; depois de criadas, você pode vê-las, ativar/desativar e excluí-las aqui."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este domínio ainda não tem regras deste tipo. Crie regras no painel da Cloudflare; depois de criadas, pode vê-las, ativar/desativar e eliminá-las aqui."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu alan adında henüz bu türde kural yok. Kuralları Cloudflare panosunda oluşturun; oluşturulduktan sonra burada görüntüleyebilir, açıp kapatabilir ve silebilirsiniz."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此網域還沒有這類規則。請在 Cloudflare 儀表板建立規則，建立後可在此查看、啟停與刪除。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此域名仲未有呢類規則。請喺 Cloudflare 儀表板建立規則，建立後可以喺度查看、啟停同刪除。"
-          }
-        }
-      }
-    },
-    "动作参数" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "معلمات الإجراء"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktionsparameter"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Action parameters"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parámetros de acción"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres d'action"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクションパラメータ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "작업 매개변수"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parâmetros de ação"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parâmetros de ação"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eylem parametreleri"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動作參數"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動作參數"
-          }
-        }
-      }
-    },
-    "没有 Page Rules" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا توجد Page Rules"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Page Rules"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Page Rules"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin Page Rules"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune Page Rule"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules はありません"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules 없음"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem Page Rules"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem Page Rules"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules yok"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有 Page Rules"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有 Page Rules"
-          }
-        }
-      }
-    },
-    "Page Rules 是传统功能，Cloudflare 建议迁移到新的规则产品；已有规则可在此查看、启停与删除。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تُعد Page Rules ميزة قديمة وتوصي Cloudflare بالانتقال إلى منتجات القواعد الجديدة؛ يمكنك هنا عرض القواعد الموجودة وتفعيلها/إيقافها وحذفها."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules sind eine Legacy-Funktion; Cloudflare empfiehlt die Migration zu den neuen Regelprodukten. Bestehende Regeln kannst du hier anzeigen, umschalten und löschen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules are a legacy feature; Cloudflare recommends migrating to the new rules products. Existing rules can be viewed, toggled, and deleted here."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las Page Rules son una función heredada; Cloudflare recomienda migrar a los nuevos productos de reglas. Aquí puedes ver, activar/desactivar y eliminar las reglas existentes."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les Page Rules sont une fonctionnalité héritée ; Cloudflare recommande de migrer vers les nouveaux produits de règles. Les règles existantes peuvent être consultées, activées/désactivées et supprimées ici."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules はレガシー機能です。Cloudflare は新しいルール製品への移行を推奨しています。既存のルールはここで表示・有効／無効・削除できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules는 레거시 기능입니다. Cloudflare는 새 규칙 제품으로의 마이그레이션을 권장합니다. 기존 규칙은 여기에서 보기, 활성화/비활성화, 삭제할 수 있습니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As Page Rules são um recurso legado; a Cloudflare recomenda migrar para os novos produtos de regras. As regras existentes podem ser vistas, ativadas/desativadas e excluídas aqui."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As Page Rules são uma funcionalidade legada; a Cloudflare recomenda migrar para os novos produtos de regras. As regras existentes podem ser vistas, ativadas/desativadas e eliminadas aqui."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules eski bir özelliktir; Cloudflare yeni kural ürünlerine geçilmesini önerir. Mevcut kuralları burada görüntüleyebilir, açıp kapatabilir ve silebilirsiniz."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules 是傳統功能，Cloudflare 建議遷移到新的規則產品；既有規則可在此查看、啟停與刪除。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Rules 係傳統功能，Cloudflare 建議遷移到新嘅規則產品；現有規則可以喺度查看、啟停同刪除。"
-          }
-        }
-      }
-    },
-    "左滑启停，右滑删除。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اسحب لليسار للتفعيل/الإيقاف، ولليمين للحذف."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach links wischen zum Aktivieren/Deaktivieren, nach rechts zum Löschen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swipe left to enable/disable, swipe right to delete."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desliza a la izquierda para activar/desactivar y a la derecha para eliminar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Balayez vers la gauche pour activer/désactiver, vers la droite pour supprimer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左スワイプで有効／無効、右スワイプで削除。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "왼쪽으로 스와이프하여 활성화/비활성화, 오른쪽으로 스와이프하여 삭제합니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deslize para a esquerda para ativar/desativar e para a direita para excluir."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deslize para a esquerda para ativar/desativar e para a direita para eliminar."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etkinleştirmek/devre dışı bırakmak için sola, silmek için sağa kaydırın."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左滑啟停，右滑刪除。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左滑啟停，右滑刪除。"
-          }
-        }
-      }
-    },
-    "URL 规范化" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تسوية عناوين URL"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL-Normalisierung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL Normalization"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalización de URL"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalisation des URL"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 正規化"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 정규화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalização de URL"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalização de URL"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL Normalleştirme"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 正規化"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 規範化"
-          }
-        }
-      }
-    },
-    "规范化类型" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نوع التسوية"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalisierungstyp"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalization type"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de normalización"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type de normalisation"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正規化タイプ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정규화 유형"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de normalização"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de normalização"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalleştirme türü"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正規化類型"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規範化類型"
-          }
-        }
-      }
-    },
-    "作用范围" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "النطاق"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geltungsbereich"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scope"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alcance"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Portée"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "適用範囲"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "적용 범위"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escopo"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Âmbito"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kapsam"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "適用範圍"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作用範圍"
-          }
-        }
-      }
-    },
-    "仅入站 URL" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عناوين URL الواردة فقط"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur eingehende URLs"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incoming URLs only"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solo URL entrantes"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL entrantes uniquement"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "受信 URL のみ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수신 URL만"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Somente URLs de entrada"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apenas URLs de entrada"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yalnızca gelen URL'ler"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "僅傳入 URL"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "僅入站 URL"
-          }
-        }
-      }
-    },
-    "入站与规则匹配" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الواردة ومطابقة القواعد"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingehend & Regelabgleich"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incoming & rule matching"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrantes y coincidencia de reglas"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrantes et correspondance des règles"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "受信とルールマッチング"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수신 및 규칙 일치"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrada e correspondência de regras"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrada e correspondência de regras"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gelen ve kural eşleştirme"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "傳入與規則比對"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "入站與規則匹配"
-          }
-        }
-      }
-    },
-    "不规范化" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بدون تسوية"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Normalisierung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No normalization"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin normalización"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune normalisation"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正規化しない"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정규화 안 함"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem normalização"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem normalização"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normalleştirme yok"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不正規化"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不規範化"
-          }
-        }
-      }
-    },
-    "URL 规范化影响所有规则的表达式匹配方式，修改立即生效。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تؤثر تسوية عناوين URL في طريقة مطابقة تعبيرات جميع القواعد، وتسري التغييرات فورًا."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die URL-Normalisierung beeinflusst, wie Ausdrücke aller Regeln abgeglichen werden; Änderungen gelten sofort."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL normalization affects how expressions match across all rules; changes take effect immediately."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La normalización de URL afecta cómo coinciden las expresiones de todas las reglas; los cambios surten efecto de inmediato."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La normalisation des URL influe sur la correspondance des expressions de toutes les règles ; les modifications prennent effet immédiatement."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 正規化はすべてのルールの式マッチングに影響します。変更は直ちに有効になります。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 정규화는 모든 규칙의 표현식 일치 방식에 영향을 줍니다. 변경 사항은 즉시 적용됩니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A normalização de URL afeta como as expressões de todas as regras são correspondidas; as alterações entram em vigor imediatamente."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A normalização de URL afeta a correspondência das expressões de todas as regras; as alterações entram em vigor imediatamente."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL normalleştirme, tüm kuralların ifade eşleştirmesini etkiler; değişiklikler hemen geçerli olur."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 正規化影響所有規則的運算式比對方式，修改立即生效。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL 規範化影響所有規則嘅表達式匹配方式，修改即時生效。"
-          }
-        }
-      }
-    },
-    "规则管理需要 Pro" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إدارة القواعد تتطلب Pro"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regelverwaltung erfordert Pro"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rules management requires Pro"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La gestión de reglas requiere Pro"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La gestion des règles nécessite Pro"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ルール管理には Pro が必要です"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "규칙 관리에는 Pro가 필요합니다"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O gerenciamento de regras requer o Pro"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A gestão de regras requer o Pro"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kural yönetimi Pro gerektirir"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規則管理需要 Pro"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規則管理需要 Pro"
-          }
-        }
-      }
-    },
-    "单条重定向、源站 / 配置 / 压缩规则、自定义错误与 Page Rules 的查看、启停与删除属于 Orange Cloud Pro。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عرض القواعد وتفعيلها/إيقافها وحذفها - عمليات إعادة التوجيه الفردية وقواعد المصدر/التكوين/الضغط والأخطاء المخصصة وPage Rules - من ميزات Orange Cloud Pro."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anzeigen, Umschalten und Löschen von Einzelweiterleitungen, Origin-/Konfigurations-/Komprimierungsregeln, benutzerdefinierten Fehlern und Page Rules gehören zu Orange Cloud Pro."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Viewing, toggling, and deleting Single Redirects, Origin/Configuration/Compression Rules, Custom Errors, and Page Rules is part of Orange Cloud Pro."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver, activar/desactivar y eliminar redirecciones individuales, reglas de origen/configuración/compresión, errores personalizados y Page Rules es parte de Orange Cloud Pro."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La consultation, l'activation/désactivation et la suppression des redirections unitaires, des règles d'origine/de configuration/de compression, des erreurs personnalisées et des Page Rules font partie d'Orange Cloud Pro."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シングルリダイレクト、オリジン／構成／圧縮ルール、カスタムエラー、Page Rules の表示・有効／無効・削除は Orange Cloud Pro の機能です。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "단일 리디렉션, 오리진/구성/압축 규칙, 사용자 지정 오류 및 Page Rules의 보기, 활성화/비활성화, 삭제는 Orange Cloud Pro에 포함됩니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver, ativar/desativar e excluir redirecionamentos individuais, regras de origem/configuração/compressão, erros personalizados e Page Rules faz parte do Orange Cloud Pro."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver, ativar/desativar e eliminar redirecionamentos individuais, regras de origem/configuração/compressão, erros personalizados e Page Rules faz parte do Orange Cloud Pro."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekil Yönlendirmeleri, Kaynak/Yapılandırma/Sıkıştırma Kurallarını, Özel Hataları ve Page Rules'u görüntüleme, açma/kapatma ve silme Orange Cloud Pro kapsamındadır."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "單條重新導向、來源／設定／壓縮規則、自訂錯誤與 Page Rules 的查看、啟停與刪除屬於 Orange Cloud Pro。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "單條重定向、源站／配置／壓縮規則、自訂錯誤同 Page Rules 嘅查看、啟停同刪除屬於 Orange Cloud Pro。"
-          }
-        }
-      }
-    },
-    "该规则基于批量列表（from_list），请在 Cloudflare Dashboard 编辑。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تستند هذه القاعدة إلى قائمة مجمّعة (from_list)؛ يُرجى تحريرها في لوحة تحكم Cloudflare."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Regel basiert auf einer Massenliste (from_list); bitte im Cloudflare Dashboard bearbeiten."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This rule is based on a bulk list (from_list); edit it in the Cloudflare Dashboard."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta regla se basa en una lista masiva (from_list); edítala en el panel de Cloudflare."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cette règle repose sur une liste en masse (from_list) ; modifiez-la dans le tableau de bord Cloudflare."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このルールは一括リスト（from_list）に基づいています。Cloudflare ダッシュボードで編集してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 규칙은 대량 목록(from_list)을 기반으로 합니다. Cloudflare 대시보드에서 편집하세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta regra é baseada em uma lista em massa (from_list); edite-a no painel da Cloudflare."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta regra baseia-se numa lista em massa (from_list); edite-a no painel da Cloudflare."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu kural bir toplu listeye (from_list) dayanır; Cloudflare panosunda düzenleyin."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此規則基於批次清單（from_list），請在 Cloudflare 儀表板編輯。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此規則基於批量列表（from_list），請喺 Cloudflare 儀表板編輯。"
-          }
-        }
-      }
-    },
-    "目标类型" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نوع الهدف"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zieltyp"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Target type"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de destino"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type de cible"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ターゲットタイプ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "대상 유형"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de destino"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de destino"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hedef türü"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目標類型"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目標類型"
-          }
-        }
-      }
-    },
-    "静态 URL" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عنوان URL ثابت"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statische URL"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Static URL"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL estática"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL statique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "静的 URL"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정적 URL"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL estática"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL estática"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statik URL"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "靜態 URL"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "靜態 URL"
-          }
-        }
-      }
-    },
-    "动态表达式" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعبير ديناميكي"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dynamischer Ausdruck"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dynamic expression"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expresión dinámica"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expression dynamique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動的な式"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "동적 표현식"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expressão dinâmica"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expressão dinâmica"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinamik ifade"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動態運算式"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動態表達式"
-          }
-        }
-      }
-    },
-    "目标为 Rules 表达式，求值结果作为跳转地址。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الهدف هو تعبير بلغة Rules، وتُستخدم نتيجة تقييمه كعنوان لإعادة التوجيه."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Ziel ist ein Rules-Ausdruck; das Auswertungsergebnis wird als Weiterleitungsadresse verwendet."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The target is a Rules expression; its evaluated result is used as the redirect URL."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El destino es una expresión del lenguaje Rules; el resultado evaluado se usa como URL de redirección."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La cible est une expression Rules ; le résultat de son évaluation sert d'URL de redirection."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ターゲットは Rules 式で、評価結果がリダイレクト先 URL になります。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "대상은 Rules 표현식이며, 평가 결과가 리디렉션 URL로 사용됩니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O destino é uma expressão Rules; o resultado avaliado é usado como URL de redirecionamento."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O destino é uma expressão Rules; o resultado avaliado é usado como URL de redirecionamento."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hedef bir Rules ifadesidir; değerlendirme sonucu yönlendirme URL'si olarak kullanılır."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目標為 Rules 運算式，求值結果作為跳轉位址。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目標為 Rules 表達式，求值結果作為跳轉地址。"
-          }
-        }
-      }
-    },
-    "301/308 为永久跳转，302/303/307 为临时跳转；307/308 保留原 HTTP 方法。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 لإعادة توجيه دائمة، و302/303/307 لإعادة توجيه مؤقتة؛ يحافظ 307/308 على طريقة HTTP الأصلية."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 sind permanente, 302/303/307 temporäre Weiterleitungen; 307/308 behalten die ursprüngliche HTTP-Methode bei."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 are permanent redirects, 302/303/307 are temporary; 307/308 preserve the original HTTP method."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 son redirecciones permanentes, 302/303/307 son temporales; 307/308 conservan el método HTTP original."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 sont des redirections permanentes, 302/303/307 des temporaires ; 307/308 conservent la méthode HTTP d'origine."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 は恒久的、302/303/307 は一時的なリダイレクトです。307/308 は元の HTTP メソッドを保持します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308은 영구 리디렉션, 302/303/307은 임시 리디렉션입니다. 307/308은 원래 HTTP 메서드를 유지합니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 são redirecionamentos permanentes, 302/303/307 são temporários; 307/308 preservam o método HTTP original."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 são redirecionamentos permanentes, 302/303/307 são temporários; 307/308 preservam o método HTTP original."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 kalıcı, 302/303/307 geçici yönlendirmelerdir; 307/308 özgün HTTP yöntemini korur."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 為永久跳轉，302/303/307 為暫時跳轉；307/308 保留原 HTTP 方法。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "301/308 為永久跳轉，302/303/307 為臨時跳轉；307/308 保留原 HTTP 方法。"
-          }
-        }
-      }
-    },
-    "Host 标头覆盖（可选）" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تجاوز ترويسة Host (اختياري)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host-Header-Override (optional)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host header override (optional)"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anulación del encabezado Host (opcional)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remplacement de l'en-tête Host (facultatif)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host ヘッダーの上書き（任意）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host 헤더 재정의(선택 사항)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Substituição do cabeçalho Host (opcional)"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Substituição do cabeçalho Host (opcional)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host üstbilgisi geçersiz kılma (isteğe bağlı)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host 標頭覆寫（選填）"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host 標頭覆蓋（可選）"
-          }
-        }
-      }
-    },
-    "源站主机（可选）" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مضيف المصدر (اختياري)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin-Host (optional)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin host (optional)"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host de origen (opcional)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hôte d'origine (facultatif)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オリジンホスト（任意）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오리진 호스트(선택 사항)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host de origem (opcional)"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host de origem (opcional)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaynak ana bilgisayarı (isteğe bağlı)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源主機（選填）"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源站主機（可選）"
-          }
-        }
-      }
-    },
-    "源站端口（可选）" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منفذ المصدر (اختياري)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin-Port (optional)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin port (optional)"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puerto de origen (opcional)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Port d'origine (facultatif)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オリジンポート（任意）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오리진 포트(선택 사항)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Porta de origem (opcional)"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Porta de origem (opcional)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaynak bağlantı noktası (isteğe bağlı)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源連接埠（選填）"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源站連接埠（可選）"
-          }
-        }
-      }
-    },
-    "SNI 覆盖（可选，仅企业版）" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تجاوز SNI (اختياري، خطة Enterprise فقط)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI-Override (optional, nur Enterprise)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI override (optional, Enterprise only)"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anulación de SNI (opcional, solo Enterprise)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remplacement SNI (facultatif, Enterprise uniquement)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI の上書き（任意、Enterprise のみ）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI 재정의(선택 사항, Enterprise 전용)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Substituição de SNI (opcional, somente Enterprise)"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Substituição de SNI (opcional, apenas Enterprise)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI geçersiz kılma (isteğe bağlı, yalnızca Enterprise)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI 覆寫（選填，僅 Enterprise）"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SNI 覆蓋（可選，僅 Enterprise）"
-          }
-        }
-      }
-    },
-    "源站覆盖" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تجاوزات المصدر"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin-Overrides"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origin overrides"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anulaciones de origen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remplacements d'origine"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オリジンの上書き"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오리진 재정의"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Substituições de origem"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Substituições de origem"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaynak geçersiz kılmaları"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源覆寫"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源站覆蓋"
-          }
-        }
-      }
-    },
-    "至少设置一项。匹配的请求将按此覆盖回源目标。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عيّن عنصرًا واحدًا على الأقل. ستُوجَّه الطلبات المطابقة إلى المصدر وفق هذه التجاوزات."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mindestens ein Feld setzen. Passende Anfragen gehen mit diesen Overrides zum Origin."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set at least one field. Matching requests go to the origin with these overrides."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configura al menos un campo. Las solicitudes coincidentes irán al origen con estas anulaciones."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définissez au moins un champ. Les requêtes correspondantes iront à l'origine avec ces remplacements."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "少なくとも 1 項目を設定してください。一致したリクエストはこの上書きでオリジンへ送られます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "하나 이상 설정하세요. 일치하는 요청은 이 재정의에 따라 오리진으로 전달됩니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Defina pelo menos um campo. As solicitações correspondentes irão à origem com essas substituições."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Defina pelo menos um campo. Os pedidos correspondentes irão à origem com estas substituições."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En az bir alan ayarlayın. Eşleşen istekler bu geçersiz kılmalarla kaynağa gider."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "至少設定一項。相符的請求將按此覆寫回源目標。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "至少設置一項。匹配嘅請求將按此覆蓋回源目標。"
-          }
-        }
-      }
-    },
-    "浏览器完整性检查" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فحص سلامة المتصفح"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browser Integrity Check"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browser Integrity Check"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobación de integridad del navegador"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contrôle d'intégrité du navigateur"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブラウザ整合性チェック"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "브라우저 무결성 검사"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificação de integridade do navegador"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificação de integridade do navegador"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarayıcı Bütünlük Denetimi"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "瀏覽器完整性檢查"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "瀏覽器完整性檢查"
-          }
-        }
-      }
-    },
-    "Email 混淆" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إخفاء عناوين البريد الإلكتروني"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-Mail-Verschleierung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Email Obfuscation"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ofuscación de correo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obfuscation des e-mails"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メール難読化"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이메일 난독화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ofuscação de e-mail"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ofuscação de e-mail"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-posta Gizleme"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Email 混淆"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Email 混淆"
-          }
-        }
-      }
-    },
-    "热链保护" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حماية الروابط الساخنة"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hotlink-Schutz"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hotlink Protection"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protección contra hotlinks"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protection contre le hotlinking"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ホットリンク保護"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "핫링크 보호"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proteção contra hotlink"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proteção contra hotlink"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hotlink Koruması"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "熱連結保護"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "熱鏈保護"
-          }
-        }
-      }
-    },
-    "机会性加密" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التشفير الانتهازي"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opportunistische Verschlüsselung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opportunistic Encryption"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cifrado oportunista"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiffrement opportuniste"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日和見暗号化"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기회적 암호화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criptografia oportunista"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encriptação oportunista"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fırsatçı Şifreleme"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "機會性加密"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "機會性加密"
-          }
-        }
-      }
-    },
-    "安全级别" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مستوى الأمان"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sicherheitsstufe"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Security Level"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nivel de seguridad"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niveau de sécurité"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セキュリティレベル"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "보안 수준"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nível de segurança"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nível de segurança"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güvenlik Düzeyi"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安全性層級"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安全級別"
-          }
-        }
-      }
-    },
-    "请求体缓冲" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تخزين نص الطلب مؤقتًا"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request-Body-Pufferung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request body buffering"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almacenamiento en búfer del cuerpo de la solicitud"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise en tampon du corps de requête"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リクエストボディのバッファリング"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "요청 본문 버퍼링"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buffer do corpo da solicitação"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buffer do corpo do pedido"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İstek gövdesi arabelleğe alma"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要求本文緩衝"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請求體緩衝"
-          }
-        }
-      }
-    },
-    "响应体缓冲" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تخزين نص الاستجابة مؤقتًا"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Response-Body-Pufferung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Response body buffering"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almacenamiento en búfer del cuerpo de la respuesta"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise en tampon du corps de réponse"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レスポンスボディのバッファリング"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "응답 본문 버퍼링"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buffer do corpo da resposta"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buffer do corpo da resposta"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yanıt gövdesi arabelleğe alma"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回應本文緩衝"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "響應體緩衝"
-          }
-        }
-      }
-    },
-    "自动压缩源码" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التصغير التلقائي"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Minify"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Minify"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minificación automática"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minification automatique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動ミニファイ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동 최소화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minificação automática"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minificação automática"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otomatik Küçültme"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動壓縮原始碼"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動壓縮源碼"
-          }
-        }
-      }
-    },
-    "停用 Zaraz" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعطيل Zaraz"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaraz deaktivieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Zaraz"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar Zaraz"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactiver Zaraz"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaraz を無効化"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaraz 비활성화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar Zaraz"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar Zaraz"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaraz'ı devre dışı bırak"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停用 Zaraz"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停用 Zaraz"
-          }
-        }
-      }
-    },
-    "停用 RUM" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعطيل RUM"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RUM deaktivieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable RUM"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar RUM"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactiver RUM"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RUM を無効化"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RUM 비활성화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar RUM"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar RUM"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RUM'u devre dışı bırak"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停用 RUM"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停用 RUM"
-          }
-        }
-      }
-    },
-    "停用 Pay Per Crawl" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعطيل Pay Per Crawl"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay Per Crawl deaktivieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Pay Per Crawl"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar Pay Per Crawl"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactiver Pay Per Crawl"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay Per Crawl を無効化"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay Per Crawl 비활성화"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar Pay Per Crawl"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar Pay Per Crawl"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay Per Crawl'ı devre dışı bırak"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停用 Pay Per Crawl"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停用 Pay Per Crawl"
-          }
-        }
-      }
-    },
-    "添加设置" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة إعداد"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellung hinzufügen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add setting"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar ajuste"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter un réglage"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定を追加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 추가"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar configuração"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar definição"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayar ekle"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入設定"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新增設定"
-          }
-        }
-      }
-    },
-    "要覆盖的设置" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإعدادات المراد تجاوزها"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zu überschreibende Einstellungen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings to override"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes a anular"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réglages à remplacer"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上書きする設定"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "재정의할 설정"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurações a substituir"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definições a substituir"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geçersiz kılınacak ayarlar"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要覆寫的設定"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要覆蓋嘅設定"
-          }
-        }
-      }
-    },
-    "至少一项。仅列出的设置会被此规则覆盖；左滑移除。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عنصر واحد على الأقل. القاعدة تتجاوز الإعدادات المدرجة فقط؛ اسحب لليسار للإزالة."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mindestens eine Einstellung. Nur gelistete Einstellungen werden überschrieben; zum Entfernen nach links wischen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "At least one setting. Only listed settings are overridden by this rule; swipe left to remove."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al menos un ajuste. Solo los ajustes listados serán anulados por esta regla; desliza a la izquierda para quitar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Au moins un réglage. Seuls les réglages listés sont remplacés par cette règle ; balayez vers la gauche pour retirer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "少なくとも 1 件。このルールで上書きされるのはリストの設定のみです。左スワイプで削除。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "최소 1개. 나열된 설정만 이 규칙으로 재정의됩니다. 왼쪽으로 스와이프하여 제거하세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pelo menos uma configuração. Apenas as configurações listadas são substituídas por esta regra; deslize para a esquerda para remover."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pelo menos uma definição. Apenas as definições listadas são substituídas por esta regra; deslize para a esquerda para remover."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En az bir ayar. Bu kural yalnızca listelenen ayarları geçersiz kılar; kaldırmak için sola kaydırın."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "至少一項。僅列出的設定會被此規則覆寫；左滑移除。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "至少一項。僅列出嘅設定會被此規則覆蓋；左滑移除。"
-          }
-        }
-      }
-    },
-    "添加算法" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة خوارزمية"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algorithmus hinzufügen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add algorithm"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar algoritmo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter un algorithme"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アルゴリズムを追加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "알고리즘 추가"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar algoritmo"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar algoritmo"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algoritma ekle"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入演算法"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新增算法"
-          }
-        }
-      }
-    },
-    "压缩算法（按偏好排序）" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خوارزميات الضغط (حسب الأفضلية)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komprimierungsalgorithmen (nach Präferenz)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compression algorithms (in order of preference)"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algoritmos de compresión (por preferencia)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algorithmes de compression (par ordre de préférence)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圧縮アルゴリズム（優先順）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "압축 알고리즘(선호 순서)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algoritmos de compressão (por preferência)"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algoritmos de compressão (por preferência)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sıkıştırma algoritmaları (tercih sırasına göre)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "壓縮演算法（依偏好排序）"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "壓縮算法（按偏好排序）"
-          }
-        }
-      }
-    },
-    "Cloudflare 使用列表中访客浏览器支持的第一个算法；none 表示不压缩，auto/default 交给 Cloudflare 决定。长按拖动排序。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تستخدم Cloudflare أول خوارزمية في القائمة يدعمها متصفح الزائر؛ تعني none عدم الضغط، بينما تترك auto/default القرار لـ Cloudflare. اضغط مطولًا واسحب لإعادة الترتيب."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare verwendet den ersten Algorithmus der Liste, den der Browser des Besuchers unterstützt; none = keine Komprimierung, auto/default überlässt die Wahl Cloudflare. Zum Sortieren gedrückt halten und ziehen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare uses the first algorithm in the list that the visitor's browser supports; none means no compression, auto/default lets Cloudflare decide. Long-press and drag to reorder."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare usa el primer algoritmo de la lista que admita el navegador del visitante; none significa sin compresión y auto/default deja la decisión a Cloudflare. Mantén presionado y arrastra para reordenar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare utilise le premier algorithme de la liste pris en charge par le navigateur du visiteur ; none signifie aucune compression, auto/default laisse Cloudflare décider. Maintenez et faites glisser pour réordonner."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare は、訪問者のブラウザが対応するリスト内の最初のアルゴリズムを使用します。none は非圧縮、auto/default は Cloudflare に任せます。長押しでドラッグして並べ替え。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare는 방문자의 브라우저가 지원하는 목록의 첫 번째 알고리즘을 사용합니다. none은 압축 안 함, auto/default는 Cloudflare에 맡깁니다. 길게 눌러 드래그하여 순서를 바꾸세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A Cloudflare usa o primeiro algoritmo da lista compatível com o navegador do visitante; none significa sem compressão, auto/default deixa a decisão para a Cloudflare. Toque e segure para reordenar."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A Cloudflare usa o primeiro algoritmo da lista suportado pelo navegador do visitante; none significa sem compressão, auto/default deixa a decisão à Cloudflare. Toque sem soltar e arraste para reordenar."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare, listede ziyaretçinin tarayıcısının desteklediği ilk algoritmayı kullanır; none sıkıştırma yok demektir, auto/default kararı Cloudflare'e bırakır. Yeniden sıralamak için basılı tutup sürükleyin."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare 使用清單中訪客瀏覽器支援的第一個演算法；none 表示不壓縮，auto/default 交給 Cloudflare 決定。長按拖曳排序。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloudflare 使用列表入面訪客瀏覽器支援嘅第一個算法；none 表示唔壓縮，auto/default 交畀 Cloudflare 決定。長按拖動排序。"
-          }
-        }
-      }
-    },
-    "内容类型" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نوع المحتوى"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inhaltstyp"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Content type"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de contenido"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type de contenu"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コンテンツタイプ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "콘텐츠 유형"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de conteúdo"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de conteúdo"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İçerik türü"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "內容類型"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "內容類型"
-          }
-        }
-      }
-    },
-    "状态码（可选，400–999）" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رمز الحالة (اختياري، 400–999)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statuscode (optional, 400–999)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status code (optional, 400–999)"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código de estado (opcional, 400–999)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Code d'état (facultatif, 400–999)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ステータスコード（任意、400–999）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "상태 코드(선택 사항, 400–999)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código de status (opcional, 400–999)"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código de estado (opcional, 400–999)"
-          }
-        },
-        "tr" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durum kodu (isteğe bağlı, 400–999)"
+            "value" : "Permanently Delete Worker"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "狀態碼（選填，400–999）"
+            "value" : "永久刪除 Worker"
           }
         },
         "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "狀態碼（可選，400–999）"
-          }
-        }
-      }
-    },
-    "错误响应" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استجابة الخطأ"
-          }
-        },
-        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fehlerantwort"
+            "value" : "永久刪除 Worker"
           }
         },
-        "en" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Error response"
+            "value" : "Worker を完全に削除"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respuesta de error"
+            "value" : "Eliminar Worker permanentemente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réponse d'erreur"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エラー応答"
-          }
-        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "오류 응답"
+            "value" : "Worker 영구 삭제"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resposta de erro"
+            "value" : "Excluir Worker permanentemente"
           }
         },
         "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resposta de erro"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hata yanıtı"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "錯誤回應"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "錯誤響應"
-          }
-        }
-      }
-    },
-    "不填状态码则沿用原响应状态。" : {
-      "localizations" : {
-        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "إذا تركت رمز الحالة فارغًا فسيُستخدم رمز الاستجابة الأصلي."
+            "value" : "Eliminar Worker permanentemente"
           }
         },
         "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohne Statuscode wird der ursprüngliche Antwortstatus beibehalten."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leave the status code empty to keep the original response status."
-          }
-        },
-        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si no indicas un código de estado, se mantiene el de la respuesta original."
+            "value" : "Worker dauerhaft löschen"
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sans code d'état, le statut de la réponse d'origine est conservé."
-          }
-        },
-        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ステータスコードを空にすると元のレスポンスのステータスを維持します。"
+            "value" : "Supprimer définitivement le Worker"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "상태 코드를 비워 두면 원래 응답 상태가 유지됩니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deixe o código de status vazio para manter o status da resposta original."
-          }
-        },
-        "pt-PT" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deixe o código de estado vazio para manter o estado da resposta original."
+            "value" : "حذف Worker نهائيًا"
           }
         },
         "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durum kodunu boş bırakırsanız özgün yanıt durumu korunur."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不填狀態碼則沿用原回應狀態。"
-          }
-        },
-        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "唔填狀態碼就沿用原響應狀態。"
+            "value" : "Worker'ı kalıcı olarak sil"
           }
         }
       }
     },
-    "自定义资产" : {
+    "此操作将永久删除 Worker %@ 及其部署与路由绑定，无法撤销，也无法恢复。" : {
       "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أصل مخصص"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Asset"
-          }
-        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Custom asset"
+            "value" : "This will permanently delete the Worker %@ along with its deployments and route bindings. This cannot be undone or recovered."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recurso personalizado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ressource personnalisée"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カスタムアセット"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용자 지정 자산"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ativo personalizado"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recurso personalizado"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Özel varlık"
-          }
-        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自訂資產"
+            "value" : "此操作將永久刪除 Worker %@ 及其部署與路由綁定，無法復原，也無法還原。"
           }
         },
         "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自訂資產"
-          }
-        }
-      }
-    },
-    "该规则的内容由自定义资产提供，App 内不改动资产本身。" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يوفَّر محتوى هذه القاعدة من أصل مخصص؛ لا يعدّل التطبيق الأصل نفسه."
-          }
-        },
-        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der Inhalt dieser Regel stammt aus einem benutzerdefinierten Asset; das Asset selbst wird in der App nicht geändert."
+            "value" : "此操作將永久刪除 Worker %@ 及其部署與路由綁定，無法復原，也無法還原。"
           }
         },
-        "en" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This rule's content comes from a custom asset; the asset itself isn't modified in the app."
+            "value" : "この操作は Worker %@ とそのデプロイおよびルートバインディングを完全に削除します。取り消しも復元もできません。"
           }
         },
         "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El contenido de esta regla proviene de un recurso personalizado; la app no modifica el recurso en sí."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le contenu de cette règle provient d'une ressource personnalisée ; l'app ne modifie pas la ressource elle-même."
-          }
-        },
-        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このルールの内容はカスタムアセットから提供されます。アセット自体はアプリ内で変更されません。"
+            "value" : "Esto eliminará permanentemente el Worker %@ junto con sus implementaciones y enlaces de ruta. No se puede deshacer ni recuperar."
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이 규칙의 콘텐츠는 사용자 지정 자산에서 제공됩니다. 자산 자체는 앱에서 수정되지 않습니다."
+            "value" : "이 작업은 Worker %@ 및 배포와 라우트 바인딩을 영구적으로 삭제합니다. 되돌리거나 복구할 수 없습니다."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "O conteúdo desta regra vem de um ativo personalizado; o ativo em si não é modificado no app."
+            "value" : "Isso excluirá permanentemente o Worker %@ e suas implantações e vinculações de rota. Não é possível desfazer nem recuperar."
           }
         },
         "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O conteúdo desta regra provém de um recurso personalizado; o recurso em si não é modificado na app."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu kuralın içeriği özel bir varlıktan gelir; varlığın kendisi uygulamada değiştirilmez."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此規則的內容由自訂資產提供，App 內不變更資產本身。"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此規則嘅內容由自訂資產提供，App 內唔會改動資產本身。"
-          }
-        }
-      }
-    },
-    "响应内容" : {
-      "localizations" : {
-        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "محتوى الاستجابة"
+            "value" : "Isto eliminará permanentemente o Worker %@ e as respetivas implementações e ligações de rota. Não é possível anular nem recuperar."
           }
         },
         "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Antwortinhalt"
-          }
-        },
-        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Response content"
+            "value" : "Dadurch werden der Worker %@ sowie seine Bereitstellungen und Routen-Bindings dauerhaft gelöscht. Das kann nicht rückgängig gemacht oder wiederhergestellt werden."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contenido de la respuesta"
-          }
-        },
         "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contenu de la réponse"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "応答コンテンツ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "응답 콘텐츠"
-          }
-        },
-        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conteúdo da resposta"
+            "value" : "Cette action supprimera définitivement le Worker %@ ainsi que ses déploiements et liaisons de route. Elle est irréversible et irrécupérable."
           }
         },
-        "pt-PT" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conteúdo da resposta"
+            "value" : "‏سيؤدي هذا إلى حذف Worker %@ نهائيًا مع عمليات النشر وارتباطات المسار الخاصة به. لا يمكن التراجع عن ذلك أو استعادته."
           }
         },
         "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yanıt içeriği"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回應內容"
-          }
-        },
-        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "響應內容"
+            "value" : "Bu işlem, %@ adlı Worker'ı, dağıtımlarını ve rota bağlamalarını kalıcı olarak siler. Geri alınamaz ve kurtarılamaz."
           }
         }
       }
     },
-    "最大 10 KB。将按上方内容类型原样返回给访客。" : {
+    "输入 Worker 名称以确认" : {
       "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بحد أقصى 10 كيلوبايت. سيُعاد للزائر كما هو وفق نوع المحتوى أعلاه."
-          }
-        },
-        "de" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Maximal 10 KB. Wird dem Besucher unverändert mit dem obigen Inhaltstyp zurückgegeben."
+            "value" : "Enter the Worker name to confirm"
           }
         },
-        "en" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Up to 10 KB. Returned to visitors as-is with the content type above."
+            "value" : "輸入 Worker 名稱以確認"
           }
         },
-        "es-MX" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Máximo 10 KB. Se devuelve al visitante tal cual con el tipo de contenido anterior."
+            "value" : "輸入 Worker 名稱以確認"
           }
         },
-        "fr" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "10 Ko maximum. Renvoyé tel quel au visiteur avec le type de contenu ci-dessus."
+            "value" : "確認のため Worker 名を入力"
           }
         },
-        "ja" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大 10 KB。上記のコンテンツタイプでそのまま訪問者に返されます。"
+            "value" : "Escribe el nombre del Worker para confirmar"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "최대 10 KB. 위의 콘텐츠 유형으로 방문자에게 그대로 반환됩니다."
+            "value" : "확인하려면 Worker 이름을 입력하세요"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Máximo de 10 KB. Retornado ao visitante como está, com o tipo de conteúdo acima."
+            "value" : "Digite o nome do Worker para confirmar"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Máximo de 10 KB. Devolvido ao visitante tal como está, com o tipo de conteúdo acima."
+            "value" : "Introduza o nome do Worker para confirmar"
           }
         },
-        "tr" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En fazla 10 KB. Yukarıdaki içerik türüyle ziyaretçiye olduğu gibi döndürülür."
+            "value" : "Zur Bestätigung den Worker-Namen eingeben"
           }
         },
-        "zh-Hant" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大 10 KB。將按上方內容類型原樣回傳給訪客。"
+            "value" : "Saisissez le nom du Worker pour confirmer"
           }
         },
-        "zh-HK" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل اسم Worker للتأكيد"
+          }
+        },
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大 10 KB。將按上方內容類型原樣返畀訪客。"
+            "value" : "Onaylamak için Worker adını girin"
           }
         }
       }
     },
-    "此域名还没有这类规则。点右上角 + 创建第一条。" : {
+    "删除 Worker" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا يحتوي هذا النطاق على قواعد من هذا النوع بعد. انقر على + في الأعلى لإنشاء أول قاعدة."
+            "value" : "Delete Worker"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Domain hat noch keine Regeln dieses Typs. Tippe oben rechts auf +, um die erste zu erstellen."
+            "value" : "刪除 Worker"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This domain doesn't have rules of this type yet. Tap + in the top corner to create the first one."
+            "value" : "刪除 Worker"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este dominio aún no tiene reglas de este tipo. Toca + arriba a la derecha para crear la primera."
+            "value" : "Worker を削除"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce domaine n'a pas encore de règles de ce type. Touchez + en haut à droite pour créer la première."
+            "value" : "Eliminar Worker"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このドメインにはまだこのタイプのルールがありません。右上の + から最初のルールを作成できます。"
+            "value" : "Worker 삭제"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이 도메인에는 아직 이 유형의 규칙이 없습니다. 오른쪽 위 +를 탭하여 첫 규칙을 만드세요."
+            "value" : "Excluir Worker"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este domínio ainda não tem regras deste tipo. Toque em + no canto superior para criar a primeira."
+            "value" : "Eliminar Worker"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este domínio ainda não tem regras deste tipo. Toque em + no canto superior para criar a primeira."
+            "value" : "Worker löschen"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu alan adında henüz bu türde kural yok. İlkini oluşturmak için sağ üstteki + simgesine dokunun."
+            "value" : "Supprimer le Worker"
           }
         },
-        "zh-Hant" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此網域還沒有這類規則。點右上角 + 建立第一條。"
+            "value" : "حذف Worker"
           }
         },
-        "zh-HK" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此域名仲未有呢類規則。點右上角 + 建立第一條。"
+            "value" : "Worker'ı sil"
           }
         }
       }
     },
-    "此域名还没有这类规则。当前授权仅限读取（%@），无法创建。" : {
+    "向左滑动查看实时日志或删除 · 点按查看详情" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا يحتوي هذا النطاق على قواعد من هذا النوع بعد. التفويض الحالي للقراءة فقط (%@) ولا يمكنه الإنشاء."
+            "value" : "Swipe left for live logs or delete · Tap for details"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Domain hat noch keine Regeln dieses Typs. Die aktuelle Autorisierung ist schreibgeschützt (%@); Erstellen nicht möglich."
+            "value" : "向左滑動查看即時記錄或刪除 · 點按查看詳情"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This domain doesn't have rules of this type yet. The current authorization is read-only (%@) and can't create rules."
+            "value" : "向左滑動查看即時記錄或刪除 · 點按查看詳情"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este dominio aún no tiene reglas de este tipo. La autorización actual es de solo lectura (%@) y no permite crearlas."
+            "value" : "左スワイプでライブログまたは削除・タップで詳細"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce domaine n'a pas encore de règles de ce type. L'autorisation actuelle est en lecture seule (%@) et ne permet pas d'en créer."
+            "value" : "Desliza a la izquierda para registros en vivo o eliminar · Toca para ver detalles"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このドメインにはまだこのタイプのルールがありません。現在の認可は読み取り専用（%@）のため作成できません。"
+            "value" : "왼쪽으로 스와이프하여 실시간 로그 또는 삭제 · 탭하여 세부 정보"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이 도메인에는 아직 이 유형의 규칙이 없습니다. 현재 승인은 읽기 전용(%@)이라 만들 수 없습니다."
+            "value" : "Deslize para a esquerda para logs ao vivo ou excluir · Toque para detalhes"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este domínio ainda não tem regras deste tipo. A autorização atual é somente leitura (%@) e não permite criá-las."
+            "value" : "Deslize para a esquerda para registos em direto ou eliminar · Toque para ver detalhes"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este domínio ainda não tem regras deste tipo. A autorização atual é apenas de leitura (%@) e não permite criá-las."
+            "value" : "Nach links wischen für Live-Logs oder Löschen · Tippen für Details"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu alan adında henüz bu türde kural yok. Mevcut yetkilendirme salt okunur (%@) olduğundan oluşturamaz."
+            "value" : "Balayez vers la gauche pour les journaux en direct ou supprimer · Touchez pour les détails"
           }
         },
-        "zh-Hant" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此網域還沒有這類規則。目前授權僅限讀取（%@），無法建立。"
+            "value" : "اسحب لليسار لعرض السجلات المباشرة أو الحذف · انقر لعرض التفاصيل"
           }
         },
-        "zh-HK" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此域名仲未有呢類規則。目前授權僅限讀取（%@），無法建立。"
+            "value" : "Canlı günlükler veya silme için sola kaydırın · Ayrıntılar için dokunun"
           }
         }
       }
     },
-    "Page Rules 为传统功能，仅支持查看、启停与删除；其余规则类型支持在 App 内创建与编辑。" : {
+    "部署历史" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تُعد Page Rules ميزة قديمة وتدعم العرض والتفعيل/الإيقاف والحذف فقط؛ أما بقية أنواع القواعد فيمكن إنشاؤها وتحريرها داخل التطبيق."
+            "value" : "Deployment History"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules sind eine Legacy-Funktion und unterstützen nur Anzeigen, Umschalten und Löschen; alle anderen Regeltypen lassen sich in der App erstellen und bearbeiten."
+            "value" : "部署歷史"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules are a legacy feature and only support viewing, toggling, and deleting; all other rule types can be created and edited in the app."
+            "value" : "部署歷史"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Las Page Rules son una función heredada y solo permiten ver, activar/desactivar y eliminar; los demás tipos de reglas se pueden crear y editar en la app."
+            "value" : "デプロイ履歴"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les Page Rules sont une fonctionnalité héritée et ne permettent que consulter, activer/désactiver et supprimer ; les autres types de règles peuvent être créés et modifiés dans l'app."
+            "value" : "Historial de despliegues"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules はレガシー機能のため表示・有効／無効・削除のみ対応です。その他のルールタイプはアプリ内で作成・編集できます。"
+            "value" : "배포 기록"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules는 레거시 기능으로 보기, 활성화/비활성화, 삭제만 지원합니다. 다른 규칙 유형은 앱에서 만들고 편집할 수 있습니다."
+            "value" : "Histórico de implantações"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "As Page Rules são um recurso legado e permitem apenas ver, ativar/desativar e excluir; os demais tipos de regras podem ser criados e editados no app."
+            "value" : "Histórico de implementações"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "As Page Rules são uma funcionalidade legada e permitem apenas ver, ativar/desativar e eliminar; os restantes tipos de regras podem ser criados e editados na app."
+            "value" : "Bereitstellungsverlauf"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules eski bir özelliktir ve yalnızca görüntüleme, açma/kapatma ve silmeyi destekler; diğer tüm kural türleri uygulamada oluşturulup düzenlenebilir."
+            "value" : "Historique des déploiements"
           }
         },
-        "zh-Hant" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules 為傳統功能，僅支援查看、啟停與刪除；其餘規則類型支援在 App 內建立與編輯。"
+            "value" : "سجل عمليات النشر"
           }
         },
-        "zh-HK" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Page Rules 係傳統功能，僅支援查看、啟停同刪除；其餘規則類型支援喺 App 內建立同編輯。"
+            "value" : "Dağıtım geçmişi"
           }
         }
       }
     },
-    "规则中心" : {
+    "活跃" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مركز القواعد"
+            "value" : "Active"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regelzentrum"
+            "value" : "使用中"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rules Hub"
+            "value" : "使用中"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Centro de reglas"
+            "value" : "稼働中"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Centre de règles"
+            "value" : "Activo"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ルールセンター"
+            "value" : "활성"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "규칙 센터"
+            "value" : "Ativo"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Central de regras"
+            "value" : "Ativo"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Centro de regras"
+            "value" : "Aktiv"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kural Merkezi"
+            "value" : "Actif"
           }
         },
-        "zh-Hant" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "規則中心"
+            "value" : "نشط"
           }
         },
-        "zh-HK" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "規則中心"
+            "value" : "Etkin"
           }
         }
       }
     },
-    "单条重定向、源站、配置、压缩、自定义错误与 Page Rules" : {
+    "首项为当前活跃部署，不可删除。向左滑动删除历史部署。" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "إعادة التوجيه الفردية والمصدر والتكوين والضغط والأخطاء المخصصة وPage Rules"
+            "value" : "The first entry is the active deployment and can't be deleted. Swipe left to delete past deployments."
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Single Redirects, Origin-, Konfigurations-, Komprimierungs-, Custom-Error- und Page Rules"
+            "value" : "第一項為目前使用中的部署，無法刪除。向左滑動刪除歷史部署。"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Single Redirects, Origin, Configuration, Compression, Custom Error, and Page Rules"
+            "value" : "第一項為目前使用中的部署，無法刪除。向左滑動刪除歷史部署。"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Single Redirects, reglas de origen, configuración, compresión, errores personalizados y Page Rules"
+            "value" : "先頭は稼働中のデプロイで削除できません。左スワイプで過去のデプロイを削除します。"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Single Redirects, règles d'origine, de configuration, de compression, d'erreurs personnalisées et Page Rules"
+            "value" : "La primera entrada es el despliegue activo y no se puede eliminar. Desliza a la izquierda para eliminar despliegues anteriores."
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "単一リダイレクト、オリジン、構成、圧縮、カスタムエラー、Page Rules"
+            "value" : "첫 번째 항목은 활성 배포로 삭제할 수 없습니다. 왼쪽으로 스와이프하여 이전 배포를 삭제하세요."
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "단일 리디렉션, 오리진, 구성, 압축, 사용자 지정 오류 및 Page Rules"
+            "value" : "A primeira entrada é a implantação ativa e não pode ser excluída. Deslize para a esquerda para excluir implantações anteriores."
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Single Redirects, regras de origem, configuração, compressão, erros personalizados e Page Rules"
+            "value" : "A primeira entrada é a implementação ativa e não pode ser eliminada. Deslize para a esquerda para eliminar implementações anteriores."
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Single Redirects, regras de origem, configuração, compressão, erros personalizados e Page Rules"
+            "value" : "Der erste Eintrag ist die aktive Bereitstellung und kann nicht gelöscht werden. Nach links wischen, um frühere Bereitstellungen zu löschen."
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tekli Yönlendirmeler, Kaynak, Yapılandırma, Sıkıştırma, Özel Hata ve Page Rules"
+            "value" : "La première entrée est le déploiement actif et ne peut pas être supprimée. Balayez vers la gauche pour supprimer les déploiements précédents."
           }
         },
-        "zh-Hant" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "單條重新導向、來源、設定、壓縮、自訂錯誤與 Page Rules"
+            "value" : "العنصر الأول هو النشر النشط ولا يمكن حذفه. اسحب لليسار لحذف عمليات النشر السابقة."
           }
         },
-        "zh-HK" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "單條重新導向、源站、設定、壓縮、自訂錯誤同 Page Rules"
+            "value" : "İlk giriş etkin dağıtımdır ve silinemez. Önceki dağıtımları silmek için sola kaydırın."
           }
         }
       }
     },
-    "已加载 %lld 行，请在查询控制台用 WHERE 条件继续筛选" : {
+    "删除后不可恢复。" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تم تحميل %lld صفوف، يُرجى المتابعة بالتصفية بشرط WHERE في وحدة الاستعلام"
+            "value" : "This cannot be undone."
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld Zeilen geladen. In der Abfragekonsole mit einer WHERE-Bedingung weiter eingrenzen."
+            "value" : "刪除後無法復原。"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Loaded %lld rows. Use a WHERE clause in the query console to narrow down."
+            "value" : "刪除後無法復原。"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se cargaron %lld filas. Usa una condición WHERE en la consola de consultas para filtrar."
+            "value" : "削除すると元に戻せません。"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld lignes chargées. Affinez avec une condition WHERE dans la console de requête."
+            "value" : "No se puede deshacer."
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 行を読み込みました。クエリコンソールで WHERE 条件を使って絞り込んでください"
+            "value" : "삭제하면 되돌릴 수 없습니다."
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld개 행을 불러왔습니다. 쿼리 콘솔에서 WHERE 조건으로 계속 필터링하세요."
+            "value" : "Não é possível desfazer."
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld linhas carregadas. Use uma condição WHERE no console de consultas para filtrar."
+            "value" : "Não é possível anular."
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Foram carregadas %lld linhas. Use uma condição WHERE na consola de consultas para filtrar."
+            "value" : "Das kann nicht rückgängig gemacht werden."
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld satır yüklendi. Sorgu konsolunda WHERE koşuluyla daraltmaya devam edin."
+            "value" : "Cette action est irréversible."
           }
         },
-        "zh-HK" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已載入 %lld 行，請在查詢主控台用 WHERE 條件繼續篩選"
+            "value" : "لا يمكن التراجع عن ذلك."
           }
         },
-        "zh-Hant" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已載入 %lld 列，請在查詢主控台用 WHERE 條件繼續篩選"
+            "value" : "Bu işlem geri alınamaz."
           }
         }
       }
     },
-    "字段过大（%lld 字符），请在查询控制台修改" : {
+    "删除表" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الحقل كبير جدًا (%lld حرفًا)، يُرجى تعديله في وحدة الاستعلام"
+            "value" : "Delete Table"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Feld zu groß (%lld Zeichen). Bitte in der Abfragekonsole bearbeiten."
+            "value" : "刪除資料表"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Field too large (%lld characters). Edit it in the query console."
+            "value" : "刪除資料表"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El campo es demasiado grande (%lld caracteres). Edítalo en la consola de consultas."
+            "value" : "テーブルを削除"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Champ trop volumineux (%lld caractères). Modifiez-le dans la console de requête."
+            "value" : "Eliminar tabla"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "フィールドが大きすぎます（%lld 文字）。クエリコンソールで編集してください"
+            "value" : "테이블 삭제"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "필드가 너무 큽니다(%lld자). 쿼리 콘솔에서 수정하세요."
+            "value" : "Excluir tabela"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Campo muito grande (%lld caracteres). Edite no console de consultas."
+            "value" : "Eliminar tabela"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Campo demasiado grande (%lld caracteres). Edite na consola de consultas."
+            "value" : "Tabelle löschen"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alan çok büyük (%lld karakter). Sorgu konsolunda düzenleyin."
+            "value" : "Supprimer la table"
           }
         },
-        "zh-HK" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "欄位過大（%lld 字符），請在查詢主控台修改"
+            "value" : "حذف الجدول"
           }
         },
-        "zh-Hant" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "欄位過大（%lld 字元），請在查詢主控台修改"
+            "value" : "Tabloyu sil"
           }
         }
       }
     },
-    "查询未带 LIMIT" : {
+    "永久删除表" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الاستعلام بدون LIMIT"
+            "value" : "Permanently Delete Table"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abfrage ohne LIMIT"
+            "value" : "永久刪除資料表"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Query Has No LIMIT"
+            "value" : "永久刪除資料表"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La consulta no tiene LIMIT"
+            "value" : "テーブルを完全に削除"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Requête sans LIMIT"
+            "value" : "Eliminar tabla permanentemente"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LIMIT のないクエリ"
+            "value" : "테이블 영구 삭제"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LIMIT 없는 쿼리"
+            "value" : "Excluir tabela permanentemente"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A consulta não tem LIMIT"
+            "value" : "Eliminar tabela permanentemente"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A consulta não tem LIMIT"
+            "value" : "Tabelle dauerhaft löschen"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sorguda LIMIT yok"
+            "value" : "Supprimer définitivement la table"
           }
         },
-        "zh-HK" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查詢未帶 LIMIT"
+            "value" : "حذف الجدول نهائيًا"
           }
         },
-        "zh-Hant" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查詢未帶 LIMIT"
+            "value" : "Tabloyu kalıcı olarak sil"
           }
         }
       }
     },
-    "仍要执行" : {
+    "此操作将永久删除表 %@ 及其全部数据，无法撤销，也无法恢复。" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "التنفيذ على أي حال"
+            "value" : "This permanently deletes the table %@ and all its data. It can’t be undone or recovered."
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trotzdem ausführen"
+            "value" : "此操作將永久刪除資料表 %@ 及其全部資料，無法復原，也無法還原。"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Run Anyway"
+            "value" : "此操作將永久刪除資料表 %@ 及其全部資料，無法復原，也無法還原。"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ejecutar de todos modos"
+            "value" : "この操作はテーブル %@ とそのすべてのデータを完全に削除します。取り消すことも復元することもできません。"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Exécuter quand même"
+            "value" : "Esto elimina permanentemente la tabla %@ y todos sus datos. No se puede deshacer ni recuperar."
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "そのまま実行"
+            "value" : "이 작업은 테이블 %@ 및 모든 데이터를 영구적으로 삭제합니다. 취소하거나 복구할 수 없습니다."
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "그래도 실행"
+            "value" : "Isso exclui permanentemente a tabela %@ e todos os seus dados. Não é possível desfazer nem recuperar."
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Executar mesmo assim"
+            "value" : "Esta ação elimina permanentemente a tabela %@ e todos os seus dados. Não é possível anular nem recuperar."
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Executar mesmo assim"
+            "value" : "Dadurch werden die Tabelle %@ und alle ihre Daten dauerhaft gelöscht. Dies kann nicht rückgängig gemacht oder wiederhergestellt werden."
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yine de çalıştır"
+            "value" : "Cela supprime définitivement la table %@ ainsi que toutes ses données. C’est irréversible et irrécupérable."
           }
         },
-        "zh-HK" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仍要執行"
+            "value" : "سيؤدي هذا إلى حذف الجدول %@ وكل بياناته نهائيًا. لا يمكن التراجع عنه ولا استعادته."
           }
         },
-        "zh-Hant" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仍要執行"
+            "value" : "Bu, %@ tablosunu ve tüm verilerini kalıcı olarak siler. Geri alınamaz veya kurtarılamaz."
           }
         }
       }
     },
-    "大表可能返回大量行，造成等待和内存占用。建议加 LIMIT 后执行。" : {
+    "输入表名以确认" : {
       "localizations" : {
-        "ar" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "قد تُرجع الجداول الكبيرة عددًا كبيرًا من الصفوف، مما يسبب الانتظار واستهلاك الذاكرة. يُنصح بإضافة LIMIT قبل التنفيذ."
+            "value" : "Enter the table name to confirm"
           }
         },
-        "de" : {
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Große Tabellen können sehr viele Zeilen zurückgeben und so Wartezeiten und hohen Speicherverbrauch verursachen. Empfohlen: mit LIMIT ausführen."
+            "value" : "輸入資料表名稱以確認"
           }
         },
-        "en" : {
+        "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Large tables may return a huge number of rows, causing long waits and high memory use. Adding a LIMIT is recommended."
+            "value" : "輸入資料表名稱以確認"
           }
         },
-        "es-MX" : {
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Las tablas grandes pueden devolver muchas filas, lo que causa esperas y alto uso de memoria. Se recomienda agregar LIMIT antes de ejecutar."
+            "value" : "確認のためテーブル名を入力"
           }
         },
-        "fr" : {
+        "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les grandes tables peuvent renvoyer un très grand nombre de lignes, entraînant attente et forte consommation de mémoire. Il est conseillé d'ajouter LIMIT avant d'exécuter."
+            "value" : "Escribe el nombre de la tabla para confirmar"
           }
         },
-        "ja" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "大きなテーブルでは大量の行が返され、待ち時間やメモリ消費の原因になります。LIMIT を付けて実行することをおすすめします。"
+            "value" : "확인하려면 테이블 이름을 입력하세요"
           }
         },
-        "ko" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "큰 테이블은 많은 행을 반환해 대기 시간과 메모리 사용이 늘어날 수 있습니다. LIMIT를 추가한 뒤 실행하는 것을 권장합니다."
+            "value" : "Digite o nome da tabela para confirmar"
           }
         },
-        "pt-BR" : {
+        "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tabelas grandes podem retornar muitas linhas, causando espera e alto uso de memória. Recomenda-se adicionar LIMIT antes de executar."
+            "value" : "Escreva o nome da tabela para confirmar"
           }
         },
-        "pt-PT" : {
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tabelas grandes podem devolver muitas linhas, causando espera e utilização elevada de memória. Recomenda-se adicionar LIMIT antes de executar."
+            "value" : "Tabellennamen zur Bestätigung eingeben"
           }
         },
-        "tr" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Büyük tablolar çok sayıda satır döndürerek bekleme ve yüksek bellek kullanımına yol açabilir. LIMIT ekleyip çalıştırmanız önerilir."
+            "value" : "Saisissez le nom de la table pour confirmer"
           }
         },
-        "zh-HK" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "大表可能返回大量行，造成等待和記憶體佔用。建議加 LIMIT 後執行。"
+            "value" : "اكتب اسم الجدول للتأكيد"
           }
         },
-        "zh-Hant" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "大型資料表可能回傳大量列，造成等待與記憶體佔用。建議加上 LIMIT 後執行。"
+            "value" : "Onaylamak için tablo adını yazın"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerConfigModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerConfigModels.swift
@@ -3,7 +3,7 @@
 //  Orange Cloud
 //
 //  Workers 脚本管理（编辑 / 变量 / 密钥 / 触发器）相关模型。
-//  GET  /accounts/{a}/workers/scripts/{n}/content     源码（模块→multipart，service worker→raw JS）
+//  GET  /accounts/{a}/workers/scripts/{n}/content/v2  源码（模块→multipart，service worker→raw JS；v1 /content 被 OAuth 10405 挡，必须 v2）
 //  PUT  /accounts/{a}/workers/scripts/{n}             上传（multipart：metadata + 模块 part），保留绑定用 inherit
 //  GET  /accounts/{a}/workers/scripts/{n}/settings    绑定 + 兼容性日期/标志
 //  PATCH .../settings                                 改绑定（变量），其余绑定回传 inherit
@@ -12,6 +12,34 @@
 //
 
 import Foundation
+
+// MARK: - 部署历史
+
+/// 一次部署（GET /workers/scripts/{n}/deployments 的 result.deployments 元素）。
+/// 列表首项为当前正在服务的活跃部署（Cloudflare 不允许删除活跃部署）。
+nonisolated struct WorkerDeployment: Codable, Identifiable, Hashable, Sendable {
+    let id: String
+    let createdOn: String?
+    let source: String?
+    let authorEmail: String?
+    let annotations: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, source, annotations
+        case createdOn   = "created_on"
+        case authorEmail = "author_email"
+    }
+
+    /// annotations["workers/message"]（部署备注）
+    var message: String? { annotations?["workers/message"] }
+
+    var createdDate: Date? { WorkerScript.parseDate(createdOn) }
+}
+
+/// deployments 端点信封的 result（{ deployments: [...] }）
+nonisolated struct WorkerDeploymentsResult: Codable, Sendable {
+    let deployments: [WorkerDeployment]
+}
 
 // MARK: - 脚本源码
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerService.swift
@@ -26,10 +26,13 @@ struct WorkerService {
 
     // MARK: - 脚本源码与设置
 
-    /// 脚本源码（模块→multipart 解析为各模块；service worker→raw JS）
+    /// 脚本源码（模块→multipart 解析为各模块；service worker→raw JS）。
+    /// 必须走 /content/v2：v1 的 `/content` 对 OAuth 认证方案返回 405 cf=10405
+    /// （Method not allowed for this authentication scheme），v2 与裸 GET 才放行
+    /// （真机实测 2026-07-14，issue #55）。响应仍是 multipart/form-data，解码口径不变。
     func content(accountId: String, scriptName: String) async throws -> WorkerContent {
         let (data, response) = try await client.getRawResponse(
-            "accounts/\(accountId)/workers/scripts/\(scriptName)/content"
+            "accounts/\(accountId)/workers/scripts/\(scriptName)/content/v2"
         )
         let contentType = response.value(forHTTPHeaderField: "Content-Type")
         return WorkerContent.parse(data: data, contentType: contentType)
@@ -75,7 +78,7 @@ struct WorkerService {
     }
 
     /// 新建 / 整体替换脚本（PUT 即「不存在则建、存在则覆盖」）。主模块名由我们定，
-    /// 不读 /content（OAuth 下读不到，见 cloudflare-oauth-content-405）——新建无需读旧码；
+    /// 新建无需读旧码（原地编辑改走 content() 读 /content/v2 预填）；
     /// 替换时传 inheritBindings（现有绑定按名 inherit，连同读不到值的密钥一并保住），带
     /// ?bindings_inherit=strict 缺绑定即报错而非静默丢弃。
     func deployScript(
@@ -142,6 +145,28 @@ struct WorkerService {
             files: modules.map { (name: $0.name, contentType: $0.contentType, content: $0.data) }
         )
         guard response.success else { throw response.toAPIError() }
+    }
+
+    /// 删除整个 Worker 脚本（连同其部署、路由绑定）。OAuth 下放行（真机实测 issue #55）。
+    /// 需 workers-scripts.write。不可撤销。
+    func deleteScript(accountId: String, scriptName: String) async throws {
+        try await client.delete("accounts/\(accountId)/workers/scripts/\(scriptName)")
+    }
+
+    // MARK: - 部署历史
+
+    /// 部署列表（result.deployments，首项为活跃部署）。
+    func listDeployments(accountId: String, scriptName: String) async throws -> [WorkerDeployment] {
+        let response: CFAPIResponse<WorkerDeploymentsResult> = try await client.get(
+            "accounts/\(accountId)/workers/scripts/\(scriptName)/deployments"
+        )
+        guard response.success, let result = response.result else { throw response.toAPIError() }
+        return result.deployments
+    }
+
+    /// 删除某次部署。当前活跃（最新）部署 Cloudflare 会拒绝删除。需 workers-scripts.write。
+    func deleteDeployment(accountId: String, scriptName: String, deploymentId: String) async throws {
+        try await client.delete("accounts/\(accountId)/workers/scripts/\(scriptName)/deployments/\(deploymentId)")
     }
 
     // MARK: - 静态资源（Workers Assets）

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/StorageViewModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/StorageViewModels.swift
@@ -579,6 +579,32 @@ final class D1QueryViewModel {
         }
         isRunning = false
     }
+
+    // MARK: - 删表（DROP TABLE）
+
+    var isDroppingTable = false
+    var dropError: String?
+
+    /// 标识符加引号并转义内部双引号，防 SQL 注入（对齐 D1TableViewModel.quoted）
+    private func quoted(_ identifier: String) -> String {
+        "\"" + identifier.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
+
+    /// DROP TABLE：删除整张表及其全部数据（d1.write 门控，标识符加引号防注入）
+    func dropTable(_ name: String) async -> Bool {
+        guard !isDroppingTable else { return false }
+        isDroppingTable = true
+        dropError = nil
+        defer { isDroppingTable = false }
+        do {
+            _ = try await service.query(accountId: accountId, databaseId: databaseId, sql: "DROP TABLE IF EXISTS \(quoted(name))")
+            tables.removeAll { $0 == name }
+            return true
+        } catch {
+            dropError = error.localizedDescription
+            return false
+        }
+    }
 }
 
 @Observable

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerDeploymentsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerDeploymentsViewModel.swift
@@ -1,0 +1,61 @@
+//
+//  WorkerDeploymentsViewModel.swift
+//  Orange Cloud
+//
+//  Worker 部署历史：列出部署、删除历史部署（活跃部署由 Cloudflare 拒绝删除）。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class WorkerDeploymentsViewModel {
+
+    var deployments: [WorkerDeployment] = []
+    var isLoading = false
+    var loaded = false
+    var error: String?
+    var isDeleting = false
+    var didDelete = false       // sensoryFeedback 触发器
+
+    private let service: WorkerService
+    let accountId: String
+    let scriptName: String
+
+    init(service: WorkerService, accountId: String, scriptName: String) {
+        self.service = service
+        self.accountId = accountId
+        self.scriptName = scriptName
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false; loaded = true }
+        do {
+            deployments = try await service.listDeployments(accountId: accountId, scriptName: scriptName)
+        } catch is CancellationError {
+        } catch let urlError as URLError where urlError.code == .cancelled {
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// 删除某次部署。活跃部署 Cloudflare 会拒绝（错误透传到 error）。
+    func delete(_ deployment: WorkerDeployment) async -> Bool {
+        guard !isDeleting else { return false }
+        isDeleting = true
+        error = nil
+        defer { isDeleting = false }
+        do {
+            try await service.deleteDeployment(accountId: accountId, scriptName: scriptName, deploymentId: deployment.id)
+            deployments.removeAll { $0.id == deployment.id }
+            didDelete.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerListViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerListViewModel.swift
@@ -15,6 +15,8 @@ final class WorkerListViewModel {
 
     var isLoading = false
     var error: String?
+    var isDeleting = false
+    var didDelete = false       // sensoryFeedback 触发器
 
     private let workerService: WorkerService
     /// 进行中的加载任务（见 ZoneListViewModel：独立 Task 承载加载，避免下拉手势取消导致 .cancelled 误报）
@@ -39,6 +41,24 @@ final class WorkerListViewModel {
         loadTask = task
         defer { loadTask = nil }
         await task.value
+    }
+
+    /// 删除 Worker 脚本，成功后从缓存移除该条目（@Query 列表随之更新）。需 workers-scripts.write。
+    func delete(accountId: String, script: CachedWorkerScript, context: ModelContext) async -> Bool {
+        guard !isDeleting else { return false }
+        isDeleting = true
+        error = nil
+        defer { isDeleting = false }
+        do {
+            try await workerService.deleteScript(accountId: accountId, scriptName: script.id)
+            context.delete(script)
+            try? context.save()
+            didDelete.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
     }
 
     private func load(accountId: String, context: ModelContext) async {

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerUploadViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerUploadViewModel.swift
@@ -21,6 +21,10 @@ final class WorkerUploadViewModel {
     var error: String?
     var didUpload = false       // sensoryFeedback 触发器
 
+    // 原地编辑：读现有源码预填（/content/v2，OAuth 下可读）
+    var isLoadingSource = false
+    var sourceUneditable = false   // 多模块打包产物：无法安全单文件替换（会丢其它模块）
+
     // 静态资源上传进度
     var uploadedAssets = 0
     var totalAssets = 0
@@ -151,6 +155,23 @@ final class WorkerUploadViewModel {
         } catch {
             self.error = error.localizedDescription
             return false
+        }
+    }
+
+    /// 原地编辑前读取当前线上源码用于预填。多模块打包产物置 sourceUneditable，
+    /// 单文件替换会丢失其它模块，故不允许原地编辑（引导用户走多模块整体替换）。
+    func fetchSource(scriptName: String) async -> WorkerContent? {
+        isLoadingSource = true
+        sourceUneditable = false
+        error = nil
+        defer { isLoadingSource = false }
+        do {
+            let content = try await service.content(accountId: accountId, scriptName: scriptName)
+            sourceUneditable = !content.isEditable
+            return content
+        } catch {
+            self.error = error.localizedDescription
+            return nil
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1DropTableConfirmView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1DropTableConfirmView.swift
@@ -1,0 +1,109 @@
+//
+//  D1DropTableConfirmView.swift
+//  Orange Cloud
+//
+//  D1 表删除二次确认（Sheet）：必须原样输入表名才能启用删除按钮，与数据库删除确认一致。
+//  入口（D1QueryView 表列表长按菜单）已按 d1.write 门控。DROP TABLE 连同全部数据，不可恢复。
+//
+
+import SwiftUI
+
+struct D1DropTableConfirmView: View {
+
+    let tableName: String
+    let viewModel: D1QueryViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var typedName = ""
+    @FocusState private var fieldFocused: Bool
+
+    /// 输入与表名完全一致（去空白）才允许删除
+    private var nameMatches: Bool {
+        typedName.trimmingCharacters(in: .whitespacesAndNewlines) == tableName
+    }
+
+    private var canDelete: Bool {
+        nameMatches && !viewModel.isDroppingTable
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    VStack(spacing: 12) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 44))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.red)
+                        Text("永久删除表")
+                            .font(.headline)
+                        Text("此操作将永久删除表 \(tableName) 及其全部数据，无法撤销，也无法恢复。")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .listRowBackground(Color.clear)
+                }
+
+                Section {
+                    TextField(tableName, text: $typedName)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .font(.callout.monospaced())
+                        .focused($fieldFocused)
+                        .submitLabel(.done)
+                        .onSubmit { Task { await performDrop() } }
+                } header: {
+                    Text("输入表名以确认")
+                } footer: {
+                    Text("请输入 \(tableName) 以启用删除。")
+                }
+
+                if let error = viewModel.dropError {
+                    Section {
+                        Text(error)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        Task { await performDrop() }
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if viewModel.isDroppingTable {
+                                ProgressView()
+                            } else {
+                                Label("永久删除", systemImage: "trash")
+                                    .fontWeight(.semibold)
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(!canDelete)
+                }
+            }
+            .navigationTitle("删除表")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+            }
+            .onAppear { fieldFocused = true }
+            .interactiveDismissDisabled(viewModel.isDroppingTable)
+        }
+    }
+
+    private func performDrop() async {
+        guard canDelete else { return }
+        fieldFocused = false
+        if await viewModel.dropTable(tableName) {
+            dismiss()
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1QueryView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1QueryView.swift
@@ -8,6 +8,12 @@
 
 import SwiftUI
 
+/// 待删除表的 sheet 载荷（String 非 Identifiable，包一层用于 .sheet(item:)）
+private struct DropTarget: Identifiable {
+    let id = UUID()
+    let name: String
+}
+
 // MARK: - SQL 查询控制台
 
 struct D1QueryView: View {
@@ -18,6 +24,7 @@ struct D1QueryView: View {
     @Environment(AuthManager.self) private var auth
     @State private var viewModel: D1QueryViewModel
     @State private var showLimitReminder = false
+    @State private var tableToDrop: DropTarget?
     @FocusState private var sqlFocused: Bool
 
     init(database: D1Database, session: SessionStore) {
@@ -92,6 +99,9 @@ struct D1QueryView: View {
         } message: {
             Text("大表可能返回大量行，造成等待和内存占用。建议加 LIMIT 后执行。")
         }
+        .sheet(item: $tableToDrop) { target in
+            D1DropTableConfirmView(tableName: target.name, viewModel: viewModel)
+        }
     }
 
     /// 表入口：玻璃岛列表，点按进入 D1TableView 浏览/编辑行
@@ -130,6 +140,15 @@ struct D1QueryView: View {
                                 .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
+                            .contextMenu {
+                                if canWrite {
+                                    Button(role: .destructive) {
+                                        tableToDrop = DropTarget(name: table)
+                                    } label: {
+                                        Label("删除表", systemImage: "trash")
+                                    }
+                                }
+                            }
 
                             if table != viewModel.tables.last {
                                 Divider()

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDeleteConfirmView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDeleteConfirmView.swift
@@ -1,0 +1,113 @@
+//
+//  WorkerDeleteConfirmView.swift
+//  Orange Cloud
+//
+//  Worker 脚本删除二次确认（Sheet）：必须原样输入脚本名称才能启用删除按钮，
+//  与 Cloudflare Dashboard 的删除确认一致。入口（WorkerListView 滑动删除）已按
+//  workers-scripts.write 门控。删除连同其部署与路由绑定，不可恢复。
+//
+
+import SwiftUI
+import SwiftData
+
+struct WorkerDeleteConfirmView: View {
+
+    let script: CachedWorkerScript
+    let viewModel: WorkerListViewModel
+    let accountId: String
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @State private var typedName = ""
+    @FocusState private var fieldFocused: Bool
+
+    /// 输入与脚本名完全一致（去空白）才允许删除
+    private var nameMatches: Bool {
+        typedName.trimmingCharacters(in: .whitespacesAndNewlines) == script.id
+    }
+
+    private var canDelete: Bool {
+        nameMatches && !accountId.isEmpty && !viewModel.isDeleting
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    VStack(spacing: 12) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 44))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.red)
+                        Text("永久删除 Worker")
+                            .font(.headline)
+                        Text("此操作将永久删除 Worker \(script.id) 及其部署与路由绑定，无法撤销，也无法恢复。")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .listRowBackground(Color.clear)
+                }
+
+                Section {
+                    TextField(script.id, text: $typedName)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .font(.callout.monospaced())
+                        .focused($fieldFocused)
+                        .submitLabel(.done)
+                        .onSubmit { Task { await performDelete() } }
+                } header: {
+                    Text("输入 Worker 名称以确认")
+                } footer: {
+                    Text("请输入 \(script.id) 以启用删除。")
+                }
+
+                if let error = viewModel.error {
+                    Section {
+                        Text(error)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        Task { await performDelete() }
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if viewModel.isDeleting {
+                                ProgressView()
+                            } else {
+                                Label("永久删除", systemImage: "trash")
+                                    .fontWeight(.semibold)
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(!canDelete)
+                }
+            }
+            .navigationTitle("删除 Worker")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+            }
+            .onAppear { fieldFocused = true }
+            .interactiveDismissDisabled(viewModel.isDeleting)
+        }
+    }
+
+    private func performDelete() async {
+        guard canDelete else { return }
+        fieldFocused = false
+        if await viewModel.delete(accountId: accountId, script: script, context: modelContext) {
+            dismiss()
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDeploymentsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDeploymentsView.swift
@@ -1,0 +1,126 @@
+//
+//  WorkerDeploymentsView.swift
+//  Orange Cloud
+//
+//  Worker 部署历史：列出历次部署，删除历史部署（首项为活跃部署，不可删除）。
+//  写操作按 workers-scripts.write 门控。
+//
+
+import SwiftUI
+
+struct WorkerDeploymentsView: View {
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: WorkerDeploymentsViewModel
+    @State private var toDelete: WorkerDeployment?
+    @State private var deleteDenied = false
+
+    init(accountId: String, scriptName: String, session: SessionStore) {
+        _viewModel = State(initialValue: WorkerDeploymentsViewModel(
+            service: session.workerService, accountId: accountId, scriptName: scriptName
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("workers-scripts.write") }
+
+    var body: some View {
+        Group {
+            if !viewModel.loaded && viewModel.isLoading {
+                SkeletonList(rows: 6, trailing: true)
+            } else if viewModel.deployments.isEmpty {
+                ContentUnavailableView("暂无部署", systemImage: "clock.arrow.circlepath")
+            } else {
+                List {
+                    Section {
+                        ForEach(Array(viewModel.deployments.enumerated()), id: \.element.id) { index, dep in
+                            row(dep, isActive: index == 0)
+                                .swipeActions(edge: .trailing) {
+                                    if index != 0 {
+                                        Button(role: .destructive) {
+                                            if canWrite { toDelete = dep } else { deleteDenied = true }
+                                        } label: {
+                                            Label("删除", systemImage: "trash")
+                                        }
+                                    }
+                                }
+                        }
+                    } footer: {
+                        Text("首项为当前活跃部署，不可删除。向左滑动删除历史部署。")
+                            .font(.caption)
+                    }
+                    .glassRow()
+                }
+                .scrollContentBackground(.hidden)
+                .refreshable { await viewModel.load() }
+            }
+        }
+        .background { SkyBackground() }
+        .navigationTitle("部署历史")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { if !viewModel.loaded { await viewModel.load() } }
+        .sensoryFeedback(.success, trigger: viewModel.didDelete)
+        .alert("删除此部署？", isPresented: Binding(get: { toDelete != nil }, set: { if !$0 { toDelete = nil } })) {
+            Button("取消", role: .cancel) { toDelete = nil }
+            Button("删除", role: .destructive) {
+                if let dep = toDelete {
+                    Task { _ = await viewModel.delete(dep); toDelete = nil }
+                }
+            }
+        } message: {
+            Text("删除后不可恢复。")
+        }
+        .alert("权限不足", isPresented: $deleteDenied) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("当前授权未包含 Workers 写权限（workers-scripts.write）。\n请在设置中退出登录后重新授权以启用此功能。")
+        }
+        .overlay(alignment: .bottom) {
+            if let error = viewModel.error {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .padding(10)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+                    .padding()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ dep: WorkerDeployment, isActive: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                if isActive {
+                    Text("活跃")
+                        .font(.caption2.weight(.bold))
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Color.ocOrange.opacity(0.15))
+                        .foregroundStyle(Color.ocOrange)
+                        .clipShape(Capsule())
+                }
+                Text(dep.message ?? dep.source ?? String(dep.id.prefix(8)))
+                    .font(.callout)
+                    .lineLimit(1)
+                Spacer()
+                if let date = dep.createdDate {
+                    Text(date, format: .relative(presentation: .named))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            HStack(spacing: 8) {
+                Text(dep.id.prefix(8))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                if let email = dep.authorEmail {
+                    Text(email)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
@@ -92,6 +92,14 @@ struct WorkerDetailView: View {
                     WorkerTriggersView(accountId: script.accountId, scriptName: script.id, session: session)
                 }
                 ProGatedNavigationLink(
+                    label: String(localized: "部署历史"),
+                    systemImage: "clock.arrow.circlepath",
+                    requiredScope: "workers-scripts.read",
+                    feature: .workerRoutes
+                ) {
+                    WorkerDeploymentsView(accountId: script.accountId, scriptName: script.id, session: session)
+                }
+                ProGatedNavigationLink(
                     label: String(localized: "域名"),
                     systemImage: "globe",
                     requiredScope: "workers-scripts.read",

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerListView.swift
@@ -23,6 +23,8 @@ struct WorkerListView: View {
     @State private var showTailDenied = false
     @State private var showCreate = false
     @State private var createDenied = false
+    @State private var deleteTarget: CachedWorkerScript?
+    @State private var deleteDenied = false
     @AppStorage("workerListSort") private var sort: ResourceSort = .name
 
     private var canWrite: Bool { auth.hasScope("workers-scripts.write") }
@@ -94,7 +96,11 @@ struct WorkerListView: View {
                     Task { await refresh() }
                 }
             }
+            .sheet(item: $deleteTarget) { script in
+                WorkerDeleteConfirmView(script: script, viewModel: viewModel, accountId: script.accountId)
+            }
             .sensoryFeedback(.success, trigger: uploadViewModel.didUpload)
+            .sensoryFeedback(.success, trigger: viewModel.didDelete)
             .task {
                 await refresh()
             }
@@ -104,6 +110,11 @@ struct WorkerListView: View {
                 Text("当前授权未包含实时日志权限（workers-tail.read）。\n请在设置中退出登录后重新授权以启用此功能。")
             }
             .alert("权限不足", isPresented: $createDenied) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text("当前授权未包含 Workers 写权限（workers-scripts.write）。\n请在设置中退出登录后重新授权以启用此功能。")
+            }
+            .alert("权限不足", isPresented: $deleteDenied) {
                 Button("好", role: .cancel) {}
             } message: {
                 Text("当前授权未包含 Workers 写权限（workers-scripts.write）。\n请在设置中退出登录后重新授权以启用此功能。")
@@ -119,6 +130,11 @@ struct WorkerListView: View {
                         WorkerRow(script: script)
                     }
                     .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            if canWrite { deleteTarget = script } else { deleteDenied = true }
+                        } label: {
+                            Label("删除", systemImage: "trash")
+                        }
                         Button {
                             if auth.hasScope("workers-tail.read") {
                                 tailTarget = script
@@ -134,7 +150,7 @@ struct WorkerListView: View {
             } header: {
                 Text("\(cachedScripts.count) 个 Worker")
             } footer: {
-                Label("向左滑动查看实时日志 · 点按查看详情", systemImage: "hand.draw")
+                Label("向左滑动查看实时日志或删除 · 点按查看详情", systemImage: "hand.draw")
                     .font(.caption)
             }
             .glassRow()

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerUploadView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerUploadView.swift
@@ -44,6 +44,7 @@ struct WorkerUploadView: View {
     @State private var code = ""
     @State private var isModule = true
     @State private var showCodeImporter = false
+    @State private var didLoadSource = false   // 原地编辑：只预填一次
 
     // 多模块
     @State private var modules: [WorkerUploadModule] = []
@@ -67,6 +68,9 @@ struct WorkerUploadView: View {
 
     private var canSubmit: Bool {
         guard nameValid, !viewModel.isUploading else { return false }
+        if case .replace = mode, viewModel.isLoadingSource || viewModel.sourceUneditable {
+            return false   // 原地编辑：源码未就绪 / 多模块不可替换时禁止部署
+        }
         switch effectiveKind {
         case .single:  return !code.isEmpty
         case .modules: return !modules.isEmpty && entryCandidates.contains(entryName)
@@ -134,6 +138,7 @@ struct WorkerUploadView: View {
             }
             .interactiveDismissDisabled(viewModel.isUploading)
             .onAppear { viewModel.error = nil }
+            .task { await loadSourceIfNeeded() }
             .fileImporter(isPresented: $showCodeImporter, allowedContentTypes: [.javaScript, .text, .item], allowsMultipleSelection: false) { importCode($0) }
             .fileImporter(isPresented: $showModuleImporter, allowedContentTypes: [.javaScript, .text, .item], allowsMultipleSelection: true) { importModules($0) }
             .fileImporter(isPresented: $showAssetImporter, allowedContentTypes: [.item], allowsMultipleSelection: true) { importAssets($0) }
@@ -173,30 +178,53 @@ struct WorkerUploadView: View {
                     Text("Service Worker").tag(false)
                 }
                 .pickerStyle(.segmented)
-                .disabled(viewModel.isUploading)
+                // 编辑现有脚本时格式由源码决定，不允许更改（避免以错误类型回写）
+                .disabled(viewModel.isUploading || !isCreate)
             } footer: {
                 Text(isModule
                      ? String(localized: "ES Module：export default { fetch }（推荐）。")
                      : String(localized: "Service Worker：addEventListener(\"fetch\", …)。"))
             }
             Section {
-                TextEditor(text: $code)
-                    .font(.callout.monospaced())
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .frame(minHeight: 220)
+                if !isCreate && viewModel.isLoadingSource {
+                    HStack(spacing: 10) {
+                        ProgressView()
+                        Text("正在读取源码…").font(.callout).foregroundStyle(.secondary)
+                    }
+                } else if !isCreate && viewModel.sourceUneditable {
+                    Label("这是多模块打包 Worker，无法在此原地编辑（会丢失其它模块）。可在「新建」里用多模块方式整体替换。", systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    TextEditor(text: $code)
+                        .font(.callout.monospaced())
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .frame(minHeight: 220)
+                        .disabled(viewModel.isUploading)
+                    Button { showCodeImporter = true } label: {
+                        Label("从 .js 文件导入", systemImage: "doc.badge.plus")
+                    }
                     .disabled(viewModel.isUploading)
-                Button { showCodeImporter = true } label: {
-                    Label("从 .js 文件导入", systemImage: "doc.badge.plus")
                 }
-                .disabled(viewModel.isUploading)
             } header: {
                 Text("代码")
             } footer: {
-                if !isCreate {
-                    Text("Cloudflare 不允许第三方授权读取 Worker 源码，因此只能整体替换、无法在原代码上修改。现有变量 / 密钥 / 绑定会自动保留。")
+                if !isCreate && !viewModel.sourceUneditable && !viewModel.isLoadingSource {
+                    Text("已载入当前线上源码，可直接修改后部署。现有变量 / 密钥 / 绑定会自动保留。")
                 }
             }
+        }
+    }
+
+    /// 原地编辑：进 sheet 时读取现有源码预填（仅 .replace 单文件模式，只做一次）
+    private func loadSourceIfNeeded() async {
+        guard case .replace(let scriptName) = mode, !didLoadSource else { return }
+        didLoadSource = true
+        if let content = await viewModel.fetchSource(scriptName: scriptName),
+           let main = content.mainModule {
+            code = main.body
+            isModule = content.isModule
         }
     }
 

--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,5 +1,112 @@
 [
   {
+    "version": "1.8.5",
+    "date": "2026.07.18",
+    "channel": "App Store",
+    "inApp": true,
+    "items": [
+      {
+        "icon": "clock.arrow.circlepath",
+        "title": {
+          "zh-Hans": "Worker 部署历史",
+          "en": "Worker deployment history",
+          "zh-Hant": "Worker 部署歷史",
+          "zh-HK": "Worker 部署歷史",
+          "ja": "Worker のデプロイ履歴",
+          "es-MX": "Historial de despliegues de Worker",
+          "ko": "Worker 배포 기록",
+          "pt-BR": "Histórico de implantações do Worker",
+          "pt-PT": "Histórico de implementações do Worker",
+          "de": "Worker-Bereitstellungsverlauf",
+          "fr": "Historique des déploiements Worker",
+          "ar": "سجل عمليات نشر Worker",
+          "tr": "Worker dağıtım geçmişi"
+        },
+        "detail": {
+          "zh-Hans": "查看每个 Worker 的历次部署记录，并可删除不再需要的旧部署。",
+          "en": "See every past deployment of a Worker and delete older ones you no longer need.",
+          "zh-Hant": "檢視每個 Worker 的歷次部署記錄，並可刪除不再需要的舊部署。",
+          "zh-HK": "查看每個 Worker 的歷次部署記錄，並可刪除不再需要的舊部署。",
+          "ja": "各 Worker の過去のデプロイを確認し、不要になった古いデプロイを削除できます。",
+          "es-MX": "Consulta cada despliegue anterior de un Worker y elimina los que ya no necesites.",
+          "ko": "각 Worker의 과거 배포를 확인하고 더 이상 필요 없는 이전 배포를 삭제할 수 있습니다.",
+          "pt-BR": "Veja todas as implantações anteriores de um Worker e exclua as antigas que não precisa mais.",
+          "pt-PT": "Veja todas as implementações anteriores de um Worker e elimine as antigas de que já não precisa.",
+          "de": "Sieh dir alle bisherigen Bereitstellungen eines Workers an und lösche nicht mehr benötigte alte Bereitstellungen.",
+          "fr": "Consultez tous les déploiements passés d’un Worker et supprimez les anciens dont vous n’avez plus besoin.",
+          "ar": "اطّلع على كل عمليات نشر Worker السابقة واحذف القديمة التي لم تعد بحاجة إليها.",
+          "tr": "Bir Worker’ın geçmiş tüm dağıtımlarını görün ve artık ihtiyaç duymadığınız eskileri silin."
+        }
+      },
+      {
+        "icon": "square.and.pencil",
+        "title": {
+          "zh-Hans": "就地编辑与删除 Worker",
+          "en": "Edit and delete Workers in place",
+          "zh-Hant": "就地編輯與刪除 Worker",
+          "zh-HK": "就地編輯與刪除 Worker",
+          "ja": "Worker をその場で編集・削除",
+          "es-MX": "Edita y elimina Workers directamente",
+          "ko": "Worker를 바로 편집·삭제",
+          "pt-BR": "Edite e exclua Workers diretamente",
+          "pt-PT": "Edite e elimine Workers diretamente",
+          "de": "Worker direkt bearbeiten und löschen",
+          "fr": "Modifier et supprimer des Workers sur place",
+          "ar": "تعديل وحذف Workers مباشرةً",
+          "tr": "Worker’ları yerinde düzenleyin ve silin"
+        },
+        "detail": {
+          "zh-Hans": "直接载入线上源码修改后重新部署，变量、密钥与绑定自动保留；也可从 .js 文件导入，或删除整个 Worker。",
+          "en": "Load the live source, edit it and redeploy — your variables, secrets and bindings are kept. You can also import from a .js file or delete the whole Worker.",
+          "zh-Hant": "直接載入線上原始碼修改後重新部署，變數、密鑰與繫結自動保留；也可從 .js 檔案匯入，或刪除整個 Worker。",
+          "zh-HK": "直接載入線上原始碼修改後重新部署，變數、密鑰與綁定自動保留；也可從 .js 檔案匯入，或刪除整個 Worker。",
+          "ja": "稼働中のソースを読み込んで編集し、再デプロイできます。変数・シークレット・バインディングは保持されます。.js ファイルからの読み込みや Worker 全体の削除にも対応します。",
+          "es-MX": "Carga el código en producción, edítalo y vuelve a desplegar; se conservan tus variables, secretos y enlaces. También puedes importar desde un archivo .js o eliminar todo el Worker.",
+          "ko": "실행 중인 소스를 불러와 수정한 뒤 다시 배포할 수 있으며 변수, 비밀, 바인딩이 유지됩니다. .js 파일에서 가져오거나 Worker 전체를 삭제할 수도 있습니다.",
+          "pt-BR": "Carregue o código em produção, edite e reimplante — suas variáveis, segredos e bindings são mantidos. Também dá para importar de um arquivo .js ou excluir o Worker inteiro.",
+          "pt-PT": "Carregue o código em produção, edite e reimplante — as suas variáveis, segredos e ligações são mantidos. Também pode importar de um ficheiro .js ou eliminar o Worker inteiro.",
+          "de": "Lade den Live-Quellcode, bearbeite ihn und stelle neu bereit – Variablen, Secrets und Bindings bleiben erhalten. Du kannst auch aus einer .js-Datei importieren oder den ganzen Worker löschen.",
+          "fr": "Chargez le code en production, modifiez-le et redéployez ; vos variables, secrets et liaisons sont conservés. Vous pouvez aussi importer depuis un fichier .js ou supprimer le Worker entier.",
+          "ar": "حمّل الشيفرة المباشرة وعدّلها وأعد النشر مع الحفاظ على المتغيرات والأسرار والارتباطات. يمكنك أيضًا الاستيراد من ملف ‎.js‎ أو حذف Worker بالكامل.",
+          "tr": "Canlı kaynağı yükleyip düzenleyin ve yeniden dağıtın; değişkenleriniz, gizli anahtarlarınız ve bağlamalarınız korunur. Ayrıca bir .js dosyasından içe aktarabilir veya Worker’ın tamamını silebilirsiniz."
+        }
+      },
+      {
+        "icon": "tablecells",
+        "title": {
+          "zh-Hans": "删除 D1 数据表",
+          "en": "Delete D1 tables",
+          "zh-Hant": "刪除 D1 資料表",
+          "zh-HK": "刪除 D1 資料表",
+          "ja": "D1 テーブルを削除",
+          "es-MX": "Eliminar tablas de D1",
+          "ko": "D1 테이블 삭제",
+          "pt-BR": "Excluir tabelas do D1",
+          "pt-PT": "Eliminar tabelas do D1",
+          "de": "D1-Tabellen löschen",
+          "fr": "Supprimer des tables D1",
+          "ar": "حذف جداول D1",
+          "tr": "D1 tablolarını silme"
+        },
+        "detail": {
+          "zh-Hans": "在查询控制台长按任意表即可删除，需输入表名二次确认。",
+          "en": "Long-press any table in the query console to drop it, with a type-the-name confirmation.",
+          "zh-Hant": "在查詢主控台長按任一表即可刪除，需輸入表名二次確認。",
+          "zh-HK": "在查詢控制台長按任一表即可刪除，需輸入表名二次確認。",
+          "ja": "クエリコンソールでテーブルを長押しすると削除できます。テーブル名の入力による確認付きです。",
+          "es-MX": "Mantén pulsada cualquier tabla en la consola de consultas para eliminarla, con confirmación escribiendo su nombre.",
+          "ko": "쿼리 콘솔에서 테이블을 길게 눌러 삭제할 수 있으며 이름을 입력해 확인합니다.",
+          "pt-BR": "Toque e segure qualquer tabela no console de consultas para excluí-la, com confirmação digitando o nome.",
+          "pt-PT": "Toque sem soltar em qualquer tabela na consola de consultas para a eliminar, com confirmação escrevendo o nome.",
+          "de": "Halte in der Abfragekonsole eine Tabelle gedrückt, um sie zu löschen – mit Bestätigung durch Eingabe des Namens.",
+          "fr": "Appuyez longuement sur une table dans la console de requêtes pour la supprimer, avec confirmation en saisissant son nom.",
+          "ar": "اضغط مطوّلاً على أي جدول في وحدة الاستعلام لحذفه، مع تأكيد بكتابة الاسم.",
+          "tr": "Sorgu konsolunda bir tabloya uzun basarak silin; adını yazarak onaylayın."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.8.4",
     "date": "2026.07.10",
     "channel": "App Store",


### PR DESCRIPTION
## iOS 1.8.5(32)

**新功能**
- **Worker 部署历史**：查看每个 Worker 的历次部署，删除不再需要的旧部署
- **Worker 就地编辑与删除**：载入线上源码修改后重新部署（变量/密钥/绑定自动保留）、从 .js 导入、删除整个 Worker；多模块 Worker 提示改用「新建」整体替换
- **D1 删表**：查询控制台长按表 → 输入表名二次确认 → `DROP TABLE`（`d1.write` 门控、标识符引号防注入）

**发版**
- 版本号 1.8.4→1.8.5（12 处）、build 31→32
- What's New 13 语（单一数据源 `packages/changelog/ios.json` → codegen，`changelog:check` 通过）

**验证**：Xcode-beta iOS 17.0 模拟器 `xcodebuild build` → BUILD SUCCEEDED。归档 + App Store Connect 送审为手动步骤。

> 含此前工作区累积的 Worker 部署/删除批次；D1 删表为本次新增。
