### PR TITLE
feat(android): 1.6.4 — Dashboard 用量模块 + Worker 部署历史 + 存储管理增强

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         // 实况通知促升(API36) 均 if-guard 渐进增强，Android 8–11 落固定品牌调色板与常驻通知回退。
         minSdk = 26
         targetSdk = 36
-        versionCode = 12
-        versionName = "1.6.3"
+        versionCode = 13
+        versionName = "1.6.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/network/CfApiClient.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/network/CfApiClient.kt
@@ -238,10 +238,11 @@ class CfApiClient @Inject constructor(
         fileName: String,
         fileText: String,
         fileContentType: String,
+        query: List<Pair<String, String>> = emptyList(),
     ): T {
         val boundary = "OrangeCloud-${UUID.randomUUID()}"
         val body = buildMultipartFileBody(boundary, metadataJson, fileName, fileText, fileContentType)
-        val bytes = executeRaw("PUT", path, emptyList(), body, "multipart/form-data; boundary=$boundary")
+        val bytes = executeRaw("PUT", path, query, body, "multipart/form-data; boundary=$boundary")
         return decodeResult(bytes, serializer<T>())
     }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/system/AppPrefs.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/system/AppPrefs.kt
@@ -5,8 +5,14 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import jiamin.chen.orangecloud.data.model.AccountUsage
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,7 +36,17 @@ enum class ResourceSort(val value: Int) {
     }
 }
 
-/** App 偏好（外观 + 通知开关 + 列表排序），存共享 DataStore。 */
+/**
+ * Dashboard 用量套餐设置（对应 iOS AccountPrefs 的手动套餐兜底）。
+ * OAuth token 无 billing scope，套餐/账单日靠用户手动设置，按账号存。
+ */
+data class UsagePlanPrefs(
+    val workersPaid: Boolean = false,
+    val r2Paid: Boolean = false,
+    val billingDay: Int = 1,   // 1 = 自然月；否则按账单日划周期
+)
+
+/** App 偏好（外观 + 通知开关 + 列表排序 + 用量套餐），存共享 DataStore。 */
 @Singleton
 class AppPrefs @Inject constructor(
     private val dataStore: DataStore<Preferences>,
@@ -64,7 +80,41 @@ class AppPrefs @Inject constructor(
         dataStore.edit { it[intPreferencesKey("pref_sort_$key")] = sort.value }
     }
 
+    /** 某账号的用量套餐设置（Workers/R2 付费 + 账单日）。 */
+    fun usagePlan(accountId: String): Flow<UsagePlanPrefs> = dataStore.data.map { p ->
+        UsagePlanPrefs(
+            workersPaid = p[booleanPreferencesKey("pref_usage_w_paid_$accountId")] ?: false,
+            r2Paid = p[booleanPreferencesKey("pref_usage_r2_paid_$accountId")] ?: false,
+            billingDay = (p[intPreferencesKey("pref_usage_bday_$accountId")] ?: 1).coerceIn(1, 28),
+        )
+    }
+
+    suspend fun setUsageWorkersPaid(accountId: String, paid: Boolean) {
+        dataStore.edit { it[booleanPreferencesKey("pref_usage_w_paid_$accountId")] = paid }
+    }
+
+    suspend fun setUsageR2Paid(accountId: String, paid: Boolean) {
+        dataStore.edit { it[booleanPreferencesKey("pref_usage_r2_paid_$accountId")] = paid }
+    }
+
+    suspend fun setUsageBillingDay(accountId: String, day: Int) {
+        dataStore.edit { it[intPreferencesKey("pref_usage_bday_$accountId")] = day.coerceIn(1, 28) }
+    }
+
+    /** 用量快照落盘（按账号，JSON），供下次冷启动/切回即时回显（对齐 iOS UsageCache）。 */
+    suspend fun loadUsageCache(accountId: String): AccountUsage? {
+        val raw = dataStore.data.first()[stringPreferencesKey("usage_cache_$accountId")] ?: return null
+        return runCatching { usageJson.decodeFromString<AccountUsage>(raw) }.getOrNull()
+    }
+
+    suspend fun saveUsageCache(accountId: String, usage: AccountUsage) {
+        val raw = runCatching { usageJson.encodeToString(usage) }.getOrNull() ?: return
+        dataStore.edit { it[stringPreferencesKey("usage_cache_$accountId")] = raw }
+    }
+
     private companion object {
+        val usageJson = Json { ignoreUnknownKeys = true }
+
         val KEY_APPEARANCE = intPreferencesKey("pref_appearance")
         val KEY_NOTIF_MASTER = booleanPreferencesKey("pref_notif_master")
         val KEY_NOTIF_ZONE = booleanPreferencesKey("pref_notif_zone_status")

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
@@ -5,6 +5,14 @@ import jiamin.chen.orangecloud.R
 // ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。
 internal val whatsNewReleases: List<WhatsNewRelease> = listOf(
     WhatsNewRelease(
+        version = "1.6.4",
+        items = listOf(
+            WhatsNewItem(R.string.whatsnew_1_6_4_0_title, R.string.whatsnew_1_6_4_0_detail),
+            WhatsNewItem(R.string.whatsnew_1_6_4_1_title, R.string.whatsnew_1_6_4_1_detail),
+            WhatsNewItem(R.string.whatsnew_1_6_4_2_title, R.string.whatsnew_1_6_4_2_detail),
+        ),
+    ),
+    WhatsNewRelease(
         version = "1.6.0",
         items = listOf(
             WhatsNewItem(R.string.whatsnew_1_6_0_0_title, R.string.whatsnew_1_6_0_0_detail),

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/AccountUsageModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/AccountUsageModels.kt
@@ -1,0 +1,299 @@
+package jiamin.chen.orangecloud.data.model
+
+import kotlinx.serialization.Serializable
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * 账号用量（Dashboard 用量模块，对应 iOS Models/AccountUsageModels.swift）。
+ *
+ * 每个数据集拆成独立查询：账号未启用某服务 / token 无该数据集权限时单独失败，
+ * 不拖垮其余用量（对齐 iOS issue #4 的拆查询策略）。R2 复用 [R2UsageData]/[R2UsageVariables]。
+ */
+
+// MARK: - 聚合结果（@Serializable 供落盘缓存，对齐 iOS UsageCache）
+
+/** D1 用量聚合（行读/写：今日 + 周期）。 */
+@Serializable
+data class D1Usage(
+    val rowsReadToday: Long,
+    val rowsWrittenToday: Long,
+    val rowsReadPeriod: Long,
+    val rowsWrittenPeriod: Long,
+)
+
+/** KV 用量聚合（读/写：今日 + 周期）。 */
+@Serializable
+data class KVUsage(
+    val readsToday: Long,
+    val writesToday: Long,
+    val readsPeriod: Long,
+    val writesPeriod: Long,
+)
+
+/** 账号用量总表：Workers 主查询 + R2/CPU/D1/KV 独立查询合并（缺失项保持默认/ null）。 */
+@Serializable
+data class AccountUsage(
+    val workersRequestsToday: Long = 0,
+    val workersRequestsMonth: Long = 0,
+    val workersErrorsMonth: Long = 0,
+    val cpuP50Us: Double? = null,      // 微秒（单次分位）
+    val cpuP99Us: Double? = null,
+    val cpuTimeMonthUs: Double? = null,
+    val cpuTimeTodayUs: Double? = null,
+    val r2ClassAMonth: Long = 0,
+    val r2ClassBMonth: Long = 0,
+    val r2StorageBytes: Long = 0,
+    val r2ObjectCount: Long = 0,
+    val d1Usage: D1Usage? = null,
+    val d1StorageBytes: Long? = null,
+    val kvUsage: KVUsage? = null,
+    val kvStorageBytes: Long? = null,
+)
+
+// MARK: - 计费周期
+
+/** 用量周期起点：billingDay=1 即自然月起点；否则最近一次账单日（UTC 锚定）。 */
+object BillingCycle {
+    fun periodStart(billingDay: Int, now: Instant = Instant.now()): Instant {
+        val day = billingDay.coerceIn(1, 28)
+        val today = now.atZone(ZoneOffset.UTC).toLocalDate()
+        val anchor = if (today.dayOfMonth >= day) today.withDayOfMonth(day)
+        else today.minusMonths(1).withDayOfMonth(day)
+        return anchor.atStartOfDay(ZoneOffset.UTC).toInstant()
+    }
+}
+
+// MARK: - R2 操作分类（读类计 Class B，其余计 Class A，与 StorageRepository 口径一致）
+
+val R2_CLASS_B_ACTIONS: Set<String> = setOf(
+    "GetObject", "HeadObject", "HeadBucket", "UsageSummary",
+    "GetBucketEncryption", "GetBucketLocation", "GetBucketCors", "GetBucketLifecycleConfiguration",
+)
+
+// MARK: - Workers 账号用量（month/today 两窗口）
+
+@Serializable
+data class AccountUsageVariables(
+    val accountTag: String,
+    val monthStart: String,
+    val todayStart: String,
+    val now: String,
+)
+
+@Serializable
+data class AccountUsageData(val viewer: AccountUsageViewer)
+
+@Serializable
+data class AccountUsageViewer(val accounts: List<AccountUsageNode> = emptyList())
+
+@Serializable
+data class AccountUsageNode(
+    val month: List<WorkersUsageGroup>? = null,
+    val today: List<WorkersUsageGroup>? = null,
+)
+
+@Serializable
+data class WorkersUsageGroup(
+    val sum: WorkersUsageSum? = null,
+    val quantiles: WorkerQuantiles? = null,   // 复用 AnalyticsModels 的 cpuTimeP50/P99
+)
+
+@Serializable
+data class WorkersUsageSum(
+    val requests: Long? = null,
+    val errors: Long? = null,
+    val subrequests: Long? = null,
+)
+
+// MARK: - Workers CPU 总耗时（较新字段，独立查询）
+
+@Serializable
+data class WorkersCpuData(val viewer: WorkersCpuViewer)
+
+@Serializable
+data class WorkersCpuViewer(val accounts: List<WorkersCpuNode> = emptyList())
+
+@Serializable
+data class WorkersCpuNode(
+    val month: List<WorkersCpuGroup>? = null,
+    val today: List<WorkersCpuGroup>? = null,
+)
+
+@Serializable
+data class WorkersCpuGroup(val sum: WorkersCpuSum? = null)
+
+@Serializable
+data class WorkersCpuSum(val cpuTimeUs: Double? = null)
+
+// MARK: - D1 用量（date 标量窗口）
+
+@Serializable
+data class D1UsageVariables(
+    val accountTag: String,
+    val periodStart: String,   // yyyy-MM-dd（UTC）
+    val todayStart: String,
+    val until: String,
+)
+
+@Serializable
+data class D1UsageData(val viewer: D1UsageViewer)
+
+@Serializable
+data class D1UsageViewer(val accounts: List<D1UsageNode> = emptyList())
+
+@Serializable
+data class D1UsageNode(
+    val period: List<D1UsageGroup>? = null,
+    val today: List<D1UsageGroup>? = null,
+)
+
+@Serializable
+data class D1UsageGroup(val sum: D1UsageSum? = null)
+
+@Serializable
+data class D1UsageSum(
+    val rowsRead: Long? = null,
+    val rowsWritten: Long? = null,
+    val readQueries: Long? = null,
+    val writeQueries: Long? = null,
+)
+
+// MARK: - KV 用量（按 actionType 分组 + 存储，date 标量窗口，复用 D1UsageVariables）
+
+@Serializable
+data class KVUsageData(val viewer: KVUsageViewer)
+
+@Serializable
+data class KVUsageViewer(val accounts: List<KVUsageNode> = emptyList())
+
+@Serializable
+data class KVUsageNode(
+    val period: List<KVOpsGroup>? = null,
+    val today: List<KVOpsGroup>? = null,
+    val storage: List<KVStorageGroup>? = null,
+)
+
+@Serializable
+data class KVOpsGroup(
+    val dimensions: KVOpsDim? = null,
+    val sum: KVOpsSum? = null,
+)
+
+@Serializable
+data class KVOpsDim(val actionType: String? = null)   // "read" | "write" | "delete" | "list"
+
+@Serializable
+data class KVOpsSum(val requests: Long? = null)
+
+@Serializable
+data class KVStorageGroup(
+    val dimensions: KVStorageDim? = null,
+    val max: KVStorageMax? = null,
+)
+
+@Serializable
+data class KVStorageDim(val namespaceId: String? = null)
+
+@Serializable
+data class KVStorageMax(val byteCount: Long? = null, val keyCount: Long? = null)
+
+// MARK: - GraphQL 查询模板
+
+object AccountUsageQueries {
+
+    /** Workers 调用（month/today），含单次 CPU 分位。 */
+    val WORKERS = """
+        query (${'$'}accountTag: string!, ${'$'}monthStart: Time!, ${'$'}todayStart: Time!, ${'$'}now: Time!) {
+          viewer {
+            accounts(filter: { accountTag: ${'$'}accountTag }) {
+              month: workersInvocationsAdaptive(limit: 10000, filter: { datetime_geq: ${'$'}monthStart, datetime_leq: ${'$'}now }) {
+                sum { requests errors subrequests }
+                quantiles { cpuTimeP50 cpuTimeP99 }
+              }
+              today: workersInvocationsAdaptive(limit: 10000, filter: { datetime_geq: ${'$'}todayStart, datetime_leq: ${'$'}now }) {
+                sum { requests errors subrequests }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    /** Workers CPU 总耗时（month/today），sum.cpuTimeUs 是较新 schema 字段。 */
+    val WORKERS_CPU = """
+        query (${'$'}accountTag: string!, ${'$'}monthStart: Time!, ${'$'}todayStart: Time!, ${'$'}now: Time!) {
+          viewer {
+            accounts(filter: { accountTag: ${'$'}accountTag }) {
+              month: workersInvocationsAdaptive(limit: 10000, filter: { datetime_geq: ${'$'}monthStart, datetime_leq: ${'$'}now }) { sum { cpuTimeUs } }
+              today: workersInvocationsAdaptive(limit: 10000, filter: { datetime_geq: ${'$'}todayStart, datetime_leq: ${'$'}now }) { sum { cpuTimeUs } }
+            }
+          }
+        }
+    """.trimIndent()
+
+    /** R2 操作分类 + 当前存储（账号级聚合，忽略 bucketName 维度）。 */
+    val R2 = """
+        query (${'$'}accountTag: string!, ${'$'}monthStart: Time!, ${'$'}todayStart: Time!, ${'$'}now: Time!) {
+          viewer {
+            accounts(filter: { accountTag: ${'$'}accountTag }) {
+              r2Ops: r2OperationsAdaptiveGroups(limit: 10000, filter: { datetime_geq: ${'$'}monthStart, datetime_leq: ${'$'}now }) {
+                dimensions { actionType bucketName }
+                sum { requests }
+              }
+              r2Storage: r2StorageAdaptiveGroups(limit: 1000, filter: { datetime_geq: ${'$'}todayStart, datetime_leq: ${'$'}now }) {
+                dimensions { bucketName }
+                max { payloadSize metadataSize objectCount }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    /** D1 行读/写（period/today）。 */
+    val D1 = """
+        query (${'$'}accountTag: string!, ${'$'}periodStart: Date!, ${'$'}todayStart: Date!, ${'$'}until: Date!) {
+          viewer {
+            accounts(filter: { accountTag: ${'$'}accountTag }) {
+              period: d1AnalyticsAdaptiveGroups(limit: 10000, filter: { date_geq: ${'$'}periodStart, date_leq: ${'$'}until }) {
+                sum { rowsRead rowsWritten readQueries writeQueries }
+              }
+              today: d1AnalyticsAdaptiveGroups(limit: 10000, filter: { date_geq: ${'$'}todayStart, date_leq: ${'$'}until }) {
+                sum { rowsRead rowsWritten readQueries writeQueries }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    /** KV 操作按 actionType 分组（period/today）。 */
+    val KV_OPERATIONS = """
+        query (${'$'}accountTag: string!, ${'$'}periodStart: Date!, ${'$'}todayStart: Date!, ${'$'}until: Date!) {
+          viewer {
+            accounts(filter: { accountTag: ${'$'}accountTag }) {
+              period: kvOperationsAdaptiveGroups(limit: 10000, filter: { date_geq: ${'$'}periodStart, date_leq: ${'$'}until }) {
+                dimensions { actionType }
+                sum { requests }
+              }
+              today: kvOperationsAdaptiveGroups(limit: 10000, filter: { date_geq: ${'$'}todayStart, date_leq: ${'$'}until }) {
+                dimensions { actionType }
+                sum { requests }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    /** KV 当前存储（各 namespace 当日 max byteCount）。 */
+    val KV_STORAGE = """
+        query (${'$'}accountTag: string!, ${'$'}periodStart: Date!, ${'$'}todayStart: Date!, ${'$'}until: Date!) {
+          viewer {
+            accounts(filter: { accountTag: ${'$'}accountTag }) {
+              storage: kvStorageAdaptiveGroups(limit: 1000, filter: { date_geq: ${'$'}todayStart, date_leq: ${'$'}until }) {
+                dimensions { namespaceId }
+                max { byteCount keyCount }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/StorageModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/StorageModels.kt
@@ -83,6 +83,14 @@ data class D1QueryMeta(
     @SerialName("rows_written") val rowsWritten: Int? = null,
 )
 
+/** 创建 R2 桶请求体。R2 端点为 camelCase（无 snake 映射，对齐 iOS R2CreateRequest）。 */
+@Serializable
+data class R2CreateRequest(
+    val name: String,
+    val locationHint: String? = null,
+    val storageClass: String? = null,
+)
+
 // MARK: - KV
 
 @Serializable
@@ -90,6 +98,10 @@ data class KVNamespace(
     val id: String,
     val title: String,
 )
+
+/** 创建 KV 命名空间请求体。 */
+@Serializable
+data class KVCreateRequest(val title: String)
 
 @Serializable
 data class KVKey(

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/WorkerConfigModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/model/WorkerConfigModels.kt
@@ -4,14 +4,105 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Workers 脚本管理（变量 / 密钥 / 触发器）相关模型（对应 iOS WorkerConfigModels.swift）。
- * 源码读取端点在 OAuth 登录下被 Cloudflare 拒绝（cf=10405），故客户端不做脚本编辑，仅做配置管理。
+ * Workers 脚本管理（源码 / 变量 / 密钥 / 触发器）相关模型（对应 iOS WorkerConfigModels.swift）。
  *
+ * GET  /accounts/{a}/workers/scripts/{n}/content/v2  源码（v1 /content 被 OAuth 10405 挡，必须 v2；真机实测 issue #55）
+ * PUT  /accounts/{a}/workers/scripts/{n}             上传（multipart：metadata + 模块 part），保留绑定用 inherit
  * GET  /accounts/{a}/workers/scripts/{n}/settings    绑定 + 兼容性日期/标志
  * PATCH .../settings (multipart settings part)        改绑定（变量），其余绑定回传 inherit
  * GET/PUT/DELETE .../secrets                           密钥（仅名+类型，无值）
  * GET/PUT .../schedules                                Cron 触发器（整组替换）
  */
+
+// MARK: - 部署历史
+
+/** 一次部署（GET .../deployments 的 result.deployments 元素）。列表首项为当前活跃部署，不可删。 */
+@Serializable
+data class WorkerDeployment(
+    val id: String,
+    @SerialName("created_on") val createdOn: String? = null,
+    val source: String? = null,
+    @SerialName("author_email") val authorEmail: String? = null,
+    val annotations: Map<String, String>? = null,
+) {
+    /** annotations["workers/message"]（部署备注）。 */
+    val message: String? get() = annotations?.get("workers/message")
+}
+
+@Serializable
+data class WorkerDeploymentsResult(val deployments: List<WorkerDeployment> = emptyList())
+
+// MARK: - 脚本源码（原地编辑）
+
+/** 单个脚本模块（multipart 的一个 part；service worker 视为单条）。 */
+data class WorkerModule(val name: String, val contentType: String, val body: String)
+
+/** 解析后的脚本源码。单模块 / service worker 可原地编辑；多模块（打包产物）只读。 */
+data class WorkerContent(val modules: List<WorkerModule>, val isModule: Boolean) {
+    /** 单模块 / service worker 才可安全往返编辑；多模块整体替换会丢失其它模块。 */
+    val isEditable: Boolean get() = modules.size <= 1
+    val mainModule: WorkerModule? get() = modules.firstOrNull()
+
+    companion object {
+        /**
+         * 从 /content/v2 原始响应解析。响应体以 `--boundary` 开头且含 Content-Disposition = multipart（module worker）；
+         * 否则为经典 service worker 裸 JS。边界从首行推导，无需读响应头。
+         */
+        fun parse(bytes: ByteArray): WorkerContent {
+            val raw = bytes.toString(Charsets.UTF_8)
+            val lead = raw.trimStart('\r', '\n', ' ')
+            if (!lead.startsWith("--") || !raw.contains("Content-Disposition")) {
+                return WorkerContent(listOf(WorkerModule("worker.js", "application/javascript", raw)), isModule = false)
+            }
+            val boundary = lead.substringBefore('\n').trim().trimEnd('\r').removePrefix("--")
+            val modules = parseParts(raw, boundary)
+            return if (modules.isEmpty())
+                WorkerContent(listOf(WorkerModule("worker.js", "application/javascript", raw)), isModule = false)
+            else WorkerContent(modules, isModule = true)
+        }
+
+        private fun parseParts(raw: String, boundary: String): List<WorkerModule> {
+            val out = mutableListOf<WorkerModule>()
+            for (chunk in raw.split("--$boundary")) {
+                val part = chunk.trim('\r', '\n')
+                if (part.isEmpty() || part == "--") continue
+                var sep = part.indexOf("\r\n\r\n"); var sepLen = 4
+                if (sep < 0) { sep = part.indexOf("\n\n"); sepLen = 2 }
+                if (sep < 0) continue
+                val headers = part.substring(0, sep)
+                val body = part.substring(sep + sepLen)
+                val name = headerValue(headers, "name") ?: headerValue(headers, "filename") ?: "module"
+                val type = contentTypeHeader(headers) ?: "application/javascript+module"
+                out.add(WorkerModule(name, type, body))
+            }
+            return out
+        }
+
+        private fun headerValue(headers: String, key: String): String? {
+            val marker = "$key=\""
+            val i = headers.indexOf(marker)
+            if (i < 0) return null
+            val rest = headers.substring(i + marker.length)
+            val end = rest.indexOf('"')
+            return if (end < 0) null else rest.substring(0, end)
+        }
+
+        private fun contentTypeHeader(headers: String): String? =
+            headers.lineSequence()
+                .firstOrNull { it.lowercase().startsWith("content-type:") }
+                ?.substringAfter(':')?.trim()
+    }
+}
+
+/** PUT 脚本上传的 metadata part（新建 / 原地编辑整体替换共用）。 */
+@Serializable
+data class WorkerDeployMetadata(
+    @SerialName("main_module") val mainModule: String? = null,
+    @SerialName("body_part") val bodyPart: String? = null,
+    @SerialName("compatibility_date") val compatibilityDate: String? = null,
+    @SerialName("compatibility_flags") val compatibilityFlags: List<String>? = null,
+    val bindings: List<WorkerBindingInput> = emptyList(),
+)
 
 // MARK: - 绑定与设置
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/AnalyticsRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/AnalyticsRepository.kt
@@ -1,12 +1,31 @@
 package jiamin.chen.orangecloud.data.repository
 
 import jiamin.chen.orangecloud.core.network.CfApiClient
+import jiamin.chen.orangecloud.data.model.AccountUsage
+import jiamin.chen.orangecloud.data.model.AccountUsageData
+import jiamin.chen.orangecloud.data.model.AccountUsageQueries
+import jiamin.chen.orangecloud.data.model.AccountUsageVariables
 import jiamin.chen.orangecloud.data.model.AnalyticsGroup
 import jiamin.chen.orangecloud.data.model.AnalyticsQueries
 import jiamin.chen.orangecloud.data.model.AnalyticsTimeRange
+import jiamin.chen.orangecloud.data.model.D1Usage
+import jiamin.chen.orangecloud.data.model.D1UsageData
+import jiamin.chen.orangecloud.data.model.D1UsageGroup
+import jiamin.chen.orangecloud.data.model.D1UsageVariables
+import jiamin.chen.orangecloud.data.model.KVOpsGroup
+import jiamin.chen.orangecloud.data.model.KVUsage
+import jiamin.chen.orangecloud.data.model.KVUsageData
+import jiamin.chen.orangecloud.data.model.R2_CLASS_B_ACTIONS
+import jiamin.chen.orangecloud.data.model.R2UsageData
+import jiamin.chen.orangecloud.data.model.R2UsageVariables
 import jiamin.chen.orangecloud.data.model.TrafficDataPoint
+import jiamin.chen.orangecloud.data.model.WorkersCpuData
 import jiamin.chen.orangecloud.data.model.ZoneAnalyticsData
 import jiamin.chen.orangecloud.data.model.ZoneAnalyticsVariables
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -97,6 +116,127 @@ class AnalyticsRepository @Inject constructor(
         )
         val zone = data.viewer.zones.firstOrNull() ?: return emptyList()
         return zone.groups.mapNotNull { it.toDataPoint() }
+    }
+
+    // MARK: - 账号用量（Dashboard 用量模块，对应 iOS AnalyticsService account usage 系列）
+
+    /** Time 标量窗口（Workers / R2）：periodStart 传计费周期起点，null 回退自然月（UTC）。 */
+    private fun usageVariables(accountId: String, periodStart: Instant?): AccountUsageVariables {
+        val now = Instant.now().truncatedTo(ChronoUnit.SECONDS)
+        val todayStart = now.atZone(ZoneOffset.UTC).toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant()
+        val monthStart = periodStart
+            ?: now.atZone(ZoneOffset.UTC).toLocalDate().withDayOfMonth(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+        val iso = DateTimeFormatter.ISO_INSTANT
+        return AccountUsageVariables(accountId, iso.format(monthStart), iso.format(todayStart), iso.format(now))
+    }
+
+    /** Date 标量窗口（D1 / KV）：yyyy-MM-dd（UTC）。 */
+    private fun dateVariables(accountId: String, periodStart: Instant?): D1UsageVariables {
+        val today = Instant.now().atZone(ZoneOffset.UTC).toLocalDate()
+        val monthStart = periodStart?.atZone(ZoneOffset.UTC)?.toLocalDate() ?: today.withDayOfMonth(1)
+        val day = DateTimeFormatter.ISO_LOCAL_DATE
+        return D1UsageVariables(accountId, monthStart.format(day), today.format(day), today.format(day))
+    }
+
+    /** Workers 账号用量（今日/周期请求、月度错误、单次 CPU 分位）。authz 错误由 api.graphQL 抛出交调用方降级。 */
+    suspend fun accountWorkersUsage(accountId: String, periodStart: Instant?): AccountUsage {
+        val data = api.graphQL<AccountUsageData, AccountUsageVariables>(
+            AccountUsageQueries.WORKERS, usageVariables(accountId, periodStart),
+        )
+        val node = data.viewer.accounts.firstOrNull() ?: error("no account")
+        val q = node.month?.firstOrNull()?.quantiles
+        return AccountUsage(
+            workersRequestsToday = node.today.orEmpty().sumOf { it.sum?.requests ?: 0L },
+            workersRequestsMonth = node.month.orEmpty().sumOf { it.sum?.requests ?: 0L },
+            workersErrorsMonth = node.month.orEmpty().sumOf { it.sum?.errors ?: 0L },
+            cpuP50Us = q?.cpuTimeP50,
+            cpuP99Us = q?.cpuTimeP99,
+        )
+    }
+
+    /** Workers CPU 总耗时（周期/今日，微秒）。schema 不支持时抛错由调用方降级。 */
+    suspend fun workersCpuTotals(accountId: String, periodStart: Instant?): Pair<Double, Double> {
+        val data = api.graphQL<WorkersCpuData, AccountUsageVariables>(
+            AccountUsageQueries.WORKERS_CPU, usageVariables(accountId, periodStart),
+        )
+        val node = data.viewer.accounts.firstOrNull() ?: return 0.0 to 0.0
+        val month = node.month.orEmpty().sumOf { it.sum?.cpuTimeUs ?: 0.0 }
+        val today = node.today.orEmpty().sumOf { it.sum?.cpuTimeUs ?: 0.0 }
+        return month to today
+    }
+
+    /** R2 账号级用量：A/B 类操作合计 + 当前存储/对象数。读类计 Class B，其余 Class A。 */
+    data class R2Totals(val classA: Long, val classB: Long, val storageBytes: Long, val objectCount: Long)
+
+    suspend fun accountR2Usage(accountId: String, periodStart: Instant?): R2Totals {
+        val v = usageVariables(accountId, periodStart)
+        val data = api.graphQL<R2UsageData, R2UsageVariables>(
+            AccountUsageQueries.R2, R2UsageVariables(v.accountTag, v.monthStart, v.todayStart, v.now),
+        )
+        val account = data.viewer?.accounts?.firstOrNull() ?: return R2Totals(0, 0, 0, 0)
+        var classA = 0L
+        var classB = 0L
+        account.r2Ops?.forEach { g ->
+            val action = g.dimensions?.actionType ?: return@forEach
+            val count = g.sum?.requests ?: 0L
+            if (action in R2_CLASS_B_ACTIONS) classB += count else classA += count
+        }
+        var storage = 0L
+        var objects = 0L
+        account.r2Storage?.forEach { g ->
+            storage += (g.max?.payloadSize ?: 0L) + (g.max?.metadataSize ?: 0L)
+            objects += (g.max?.objectCount ?: 0).toLong()
+        }
+        return R2Totals(classA, classB, storage, objects)
+    }
+
+    /** D1 行读/写（今日 + 周期）。 */
+    suspend fun d1Usage(accountId: String, periodStart: Instant?): D1Usage {
+        val data = api.graphQL<D1UsageData, D1UsageVariables>(
+            AccountUsageQueries.D1, dateVariables(accountId, periodStart),
+        )
+        val node = data.viewer.accounts.firstOrNull() ?: error("no account")
+        fun totals(groups: List<D1UsageGroup>?): Pair<Long, Long> {
+            var read = 0L
+            var written = 0L
+            groups?.forEach { read += it.sum?.rowsRead ?: 0L; written += it.sum?.rowsWritten ?: 0L }
+            return read to written
+        }
+        val (periodRead, periodWritten) = totals(node.period)
+        val (todayRead, todayWritten) = totals(node.today)
+        return D1Usage(todayRead, todayWritten, periodRead, periodWritten)
+    }
+
+    /** KV 读/写（今日 + 周期；delete/list 不计入主额度行）。 */
+    suspend fun kvUsage(accountId: String, periodStart: Instant?): KVUsage {
+        val data = api.graphQL<KVUsageData, D1UsageVariables>(
+            AccountUsageQueries.KV_OPERATIONS, dateVariables(accountId, periodStart),
+        )
+        val node = data.viewer.accounts.firstOrNull() ?: error("no account")
+        fun totals(groups: List<KVOpsGroup>?): Pair<Long, Long> {
+            var reads = 0L
+            var writes = 0L
+            groups?.forEach {
+                val count = it.sum?.requests ?: 0L
+                when (it.dimensions?.actionType) {
+                    "read" -> reads += count
+                    "write" -> writes += count
+                }
+            }
+            return reads to writes
+        }
+        val (periodReads, periodWrites) = totals(node.period)
+        val (todayReads, todayWrites) = totals(node.today)
+        return KVUsage(todayReads, todayWrites, periodReads, periodWrites)
+    }
+
+    /** KV 当前存储（各 namespace 当日 max byteCount 求和）。 */
+    suspend fun kvStorageBytes(accountId: String): Long {
+        val data = api.graphQL<KVUsageData, D1UsageVariables>(
+            AccountUsageQueries.KV_STORAGE, dateVariables(accountId, null),
+        )
+        val node = data.viewer.accounts.firstOrNull() ?: return 0L
+        return node.storage.orEmpty().sumOf { it.max?.byteCount ?: 0L }
     }
 }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/PagesRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/PagesRepository.kt
@@ -104,6 +104,10 @@ class PagesRepository @Inject constructor(
     suspend fun rollbackDeployment(accountId: String, projectName: String, deploymentId: String): PagesDeployment =
         api.post("accounts/$accountId/pages/projects/$projectName/deployments/$deploymentId/rollback", PagesEmptyBody())
 
+    /** 删除某次部署（page.write）。当前生产部署不可删，Cloudflare 会拒绝。不可恢复。 */
+    suspend fun deleteDeployment(accountId: String, projectName: String, deploymentId: String) =
+        api.delete("accounts/$accountId/pages/projects/$projectName/deployments/$deploymentId")
+
     // MARK: - 直接上传部署（Direct Upload）
     // 流程对齐 wrangler：取上传 JWT → check-missing 问缺哪些资源 → 缺的 base64 分批 upload
     // → upsert-hashes 关联全部哈希 → 带 manifest（路径→blake3 哈希）创建部署。资源端点用 JWT 鉴权。

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/StorageRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/StorageRepository.kt
@@ -7,10 +7,12 @@ import jiamin.chen.orangecloud.data.model.D1CreateRequest
 import jiamin.chen.orangecloud.data.model.D1Database
 import jiamin.chen.orangecloud.data.model.D1QueryRequest
 import jiamin.chen.orangecloud.data.model.D1QueryResult
+import jiamin.chen.orangecloud.data.model.KVCreateRequest
 import jiamin.chen.orangecloud.data.model.KVKey
 import jiamin.chen.orangecloud.data.model.KVNamespace
 import jiamin.chen.orangecloud.data.model.R2Bucket
 import jiamin.chen.orangecloud.data.model.R2BucketList
+import jiamin.chen.orangecloud.data.model.R2CreateRequest
 import jiamin.chen.orangecloud.data.model.R2BucketUsage
 import jiamin.chen.orangecloud.data.model.R2CorsPolicy
 import jiamin.chen.orangecloud.data.model.R2CustomDomain
@@ -44,6 +46,14 @@ class StorageRepository @Inject constructor(
 
     suspend fun listBuckets(accountId: String): List<R2Bucket> =
         api.get<R2BucketList>("accounts/$accountId/r2/buckets", listOf("per_page" to "100")).buckets
+
+    /** 创建 R2 桶（workers-r2-storage.write）。名称须小写字母/数字/连字符，3–63 位。 */
+    suspend fun createBucket(accountId: String, name: String): R2Bucket =
+        api.post("accounts/$accountId/r2/buckets", R2CreateRequest(name))
+
+    /** 删除 R2 桶（workers-r2-storage.write）。Cloudflare 要求桶必须为空，否则报错。不可恢复。 */
+    suspend fun deleteBucket(accountId: String, name: String) =
+        api.delete("accounts/$accountId/r2/buckets/$name")
 
     /**
      * 对象列表一页。传 delimiter=/ 让服务端把子前缀折叠成「文件夹」，prefix 为当前所在文件夹；
@@ -245,6 +255,14 @@ class StorageRepository @Inject constructor(
         }
         return all
     }
+
+    /** 创建 KV 命名空间（workers-kv-storage.write）。POST 返回新建的命名空间。 */
+    suspend fun createNamespace(accountId: String, title: String): KVNamespace =
+        api.post("accounts/$accountId/storage/kv/namespaces", KVCreateRequest(title))
+
+    /** 删除 KV 命名空间（workers-kv-storage.write）。连同全部键值，不可恢复。 */
+    suspend fun deleteNamespace(accountId: String, namespaceId: String) =
+        api.delete("accounts/$accountId/storage/kv/namespaces/$namespaceId")
 
     /** 键列表（游标分页，一次一页）。cursor 为空串表示已到末尾。 */
     suspend fun listKeys(accountId: String, namespaceId: String, cursor: String?): Pair<List<KVKey>, String?> {

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/WorkerRepository.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/WorkerRepository.kt
@@ -5,6 +5,10 @@ import jiamin.chen.orangecloud.data.local.WorkerDao
 import jiamin.chen.orangecloud.data.local.toEntity
 import jiamin.chen.orangecloud.data.local.toWorker
 import jiamin.chen.orangecloud.data.model.WorkerBindingInput
+import jiamin.chen.orangecloud.data.model.WorkerContent
+import jiamin.chen.orangecloud.data.model.WorkerDeployMetadata
+import jiamin.chen.orangecloud.data.model.WorkerDeployment
+import jiamin.chen.orangecloud.data.model.WorkerDeploymentsResult
 import jiamin.chen.orangecloud.data.model.WorkerCustomDomain
 import jiamin.chen.orangecloud.data.model.WorkerCustomDomainInput
 import jiamin.chen.orangecloud.data.model.WorkerRoute
@@ -45,8 +49,7 @@ class WorkerRepository @Inject constructor(
 
     /**
      * 新建 / 覆盖一个 module Worker（粘贴的 JS 代码）。PUT 脚本 = multipart（metadata + worker.js 模块）。
-     * 对应 iOS WorkerService.deployScript。注意：读取现有源码端点 /content 在 OAuth 下被封（cf-10405），
-     * 故只支持「提供新代码」创建/覆盖，不预填现有代码。成功后刷新 Room 列表。
+     * 对应 iOS WorkerService.deployScript。成功后刷新 Room 列表。
      */
     suspend fun deployScript(accountId: String, name: String, code: String, compatibilityDate: String) {
         val metadata = """{"main_module":"worker.js","compatibility_date":"$compatibilityDate","bindings":[]}"""
@@ -56,6 +59,58 @@ class WorkerRepository @Inject constructor(
         )
         refreshWorkers(accountId)
     }
+
+    /**
+     * 读现有源码用于原地编辑预填。必须走 /content/v2：v1 /content 对 OAuth 认证方案返回 cf=10405，
+     * v2 与裸 GET 才放行（真机实测 2026-07-14，issue #55）。响应为 multipart/form-data（module）或裸 JS（service worker）。
+     */
+    suspend fun content(accountId: String, scriptName: String): WorkerContent {
+        val bytes = api.getRaw("accounts/$accountId/workers/scripts/$scriptName/content/v2")
+        return WorkerContent.parse(bytes)
+    }
+
+    /**
+     * 原地编辑：只替换脚本正文，现有绑定按名 inherit 保留（连同读不到值的密钥），兼容性日期/标志沿用旧值。
+     * 带 ?bindings_inherit=strict，缺绑定时报错而非静默丢弃。对应 iOS WorkerUploadViewModel.replace。
+     */
+    suspend fun replaceScript(accountId: String, name: String, code: String, isModule: Boolean) {
+        val s = settings(accountId, name)
+        val moduleName = "worker.js"
+        val metadata = WorkerDeployMetadata(
+            mainModule = if (isModule) moduleName else null,
+            bodyPart = if (isModule) null else moduleName,
+            compatibilityDate = s.compatibilityDate ?: java.time.LocalDate.now(java.time.ZoneOffset.UTC).toString(),
+            compatibilityFlags = s.compatibilityFlags,
+            bindings = s.inheritedBindings(),
+        )
+        api.putMultipartFile<kotlinx.serialization.json.JsonElement>(
+            "accounts/$accountId/workers/scripts/$name",
+            json.encodeToString(WorkerDeployMetadata.serializer(), metadata),
+            moduleName, code,
+            if (isModule) "application/javascript+module" else "application/javascript",
+            query = listOf("bindings_inherit" to "strict"),
+        )
+        refreshWorkers(accountId)
+    }
+
+    /**
+     * 删除整个 Worker 脚本（连同其部署、路由绑定）。OAuth 下放行（真机实测 issue #55）。
+     * 需 workers-scripts.write。不可撤销。成功后刷新 Room 列表。
+     */
+    suspend fun deleteScript(accountId: String, name: String) {
+        api.delete("accounts/$accountId/workers/scripts/$name")
+        refreshWorkers(accountId)
+    }
+
+    // MARK: - 部署历史
+
+    /** 部署列表（result.deployments，首项为活跃部署）。 */
+    suspend fun listDeployments(accountId: String, scriptName: String): List<WorkerDeployment> =
+        api.get<WorkerDeploymentsResult>("accounts/$accountId/workers/scripts/$scriptName/deployments").deployments
+
+    /** 删除某次部署（page.write 不需要，需 workers-scripts.write）。活跃部署 Cloudflare 会拒绝删除。 */
+    suspend fun deleteDeployment(accountId: String, scriptName: String, deploymentId: String) =
+        api.delete("accounts/$accountId/workers/scripts/$scriptName/deployments/$deploymentId")
 
     // MARK: - 设置（绑定 / 变量）
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardScreen.kt
@@ -136,6 +136,22 @@ fun DashboardScreen(
                     }
                 }
 
+                // 用量模块（账号级 Workers/R2/D1/KV 用量，环形仪表 + 点开明细）
+                Spacer(Modifier.height(26.dp))
+                DashboardUsageSection(
+                    usage = state.usage,
+                    plan = state.usagePlan,
+                    loading = state.usageLoading,
+                    loadFailed = state.usageLoadFailed,
+                    hasScope = state.hasAccountAnalytics,
+                    unavailable = state.accountAnalyticsUnavailable,
+                    onSky = onSky,
+                    onRetry = { viewModel.loadUsage(force = true) },
+                    onSetWorkersPaid = { viewModel.setUsageWorkersPaid(it) },
+                    onSetR2Paid = { viewModel.setUsageR2Paid(it) },
+                    onSetBillingDay = { viewModel.setUsageBillingDay(it) },
+                )
+
                 // 最近访问
                 Row(
                     Modifier.fillMaxWidth().padding(start = 24.dp, end = 12.dp, top = 26.dp, bottom = 10.dp),

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardUsage.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardUsage.kt
@@ -1,0 +1,542 @@
+package jiamin.chen.orangecloud.ui.dashboard
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.QueryStats
+import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jiamin.chen.orangecloud.R
+import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.core.system.UsagePlanPrefs
+import jiamin.chen.orangecloud.data.model.AccountUsage
+import jiamin.chen.orangecloud.ui.storage.formatBytes
+import kotlin.math.abs
+
+private val WarnAmber = Color(0xFFF5A623)
+private val WarnRed = Color(0xFFE5484D)
+
+// MARK: - 数据
+
+/** 一条用量指标：标签 + 值 + 可选额度文案与消耗比例（ratio 为 null 表示无额度环/条）。 */
+private data class UsageMetric(
+    val label: String,
+    val valueText: String,
+    val quotaText: String?,
+    val ratio: Double?,
+)
+
+/** 一个服务瓦片：展示消耗比例最高的「瓶颈」指标。 */
+private data class UsageTile(
+    val service: String,
+    val context: String,
+    val valueText: String,
+    val quotaText: String?,
+    val ratio: Double?,
+    val metrics: List<UsageMetric>,
+)
+
+// MARK: - Section 入口
+
+@Composable
+fun DashboardUsageSection(
+    usage: AccountUsage?,
+    plan: UsagePlanPrefs,
+    loading: Boolean,
+    loadFailed: Boolean,
+    hasScope: Boolean,
+    unavailable: Boolean,
+    onSky: Color,
+    onRetry: () -> Unit,
+    onSetWorkersPaid: (Boolean) -> Unit,
+    onSetR2Paid: (Boolean) -> Unit,
+    onSetBillingDay: (Int) -> Unit,
+) {
+    val cs = MaterialTheme.colorScheme
+    Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 8.dp, top = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                stringResource(R.string.usage_title),
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Medium,
+                color = onSky,
+                modifier = Modifier.weight(1f),
+            )
+            if (hasScope) PlanMenu(plan, onSetWorkersPaid, onSetR2Paid, onSetBillingDay)
+        }
+
+        when {
+            !hasScope -> InfoCard(Icons.Outlined.Lock, stringResource(R.string.usage_locked), null)
+            usage != null -> UsageGrid(usage, plan)
+            unavailable -> InfoCard(
+                Icons.Outlined.QueryStats,
+                stringResource(R.string.usage_unavailable_title),
+                stringResource(R.string.usage_unavailable_body),
+            )
+            loadFailed -> Surface(
+                color = cs.surfaceContainerLow,
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier.fillMaxWidth().clickable(onClick = onRetry),
+            ) {
+                Text(
+                    stringResource(R.string.usage_failed),
+                    fontSize = 13.sp,
+                    color = cs.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 18.dp),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                )
+            }
+            else -> UsageSkeleton()
+        }
+    }
+}
+
+@Composable
+private fun PlanMenu(
+    plan: UsagePlanPrefs,
+    onSetWorkersPaid: (Boolean) -> Unit,
+    onSetR2Paid: (Boolean) -> Unit,
+    onSetBillingDay: (Int) -> Unit,
+) {
+    val cs = MaterialTheme.colorScheme
+    var open by remember { mutableStateOf(false) }
+    var showDayPicker by remember { mutableStateOf(false) }
+    val summary = "W ${planWord(plan.workersPaid)} · R2 ${planWord(plan.r2Paid)}"
+    Box {
+        Row(
+            Modifier.clickable { open = true }.padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Outlined.Tune, contentDescription = null, tint = cs.primary, modifier = Modifier.size(15.dp))
+            Spacer(Modifier.width(6.dp))
+            Text(summary, fontSize = 13.sp, fontWeight = FontWeight.Medium, color = cs.primary)
+        }
+        DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+            MenuSectionLabel(stringResource(R.string.usage_plan_workers))
+            PlanChoice(FREE, !plan.workersPaid) { onSetWorkersPaid(false); open = false }
+            PlanChoice(PAID, plan.workersPaid) { onSetWorkersPaid(true); open = false }
+            HorizontalDivider()
+            MenuSectionLabel(stringResource(R.string.usage_plan_r2))
+            PlanChoice(FREE, !plan.r2Paid) { onSetR2Paid(false); open = false }
+            PlanChoice(PAID, plan.r2Paid) { onSetR2Paid(true); open = false }
+            HorizontalDivider()
+            MenuSectionLabel(stringResource(R.string.usage_billing_day))
+            DropdownMenuItem(
+                text = { Text(billingLabel(plan.billingDay), color = cs.onSurface) },
+                trailingIcon = { Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = cs.onSurfaceVariant, modifier = Modifier.size(18.dp)) },
+                onClick = { open = false; showDayPicker = true },
+            )
+        }
+    }
+    if (showDayPicker) {
+        BillingDayDialog(
+            current = plan.billingDay,
+            onPick = { onSetBillingDay(it); showDayPicker = false },
+            onDismiss = { showDayPicker = false },
+        )
+    }
+}
+
+@Composable
+private fun billingLabel(day: Int): String =
+    if (day == 1) stringResource(R.string.usage_billing_natural) else stringResource(R.string.usage_billing_day_n, day)
+
+@Composable
+private fun BillingDayDialog(current: Int, onPick: (Int) -> Unit, onDismiss: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.usage_billing_day)) },
+        text = {
+            Column(Modifier.fillMaxWidth().heightIn(max = 360.dp).verticalScroll(rememberScrollState())) {
+                (1..28).forEach { day ->
+                    Row(
+                        Modifier.fillMaxWidth().clickable { onPick(day) }.padding(vertical = 12.dp, horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            billingLabel(day),
+                            modifier = Modifier.weight(1f),
+                            fontSize = 15.sp,
+                            color = if (day == current) cs.primary else cs.onSurface,
+                            fontWeight = if (day == current) FontWeight.SemiBold else FontWeight.Normal,
+                        )
+                        if (day == current) Icon(Icons.Outlined.Check, contentDescription = null, tint = cs.primary, modifier = Modifier.size(18.dp))
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.common_cancel)) } },
+    )
+}
+
+@Composable
+private fun MenuSectionLabel(text: String) {
+    Text(
+        text,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 12.dp, top = 8.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun PlanChoice(label: String, selected: Boolean, onClick: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    DropdownMenuItem(
+        text = { Text(label, color = if (selected) cs.primary else cs.onSurface, fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal) },
+        onClick = onClick,
+    )
+}
+
+// MARK: - 宫格
+
+@Composable
+private fun UsageGrid(usage: AccountUsage, plan: UsagePlanPrefs) {
+    val tiles = buildTiles(usage, plan)
+    var detail by remember { mutableStateOf<UsageTile?>(null) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        tiles.chunked(2).forEach { rowTiles ->
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                rowTiles.forEach { tile ->
+                    UsageTileCard(tile, Modifier.weight(1f)) { detail = tile }
+                }
+                if (rowTiles.size == 1) Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+
+    detail?.let { tile -> UsageDetailSheet(tile) { detail = null } }
+}
+
+@Composable
+private fun UsageTileCard(tile: UsageTile, modifier: Modifier, onClick: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    Surface(
+        color = cs.surfaceContainerLow,
+        shape = RoundedCornerShape(20.dp),
+        modifier = modifier.clickable(onClick = onClick),
+    ) {
+        Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                "${tile.service} · ${tile.context}",
+                fontSize = 12.sp,
+                color = cs.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+                tile.ratio?.let { UsageRing(it, Modifier.size(34.dp)) }
+                Column {
+                    Text(
+                        tile.valueText,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = cs.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    tile.quotaText?.let {
+                        Text(it, fontSize = 11.sp, color = cs.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** 额度环：随消耗比例从品牌橙渐变到警示红。 */
+@Composable
+private fun UsageRing(ratio: Double, modifier: Modifier) {
+    val track = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    val color = ringColor(ratio)
+    Canvas(modifier) {
+        val stroke = 4.dp.toPx()
+        val inset = stroke / 2
+        val arcSize = Size(size.width - stroke, size.height - stroke)
+        drawArc(
+            color = track, startAngle = 0f, sweepAngle = 360f, useCenter = false,
+            topLeft = Offset(inset, inset), size = arcSize, style = Stroke(stroke),
+        )
+        val sweep = (ratio.coerceIn(0.02, 1.0) * 360.0).toFloat()
+        drawArc(
+            color = color, startAngle = -90f, sweepAngle = sweep, useCenter = false,
+            topLeft = Offset(inset, inset), size = arcSize, style = Stroke(stroke, cap = StrokeCap.Round),
+        )
+    }
+}
+
+// MARK: - 明细底部弹窗
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UsageDetailSheet(tile: UsageTile, onDismiss: () -> Unit) {
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)) {
+        Column(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp).padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(tile.service, fontSize = 20.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+            tile.metrics.forEach { UsageDetailRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun UsageDetailRow(metric: UsageMetric) {
+    val cs = MaterialTheme.colorScheme
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(metric.label, fontSize = 14.sp, color = cs.onSurface, modifier = Modifier.weight(1f))
+            Text(
+                metric.valueText + (metric.quotaText?.let { " $it" } ?: ""),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily.Monospace,
+                color = cs.onSurfaceVariant,
+            )
+        }
+        metric.ratio?.let { r ->
+            LinearProgressIndicator(
+                progress = { r.coerceIn(0.0, 1.0).toFloat() },
+                color = ringColor(r),
+                trackColor = cs.onSurface.copy(alpha = 0.10f),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+// MARK: - 骨架
+
+@Composable
+private fun UsageSkeleton() {
+    val cs = MaterialTheme.colorScheme
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        repeat(2) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                repeat(2) {
+                    Surface(
+                        color = cs.surfaceContainerLow,
+                        shape = RoundedCornerShape(20.dp),
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            Box(Modifier.size(width = 80.dp, height = 10.dp).skeleton(cs))
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+                                Canvas(Modifier.size(34.dp)) {
+                                    drawArc(
+                                        color = cs.onSurface.copy(alpha = 0.10f), startAngle = 0f, sweepAngle = 360f,
+                                        useCenter = false, style = Stroke(4.dp.toPx()),
+                                        topLeft = Offset(2.dp.toPx(), 2.dp.toPx()),
+                                        size = Size(size.width - 4.dp.toPx(), size.height - 4.dp.toPx()),
+                                    )
+                                }
+                                Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                                    Box(Modifier.size(width = 56.dp, height = 13.dp).skeleton(cs))
+                                    Box(Modifier.size(width = 40.dp, height = 9.dp).skeleton(cs))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun Modifier.skeleton(cs: androidx.compose.material3.ColorScheme): Modifier =
+    this.background(cs.onSurface.copy(alpha = 0.08f), RoundedCornerShape(4.dp))
+
+// MARK: - 指标构建（对齐 iOS workersTile/r2Tile/d1Tile/kvTile）
+
+@Composable
+private fun buildTiles(usage: AccountUsage, plan: UsagePlanPrefs): List<UsageTile> {
+    val today = stringResource(R.string.usage_today)
+    val periodLabel = if (plan.billingDay != 1) stringResource(R.string.usage_period_cycle) else stringResource(R.string.usage_period_month)
+    val wLabel = if (plan.workersPaid) periodLabel else today
+
+    // 预解析所有可能用到的 context 文案（分支只挑数据，不改 stringResource 调用集）
+    val ctxRequests = stringResource(R.string.usage_ctx_requests, wLabel)
+    val ctxCpu = stringResource(R.string.usage_ctx_cpu, wLabel)
+    val ctxCpuToday = stringResource(R.string.usage_ctx_cpu, today)
+    val ctxR2A = stringResource(R.string.usage_ctx_r2a, periodLabel)
+    val ctxR2B = stringResource(R.string.usage_ctx_r2b, periodLabel)
+    val ctxStorage = stringResource(R.string.usage_ctx_storage)
+    val ctxRowsRead = stringResource(R.string.usage_ctx_rows_read, wLabel)
+    val ctxRowsWrite = stringResource(R.string.usage_ctx_rows_write, wLabel)
+    val ctxReads = stringResource(R.string.usage_ctx_reads, wLabel)
+    val ctxWrites = stringResource(R.string.usage_ctx_writes, wLabel)
+
+    val tiles = mutableListOf<UsageTile>()
+
+    // Workers
+    run {
+        val metrics = mutableListOf<UsageMetric>()
+        val reqs = if (plan.workersPaid) usage.workersRequestsMonth else usage.workersRequestsToday
+        val reqQuota = if (plan.workersPaid) 10_000_000L else 100_000L
+        metrics += UsageMetric(ctxRequests, compact(reqs), "/ ${compact(reqQuota)}", ratio(reqs, reqQuota))
+        if (plan.workersPaid && usage.cpuTimeMonthUs != null) {
+            val ms = (usage.cpuTimeMonthUs / 1000).toLong()
+            metrics += UsageMetric(ctxCpu, "${compact(ms)} ms", "/ 30M ms", ratio(ms, 30_000_000L))
+        } else if (usage.cpuTimeTodayUs != null) {
+            val ms = (usage.cpuTimeTodayUs / 1000).toLong()
+            metrics += UsageMetric(ctxCpuToday, "${compact(ms)} ms", null, null)
+        }
+        tiles += tileOf("Workers", metrics)
+    }
+
+    // R2
+    run {
+        val metrics = mutableListOf(
+            UsageMetric(ctxR2A, compact(usage.r2ClassAMonth), "/ 1M", ratio(usage.r2ClassAMonth, 1_000_000L)),
+            UsageMetric(ctxR2B, compact(usage.r2ClassBMonth), "/ 10M", ratio(usage.r2ClassBMonth, 10_000_000L)),
+        )
+        metrics += if (plan.r2Paid) {
+            UsageMetric(ctxStorage, formatBytes(usage.r2StorageBytes), null, null)
+        } else {
+            UsageMetric(ctxStorage, formatBytes(usage.r2StorageBytes), "/ 10 GB", ratio(usage.r2StorageBytes, 10_000_000_000L))
+        }
+        tiles += tileOf("R2", metrics)
+    }
+
+    // D1
+    if (usage.d1Usage != null || usage.d1StorageBytes != null) {
+        val metrics = mutableListOf<UsageMetric>()
+        usage.d1Usage?.let { d1 ->
+            val reads = if (plan.workersPaid) d1.rowsReadPeriod else d1.rowsReadToday
+            val readQuota = if (plan.workersPaid) 25_000_000_000L else 5_000_000L
+            val writes = if (plan.workersPaid) d1.rowsWrittenPeriod else d1.rowsWrittenToday
+            val writeQuota = if (plan.workersPaid) 50_000_000L else 100_000L
+            metrics += UsageMetric(ctxRowsRead, compact(reads), "/ ${compact(readQuota)}", ratio(reads, readQuota))
+            metrics += UsageMetric(ctxRowsWrite, compact(writes), "/ ${compact(writeQuota)}", ratio(writes, writeQuota))
+        }
+        usage.d1StorageBytes?.let { storage ->
+            metrics += UsageMetric(ctxStorage, formatBytes(storage), "/ 5 GB", ratio(storage, 5_000_000_000L))
+        }
+        if (metrics.isNotEmpty()) tiles += tileOf("D1", metrics)
+    }
+
+    // KV
+    if (usage.kvUsage != null || usage.kvStorageBytes != null) {
+        val metrics = mutableListOf<UsageMetric>()
+        usage.kvUsage?.let { kv ->
+            val reads = if (plan.workersPaid) kv.readsPeriod else kv.readsToday
+            val readQuota = if (plan.workersPaid) 10_000_000L else 100_000L
+            val writes = if (plan.workersPaid) kv.writesPeriod else kv.writesToday
+            val writeQuota = if (plan.workersPaid) 1_000_000L else 1_000L
+            metrics += UsageMetric(ctxReads, compact(reads), "/ ${compact(readQuota)}", ratio(reads, readQuota))
+            metrics += UsageMetric(ctxWrites, compact(writes), "/ ${compact(writeQuota)}", ratio(writes, writeQuota))
+        }
+        usage.kvStorageBytes?.let { storage ->
+            metrics += UsageMetric(ctxStorage, formatBytes(storage), "/ 1 GB", ratio(storage, 1_000_000_000L))
+        }
+        if (metrics.isNotEmpty()) tiles += tileOf("KV", metrics)
+    }
+
+    return tiles
+}
+
+/** 瓦片取「瓶颈」指标（消耗比例最高的那条），无额度指标则取首条。 */
+private fun tileOf(service: String, metrics: List<UsageMetric>): UsageTile {
+    val top = metrics.filter { it.ratio != null }.maxByOrNull { it.ratio!! } ?: metrics.first()
+    return UsageTile(service, top.label, top.valueText, top.quotaText, top.ratio, metrics)
+}
+
+private fun ringColor(ratio: Double): Color = when {
+    ratio >= 0.9 -> WarnRed
+    ratio >= 0.7 -> WarnAmber
+    else -> OcOrange
+}
+
+private fun ratio(used: Long, quota: Long): Double = if (quota > 0) used.toDouble() / quota else 0.0
+
+private fun compact(n: Long): String {
+    val a = abs(n)
+    return when {
+        a >= 1_000_000_000 -> trimDec(n / 1e9) + "B"
+        a >= 1_000_000 -> trimDec(n / 1e6) + "M"
+        a >= 1_000 -> trimDec(n / 1e3) + "K"
+        else -> n.toString()
+    }
+}
+
+private fun trimDec(v: Double): String {
+    val s = "%.1f".format(v)
+    return if (s.endsWith(".0")) s.dropLast(2) else s
+}
+
+@Composable
+private fun InfoCard(icon: androidx.compose.ui.graphics.vector.ImageVector, title: String, body: String?) {
+    val cs = MaterialTheme.colorScheme
+    Surface(color = cs.surfaceContainerLow, shape = RoundedCornerShape(16.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(
+            Modifier.fillMaxWidth().padding(vertical = 18.dp, horizontal = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Icon(icon, contentDescription = null, tint = cs.onSurfaceVariant, modifier = Modifier.size(22.dp))
+            Text(title, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = cs.onSurface, textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+            body?.let {
+                Text(it, fontSize = 12.sp, color = cs.onSurfaceVariant, textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+            }
+        }
+    }
+}
+
+private const val FREE = "Free"
+private const val PAID = "Paid"
+private fun planWord(paid: Boolean): String = if (paid) PAID else FREE

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardViewModel.kt
@@ -6,9 +6,16 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import jiamin.chen.orangecloud.core.auth.AuthRepository
 import jiamin.chen.orangecloud.core.auth.AuthSessionMeta
 import jiamin.chen.orangecloud.core.auth.Scopes
+import jiamin.chen.orangecloud.core.network.ApiError
+import jiamin.chen.orangecloud.core.system.AppPrefs
+import jiamin.chen.orangecloud.core.system.UsagePlanPrefs
 import jiamin.chen.orangecloud.data.model.Account
+import jiamin.chen.orangecloud.data.model.AccountUsage
 import jiamin.chen.orangecloud.data.model.AnalyticsTimeRange
+import jiamin.chen.orangecloud.data.model.BillingCycle
 import jiamin.chen.orangecloud.data.model.Zone
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import jiamin.chen.orangecloud.data.repository.AccountStore
 import jiamin.chen.orangecloud.data.repository.AnalyticsRepository
 import jiamin.chen.orangecloud.data.repository.StorageRepository
@@ -49,6 +56,13 @@ data class DashboardUiState(
     val isLoading: Boolean = false,
     val authSessions: List<AuthSessionMeta> = emptyList(),
     val currentAuthSessionId: String? = null,
+    // 用量模块
+    val usage: AccountUsage? = null,
+    val usagePlan: UsagePlanPrefs = UsagePlanPrefs(),
+    val usageLoading: Boolean = false,
+    val usageLoadFailed: Boolean = false,
+    val accountAnalyticsUnavailable: Boolean = false,
+    val hasAccountAnalytics: Boolean = false,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -61,10 +75,17 @@ class DashboardViewModel @Inject constructor(
     private val workerRepository: WorkerRepository,
     private val storageRepository: StorageRepository,
     private val analyticsRepository: AnalyticsRepository,
+    private val appPrefs: AppPrefs,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DashboardUiState(isLoading = true))
     val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
+
+    // 用量：账号级会话缓存（切回同账号即时回显）+ 加载/不可用惰性标记
+    private val usageCache = mutableMapOf<String, AccountUsage>()
+    private var usageLoadedForAccount: String? = null
+    private var analyticsUnavailableForAccount: String? = null
+    private var usageJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -72,7 +93,15 @@ class DashboardViewModel @Inject constructor(
         }
         viewModelScope.launch {
             accountStore.selectedAccountId.collect { id ->
-                _uiState.update { it.copy(selectedAccountId = id) }
+                // 切账号时清掉上一个账号的用量快照，避免旧数字在新账号加载期间残留
+                _uiState.update {
+                    it.copy(
+                        selectedAccountId = id,
+                        usage = null,
+                        usageLoadFailed = false,
+                        accountAnalyticsUnavailable = false,
+                    )
+                }
             }
         }
         // 登录身份列表 / 当前身份：头像菜单「登录身份」段的数据源
@@ -100,6 +129,12 @@ class DashboardViewModel @Inject constructor(
                 .collect { zones ->
                     _uiState.update { it.copy(zoneCount = zones.size.toString(), recentZones = zones.take(4)) }
                 }
+        }
+        // 用量套餐设置：随账号切流，仅驱动菜单显示（改动由 setter 主动触发重载，避免切账号双刷）。
+        viewModelScope.launch {
+            accountStore.selectedAccountId
+                .flatMapLatest { id -> if (id == null) flowOf(UsagePlanPrefs()) else appPrefs.usagePlan(id) }
+                .collect { plan -> _uiState.update { it.copy(usagePlan = plan) } }
         }
         // 桌面小组件快照：账号总览（账号名 / 今日请求 / 域名数）变化即写入并刷新 Glance。
         viewModelScope.launch {
@@ -165,6 +200,122 @@ class DashboardViewModel @Inject constructor(
                 _uiState.update { it.copy(isLoading = false) }
             }
         }
+        loadUsage()
+    }
+
+    // MARK: - 用量模块
+
+    /**
+     * 加载账号用量：Workers 主查询（authz = 整账号无账户级数据权限即降级停发其余），
+     * R2 / CPU / D1 / KV 独立合并，能显示多少显示多少（对齐 iOS performLoadUsage）。
+     */
+    fun loadUsage(force: Boolean = false) {
+        val accountId = accountStore.selectedAccountId.value ?: return
+        val hasScope = authRepository.hasScope(Scopes.ACCOUNT_ANALYTICS_READ)
+        _uiState.update { it.copy(hasAccountAnalytics = hasScope) }
+        if (!hasScope) return
+
+        usageCache[accountId]?.let { cached ->
+            if (_uiState.value.usage == null) _uiState.update { it.copy(usage = cached) }
+        }
+        if (!force && usageLoadedForAccount == accountId) return
+        if (!force && analyticsUnavailableForAccount == accountId) {
+            _uiState.update { it.copy(accountAnalyticsUnavailable = true, usageLoading = false) }
+            return
+        }
+
+        usageJob?.cancel()
+        usageJob = viewModelScope.launch {
+            _uiState.update { it.copy(usageLoading = true, usageLoadFailed = false, accountAnalyticsUnavailable = false) }
+            // 内存无缓存时先从磁盘回显上次快照，网络回来再覆盖（对齐 iOS UsageCache 落盘）
+            if (usageCache[accountId] == null) {
+                appPrefs.loadUsageCache(accountId)?.let { disk ->
+                    usageCache[accountId] = disk
+                    if (_uiState.value.usage == null) _uiState.update { it.copy(usage = disk) }
+                }
+            }
+            val plan = appPrefs.usagePlan(accountId).first()
+            val periodStart = if (plan.workersPaid || plan.billingDay != 1) BillingCycle.periodStart(plan.billingDay) else null
+
+            val workers = try {
+                analyticsRepository.accountWorkersUsage(accountId, periodStart)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: ApiError.Cloudflare) {
+                if (isAuthz(e)) {
+                    analyticsUnavailableForAccount = accountId
+                    _uiState.update {
+                        it.copy(accountAnalyticsUnavailable = true, usage = null, usageLoading = false, usageLoadFailed = false)
+                    }
+                    return@launch
+                }
+                null
+            } catch (e: Exception) {
+                null
+            }
+            analyticsUnavailableForAccount = null
+
+            var usage = workers ?: AccountUsage()
+            var anyData = workers != null
+
+            runCatching { analyticsRepository.accountR2Usage(accountId, periodStart) }.getOrNull()?.let { r2 ->
+                usage = usage.copy(
+                    r2ClassAMonth = r2.classA, r2ClassBMonth = r2.classB,
+                    r2StorageBytes = r2.storageBytes, r2ObjectCount = r2.objectCount,
+                )
+                anyData = true
+            }
+            runCatching { analyticsRepository.workersCpuTotals(accountId, periodStart) }.getOrNull()?.let { (month, today) ->
+                usage = usage.copy(cpuTimeMonthUs = month, cpuTimeTodayUs = today)
+            }
+            runCatching { analyticsRepository.d1Usage(accountId, periodStart) }.getOrNull()?.let { d1 ->
+                usage = usage.copy(d1Usage = d1); anyData = true
+            }
+            if (authRepository.hasScope(Scopes.D1_READ)) {
+                runCatching { storageRepository.listDatabases(accountId) }.getOrNull()?.let { dbs ->
+                    usage = usage.copy(d1StorageBytes = dbs.sumOf { it.fileSize ?: 0L }); anyData = true
+                }
+            }
+            runCatching { analyticsRepository.kvUsage(accountId, periodStart) }.getOrNull()?.let { kv ->
+                usage = usage.copy(kvUsage = kv); anyData = true
+            }
+            runCatching { analyticsRepository.kvStorageBytes(accountId) }.getOrNull()?.let { bytes ->
+                usage = usage.copy(kvStorageBytes = bytes); anyData = true
+            }
+
+            if (anyData) {
+                usageCache[accountId] = usage
+                usageLoadedForAccount = accountId
+                appPrefs.saveUsageCache(accountId, usage)   // 落盘供下次冷启动/切回即时回显
+                _uiState.update {
+                    it.copy(usage = usage, usageLoading = false, usageLoadFailed = false, accountAnalyticsUnavailable = false)
+                }
+            } else {
+                _uiState.update { it.copy(usageLoading = false, usageLoadFailed = true) }
+            }
+        }
+    }
+
+    fun setUsageWorkersPaid(paid: Boolean) {
+        val id = accountStore.selectedAccountId.value ?: return
+        viewModelScope.launch { appPrefs.setUsageWorkersPaid(id, paid); loadUsage(force = true) }
+    }
+
+    fun setUsageR2Paid(paid: Boolean) {
+        val id = accountStore.selectedAccountId.value ?: return
+        viewModelScope.launch { appPrefs.setUsageR2Paid(id, paid); loadUsage(force = true) }
+    }
+
+    fun setUsageBillingDay(day: Int) {
+        val id = accountStore.selectedAccountId.value ?: return
+        viewModelScope.launch { appPrefs.setUsageBillingDay(id, day); loadUsage(force = true) }
+    }
+
+    /** GraphQL 账户级 authz 错误识别（免费账号账户级数据集常被 authz 挡）。 */
+    private fun isAuthz(e: ApiError.Cloudflare): Boolean {
+        val msg = e.errors.joinToString(" ") { it.message }.lowercase()
+        return "authz" in msg || "not authorized" in msg || "unauthorized" in msg ||
+            "permission" in msg || "authentication" in msg
     }
 
     /** 今日请求总数 = 各域名 24h 请求之和（best-effort，缺 analytics scope 返回 null）。 */

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesScreens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesScreens.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.outlined.InsertDriveFile
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material.icons.outlined.Web
 import androidx.compose.foundation.layout.Box
@@ -223,6 +224,7 @@ fun PagesProjectDetailScreen(
     var showAddDomain by remember { mutableStateOf(false) }
     var domainSheet by remember { mutableStateOf<PagesDomain?>(null) }
     var domainToDelete by remember { mutableStateOf<PagesDomain?>(null) }
+    var pendingDeleteDep by remember { mutableStateOf<PagesDeployment?>(null) }
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         if (uri != null) deployViewModel.deployFrom(uri, pendingZip)
@@ -234,6 +236,7 @@ fun PagesProjectDetailScreen(
     val domainAddedMsg = stringResource(R.string.pages_domain_added)
     val domainDeletedMsg = stringResource(R.string.pages_domain_deleted)
     val cnameCreatedMsg = stringResource(R.string.pages_cname_created)
+    val deploymentDeletedMsg = stringResource(R.string.pages_deployment_deleted)
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
@@ -242,6 +245,7 @@ fun PagesProjectDetailScreen(
                 PagesEvent.DomainAdded -> snackbarHostState.showSnackbar(domainAddedMsg)
                 PagesEvent.DomainDeleted -> snackbarHostState.showSnackbar(domainDeletedMsg)
                 PagesEvent.CnameCreated -> snackbarHostState.showSnackbar(cnameCreatedMsg)
+                PagesEvent.DeploymentDeleted -> snackbarHostState.showSnackbar(deploymentDeletedMsg)
                 is PagesEvent.Error -> snackbarHostState.showSnackbar(event.message ?: "")
             }
         }
@@ -337,6 +341,7 @@ fun PagesProjectDetailScreen(
                                 busy = state.busyDeploymentId == dep.id,
                                 onRetry = { viewModel.retry(dep) },
                                 onRollback = { viewModel.rollback(dep) },
+                                onDelete = { pendingDeleteDep = dep },
                             )
                         }
                     }
@@ -389,6 +394,20 @@ fun PagesProjectDetailScreen(
                 }
             },
             dismissButton = { TextButton(onClick = { domainToDelete = null }) { Text(stringResource(R.string.common_cancel)) } },
+        )
+    }
+
+    pendingDeleteDep?.let { dep ->
+        AlertDialog(
+            onDismissRequest = { pendingDeleteDep = null },
+            title = { Text(stringResource(R.string.pages_deployment_delete_title)) },
+            text = { Text(stringResource(R.string.pages_deployment_delete_msg, dep.shortId ?: dep.id.take(8))) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteDeployment(dep); pendingDeleteDep = null }) {
+                    Text(stringResource(R.string.dns_delete), color = Color(0xFFE5484D))
+                }
+            },
+            dismissButton = { TextButton(onClick = { pendingDeleteDep = null }) { Text(stringResource(R.string.common_cancel)) } },
         )
     }
 
@@ -467,6 +486,7 @@ private fun DeploymentRow(
     busy: Boolean,
     onRetry: () -> Unit,
     onRollback: () -> Unit,
+    onDelete: () -> Unit,
 ) {
     Surface(color = MaterialTheme.colorScheme.surfaceContainerLow, shape = RoundedCornerShape(16.dp), modifier = Modifier.fillMaxWidth()) {
         Column(Modifier.padding(14.dp)) {
@@ -502,6 +522,11 @@ private fun DeploymentRow(
                             Spacer(Modifier.width(4.dp))
                             Text(stringResource(R.string.pages_rollback), color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp)
                         }
+                    }
+                    TextButton(onClick = onDelete) {
+                        Icon(Icons.Outlined.Delete, contentDescription = null, tint = Color(0xFFE5484D), modifier = Modifier.width(16.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(stringResource(R.string.dns_delete), color = Color(0xFFE5484D), fontSize = 13.sp)
                     }
                 }
             }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesViewModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/pages/PagesViewModels.kt
@@ -81,6 +81,7 @@ sealed interface PagesEvent {
     data object RolledBack : PagesEvent
     data object DomainAdded : PagesEvent
     data object DomainDeleted : PagesEvent
+    data object DeploymentDeleted : PagesEvent
     data object CnameCreated : PagesEvent
     data class Error(val message: String?) : PagesEvent
 }
@@ -243,6 +244,12 @@ class PagesDetailViewModel @Inject constructor(
     fun rollback(deployment: PagesDeployment) = mutate(deployment) { accountId ->
         repository.rollbackDeployment(accountId, projectName, deployment.id)
         eventChannel.send(PagesEvent.RolledBack)
+    }
+
+    fun deleteDeployment(deployment: PagesDeployment) = mutate(deployment) { accountId ->
+        repository.deleteDeployment(accountId, projectName, deployment.id)
+        _uiState.update { it.copy(deployments = it.deployments.filterNot { d -> d.id == deployment.id }) }
+        eventChannel.send(PagesEvent.DeploymentDeleted)
     }
 
     /** 编辑构建配置（构建命令 / 输出目录 / 根目录）。 */

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/root/OrangeCloudRoot.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/root/OrangeCloudRoot.kt
@@ -106,6 +106,7 @@ import jiamin.chen.orangecloud.ui.storage.R2BucketSettingsScreen
 import jiamin.chen.orangecloud.ui.storage.R2ObjectListScreen
 import jiamin.chen.orangecloud.ui.storage.StorageHubScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerCreateScreen
+import jiamin.chen.orangecloud.ui.workers.WorkerDeploymentsScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerDetailScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerListScreen
 import jiamin.chen.orangecloud.ui.workers.WorkerRoutesScreen
@@ -221,9 +222,11 @@ private object Dest {
     const val LB_POOLS = "lb/pools"
     const val LB_MONITORS = "lb/monitors"
     const val WORKER_ROUTE = "worker/{scriptName}"
+    const val WORKER_EDIT_ROUTE = "worker_edit/{editScript}"
     const val WORKER_SECRETS_ROUTE = "worker/{scriptName}/secrets"
     const val WORKER_TRIGGERS_ROUTE = "worker/{scriptName}/triggers"
     const val WORKER_DOMAINS_ROUTE = "worker/{scriptName}/domains"
+    const val WORKER_DEPLOYMENTS_ROUTE = "worker/{scriptName}/deployments"
     const val TAIL_ROUTE = "tail/{scriptName}"
     private fun zoneScoped(prefix: String, zoneId: String, zoneName: String) =
         "$prefix/$zoneId?zoneName=${Uri.encode(zoneName)}"
@@ -251,9 +254,11 @@ private object Dest {
     fun identity(sessionId: String): String = "identity/${Uri.encode(sessionId)}"
     fun tunnelDetail(id: String, name: String): String = "tunnel/$id?tunnelName=${Uri.encode(name)}"
     fun worker(scriptName: String): String = "worker/${Uri.encode(scriptName)}"
+    fun workerEdit(scriptName: String): String = "worker_edit/${Uri.encode(scriptName)}"
     fun workerSecrets(scriptName: String): String = "worker/${Uri.encode(scriptName)}/secrets"
     fun workerTriggers(scriptName: String): String = "worker/${Uri.encode(scriptName)}/triggers"
     fun workerDomains(scriptName: String): String = "worker/${Uri.encode(scriptName)}/domains"
+    fun workerDeployments(scriptName: String): String = "worker/${Uri.encode(scriptName)}/deployments"
     fun tail(scriptName: String): String = "tail/${Uri.encode(scriptName)}"
     fun r2Objects(bucket: String): String = "r2/objects/${Uri.encode(bucket)}"
     fun r2Settings(bucket: String): String = "r2/settings/${Uri.encode(bucket)}"
@@ -624,6 +629,15 @@ private fun MainScaffold(onOpenToolbox: () -> Unit) {
                     onCreated = { navController.popBackStack() },
                 )
             }
+            composable(
+                route = Dest.WORKER_EDIT_ROUTE,
+                arguments = listOf(navArgument("editScript") { type = NavType.StringType }),
+            ) {
+                WorkerCreateScreen(
+                    onBack = { navController.popBackStack() },
+                    onCreated = { navController.popBackStack() },
+                )
+            }
             composable(Dest.DEV_WORKERS_AI) {
                 ProGate {
                     WorkersAIScreen(
@@ -668,6 +682,8 @@ private fun MainScaffold(onOpenToolbox: () -> Unit) {
                     onOpenSecrets = { navController.navigate(Dest.workerSecrets(scriptName)) },
                     onOpenTriggers = { navController.navigate(Dest.workerTriggers(scriptName)) },
                     onOpenDomains = { navController.navigate(Dest.workerDomains(scriptName)) },
+                    onOpenDeployments = { navController.navigate(Dest.workerDeployments(scriptName)) },
+                    onEditCode = { navController.navigate(Dest.workerEdit(scriptName)) },
                 )
             }
             composable(
@@ -687,6 +703,12 @@ private fun MainScaffold(onOpenToolbox: () -> Unit) {
                 arguments = listOf(navArgument("scriptName") { type = NavType.StringType }),
             ) {
                 ProGate { WorkerRoutesScreen(onBack = { navController.popBackStack() }) }
+            }
+            composable(
+                route = Dest.WORKER_DEPLOYMENTS_ROUTE,
+                arguments = listOf(navArgument("scriptName") { type = NavType.StringType }),
+            ) {
+                ProGate { WorkerDeploymentsScreen(onBack = { navController.popBackStack() }) }
             }
             composable(
                 route = Dest.TAIL_ROUTE,

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/D1Screens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/D1Screens.kt
@@ -155,8 +155,22 @@ fun D1QueryScreen(
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
     var sql by rememberSaveable { mutableStateOf("SELECT name FROM sqlite_master WHERE type='table';") }
+    var toDropTable by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val droppedMsg = stringResource(R.string.d1_table_dropped)
+    val errMsg = stringResource(R.string.error_generic)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                D1QueryEvent.TableDropped -> { toDropTable = null; snackbarHostState.showSnackbar(droppedMsg) }
+                is D1QueryEvent.Error -> snackbarHostState.showSnackbar(event.message ?: errMsg)
+            }
+        }
+    }
 
     SkyBackground(phase = phase) {
+        Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().systemBarsPadding()) {
             SkyHeader(
                 title = viewModel.databaseName.ifBlank { stringResource(R.string.storage_d1) },
@@ -192,6 +206,7 @@ fun D1QueryScreen(
                                 Icons.Outlined.TableRows,
                                 table,
                                 onClick = { onOpenTable(table) },
+                                onLongClick = if (state.canWrite) ({ toDropTable = table }) else null,
                             )
                         }
                     }
@@ -232,6 +247,17 @@ fun D1QueryScreen(
                 }
             }
         }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    toDropTable?.let { table ->
+        D1DropTableDialog(
+            tableName = table,
+            isDeleting = state.droppingTable == table,
+            onConfirm = { viewModel.dropTable(table) },
+            onDismiss = { toDropTable = null },
+        )
     }
 }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/KVScreens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/KVScreens.kt
@@ -54,6 +54,7 @@ import jiamin.chen.orangecloud.core.design.onSky
 import jiamin.chen.orangecloud.core.design.rememberSkyPhase
 import jiamin.chen.orangecloud.core.design.theme.OcOrange
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KVNamespaceListScreen(
     onBack: () -> Unit,
@@ -61,25 +62,79 @@ fun KVNamespaceListScreen(
     viewModel: KVNamespaceListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val opState by viewModel.opState.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showCreate by remember { mutableStateOf(false) }
+    var toDelete by remember { mutableStateOf<jiamin.chen.orangecloud.data.model.KVNamespace?>(null) }
+    val createSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val createdMsg = stringResource(R.string.kv_created)
+    val deletedMsg = stringResource(R.string.kv_deleted)
+    val errMsg = stringResource(R.string.error_generic)
 
-    SkyBackground(phase = phase) {
-        Column(Modifier.fillMaxSize().systemBarsPadding()) {
-            SkyHeader(
-                title = stringResource(R.string.storage_kv),
-                onSky = onSky,
-                isLoading = state.isLoading,
-                onRefresh = { viewModel.load() },
-                onBack = onBack,
-                titleSize = 22,
-                backDescription = stringResource(R.string.common_back),
-                refreshDescription = stringResource(R.string.common_refresh),
-            )
-            StorageListBody(state, onSky, Icons.Outlined.Key, stringResource(R.string.kv_empty), { viewModel.load() }) { ns ->
-                StorageRow(Icons.Outlined.Key, ns.title, ns.id, onClick = { onOpenNamespace(ns.id, ns.title) })
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                StorageOpEvent.Created -> { showCreate = false; snackbarHostState.showSnackbar(createdMsg) }
+                StorageOpEvent.Deleted -> { toDelete = null; snackbarHostState.showSnackbar(deletedMsg) }
+                is StorageOpEvent.Error -> snackbarHostState.showSnackbar(event.message ?: errMsg)
             }
         }
+    }
+
+    SkyBackground(phase = phase) {
+        Box(Modifier.fillMaxSize().systemBarsPadding()) {
+            Column(Modifier.fillMaxSize()) {
+                SkyHeader(
+                    title = stringResource(R.string.storage_kv),
+                    onSky = onSky,
+                    isLoading = state.isLoading,
+                    onRefresh = { viewModel.load() },
+                    onBack = onBack,
+                    titleSize = 22,
+                    backDescription = stringResource(R.string.common_back),
+                    refreshDescription = stringResource(R.string.common_refresh),
+                )
+                StorageListBody(state, onSky, Icons.Outlined.Key, stringResource(R.string.kv_empty), { viewModel.load() }) { ns ->
+                    StorageRow(
+                        Icons.Outlined.Key,
+                        ns.title,
+                        ns.id,
+                        onClick = { onOpenNamespace(ns.id, ns.title) },
+                        onLongClick = if (viewModel.canWrite) ({ toDelete = ns }) else null,
+                    )
+                }
+            }
+            if (viewModel.canWrite) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    containerColor = OcOrange,
+                    contentColor = Color.White,
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = stringResource(R.string.kv_create_title))
+                }
+            }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    if (showCreate) {
+        KVCreateSheet(
+            isCreating = opState.isCreating,
+            sheetState = createSheetState,
+            onCreate = { title -> viewModel.create(title) },
+            onDismiss = { showCreate = false },
+        )
+    }
+    toDelete?.let { ns ->
+        KVDeleteDialog(
+            namespace = ns,
+            isDeleting = opState.isDeleting,
+            onConfirm = { viewModel.delete(ns) },
+            onDismiss = { toDelete = null },
+        )
     }
 }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/R2Screens.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/R2Screens.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
@@ -82,6 +83,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun R2BucketListScreen(
     onBack: () -> Unit,
@@ -89,25 +91,79 @@ fun R2BucketListScreen(
     viewModel: R2BucketListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val opState by viewModel.opState.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showCreate by remember { mutableStateOf(false) }
+    var toDelete by remember { mutableStateOf<jiamin.chen.orangecloud.data.model.R2Bucket?>(null) }
+    val createSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val createdMsg = stringResource(R.string.r2_created)
+    val deletedMsg = stringResource(R.string.r2_deleted)
+    val errMsg = stringResource(R.string.error_generic)
 
-    SkyBackground(phase = phase) {
-        Column(Modifier.fillMaxSize().systemBarsPadding()) {
-            SkyHeader(
-                title = stringResource(R.string.storage_r2),
-                onSky = onSky,
-                isLoading = state.isLoading,
-                onRefresh = { viewModel.load() },
-                onBack = onBack,
-                titleSize = 22,
-                backDescription = stringResource(R.string.common_back),
-                refreshDescription = stringResource(R.string.common_refresh),
-            )
-            StorageListBody(state, onSky, Icons.Outlined.Cloud, stringResource(R.string.r2_empty), { viewModel.load() }) { bucket ->
-                StorageRow(Icons.Outlined.Cloud, bucket.name, bucket.location, onClick = { onOpenBucket(bucket.name) })
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                StorageOpEvent.Created -> { showCreate = false; snackbarHostState.showSnackbar(createdMsg) }
+                StorageOpEvent.Deleted -> { toDelete = null; snackbarHostState.showSnackbar(deletedMsg) }
+                is StorageOpEvent.Error -> snackbarHostState.showSnackbar(event.message ?: errMsg)
             }
         }
+    }
+
+    SkyBackground(phase = phase) {
+        Box(Modifier.fillMaxSize().systemBarsPadding()) {
+            Column(Modifier.fillMaxSize()) {
+                SkyHeader(
+                    title = stringResource(R.string.storage_r2),
+                    onSky = onSky,
+                    isLoading = state.isLoading,
+                    onRefresh = { viewModel.load() },
+                    onBack = onBack,
+                    titleSize = 22,
+                    backDescription = stringResource(R.string.common_back),
+                    refreshDescription = stringResource(R.string.common_refresh),
+                )
+                StorageListBody(state, onSky, Icons.Outlined.Cloud, stringResource(R.string.r2_empty), { viewModel.load() }) { bucket ->
+                    StorageRow(
+                        Icons.Outlined.Cloud,
+                        bucket.name,
+                        bucket.location,
+                        onClick = { onOpenBucket(bucket.name) },
+                        onLongClick = if (viewModel.canWrite) ({ toDelete = bucket }) else null,
+                    )
+                }
+            }
+            if (viewModel.canWrite) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    containerColor = OcOrange,
+                    contentColor = Color.White,
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = stringResource(R.string.r2_create_title))
+                }
+            }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    if (showCreate) {
+        R2CreateSheet(
+            isCreating = opState.isCreating,
+            sheetState = createSheetState,
+            onCreate = { name -> viewModel.create(name) },
+            onDismiss = { showCreate = false },
+        )
+    }
+    toDelete?.let { bucket ->
+        R2DeleteDialog(
+            bucket = bucket,
+            isDeleting = opState.isDeleting,
+            onConfirm = { viewModel.delete(bucket) },
+            onDismiss = { toDelete = null },
+        )
     }
 }
 

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageManageUi.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageManageUi.kt
@@ -13,12 +13,8 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
@@ -38,31 +34,21 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jiamin.chen.orangecloud.R
 import jiamin.chen.orangecloud.core.design.theme.OcOrange
-import jiamin.chen.orangecloud.data.model.D1Database
+import jiamin.chen.orangecloud.data.model.KVNamespace
+import jiamin.chen.orangecloud.data.model.R2Bucket
 
-/** D1 主副本放置提示（primary_location_hint）。AUTOMATIC 不传 hint，由 Cloudflare 就近分配。 */
-private enum class D1Loc(val hint: String?, val labelRes: Int) {
-    AUTOMATIC(null, R.string.d1_loc_auto),
-    WNAM("wnam", R.string.d1_loc_wnam),
-    ENAM("enam", R.string.d1_loc_enam),
-    WEUR("weur", R.string.d1_loc_weur),
-    EEUR("eeur", R.string.d1_loc_eeur),
-    APAC("apac", R.string.d1_loc_apac),
-    OC("oc", R.string.d1_loc_oc),
-}
+// MARK: - R2 桶
 
-/** 创建数据库底部表单：名称 + 可选主要位置。 */
+/** 创建 R2 桶底部表单：仅名称（小写字母/数字/连字符，3–63 位，服务端校验）。 */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun D1CreateSheet(
+fun R2CreateSheet(
     isCreating: Boolean,
     sheetState: SheetState,
-    onCreate: (name: String, locationHint: String?) -> Unit,
+    onCreate: (name: String) -> Unit,
     onDismiss: () -> Unit,
 ) {
     var name by remember { mutableStateOf("") }
-    var location by remember { mutableStateOf(D1Loc.AUTOMATIC) }
-    var expanded by remember { mutableStateOf(false) }
     val canCreate = name.trim().isNotEmpty() && !isCreating
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
@@ -75,43 +61,22 @@ fun D1CreateSheet(
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
-            Text(stringResource(R.string.d1_create_title), fontSize = 20.sp, fontWeight = FontWeight.Bold)
-
+            Text(stringResource(R.string.r2_create_title), fontSize = 20.sp, fontWeight = FontWeight.Bold)
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text(stringResource(R.string.d1_name)) },
+                label = { Text(stringResource(R.string.r2_name)) },
                 singleLine = true,
                 textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                 modifier = Modifier.fillMaxWidth(),
             )
-
-            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
-                OutlinedTextField(
-                    value = stringResource(location.labelRes),
-                    onValueChange = {},
-                    readOnly = true,
-                    label = { Text(stringResource(R.string.d1_location)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                    modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
-                )
-                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                    D1Loc.entries.forEach { option ->
-                        DropdownMenuItem(
-                            text = { Text(stringResource(option.labelRes)) },
-                            onClick = { location = option; expanded = false },
-                        )
-                    }
-                }
-            }
             Text(
-                stringResource(R.string.d1_location_hint),
+                stringResource(R.string.r2_name_hint),
                 fontSize = 12.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-
             Button(
-                onClick = { onCreate(name.trim(), location.hint) },
+                onClick = { onCreate(name.trim()) },
                 enabled = canCreate,
                 colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
                 modifier = Modifier.fillMaxWidth(),
@@ -120,34 +85,34 @@ fun D1CreateSheet(
                     CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
                     Spacer(Modifier.width(8.dp))
                 }
-                Text(stringResource(R.string.d1_create))
+                Text(stringResource(R.string.r2_create))
             }
         }
     }
 }
 
-/** 删除数据库二次确认：必须原样输入库名才启用删除（对齐 iOS / Dashboard）。 */
+/** 删除 R2 桶二次确认：必须原样输入桶名才启用删除。 */
 @Composable
-fun D1DeleteDialog(
-    database: D1Database,
+fun R2DeleteDialog(
+    bucket: R2Bucket,
     isDeleting: Boolean,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     var typed by remember { mutableStateOf("") }
-    val matches = typed.trim() == database.name
+    val matches = typed.trim() == bucket.name
 
     AlertDialog(
         onDismissRequest = { if (!isDeleting) onDismiss() },
-        title = { Text(stringResource(R.string.d1_delete_title)) },
+        title = { Text(stringResource(R.string.r2_delete_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(stringResource(R.string.d1_delete_warn, database.name), fontSize = 14.sp)
+                Text(stringResource(R.string.r2_delete_warn, bucket.name), fontSize = 14.sp)
                 OutlinedTextField(
                     value = typed,
                     onValueChange = { typed = it },
-                    label = { Text(stringResource(R.string.d1_delete_confirm_label)) },
-                    placeholder = { Text(database.name) },
+                    label = { Text(stringResource(R.string.r2_delete_confirm_label)) },
+                    placeholder = { Text(bucket.name) },
                     singleLine = true,
                     textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                     modifier = Modifier.fillMaxWidth(),
@@ -156,7 +121,7 @@ fun D1DeleteDialog(
         },
         confirmButton = {
             TextButton(onClick = onConfirm, enabled = matches && !isDeleting) {
-                Text(stringResource(R.string.d1_delete_button), color = if (matches && !isDeleting) Color(0xFFE5484D) else MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(stringResource(R.string.r2_delete_button), color = if (matches && !isDeleting) Color(0xFFE5484D) else MaterialTheme.colorScheme.onSurfaceVariant)
             }
         },
         dismissButton = {
@@ -165,28 +130,77 @@ fun D1DeleteDialog(
     )
 }
 
-/** 删除表二次确认：必须原样输入表名才启用删除（对齐 D1DeleteDialog）。 */
+// MARK: - KV 命名空间
+
+/** 创建 KV 命名空间底部表单：仅标题。 */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun D1DropTableDialog(
-    tableName: String,
+fun KVCreateSheet(
+    isCreating: Boolean,
+    sheetState: SheetState,
+    onCreate: (title: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var title by remember { mutableStateOf("") }
+    val canCreate = title.trim().isNotEmpty() && !isCreating
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .imePadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(stringResource(R.string.kv_create_title), fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text(stringResource(R.string.kv_title_label)) },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Button(
+                onClick = { onCreate(title.trim()) },
+                enabled = canCreate,
+                colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isCreating) {
+                    CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.kv_create))
+            }
+        }
+    }
+}
+
+/** 删除 KV 命名空间二次确认：必须原样输入标题才启用删除。 */
+@Composable
+fun KVDeleteDialog(
+    namespace: KVNamespace,
     isDeleting: Boolean,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     var typed by remember { mutableStateOf("") }
-    val matches = typed.trim() == tableName
+    val matches = typed.trim() == namespace.title
 
     AlertDialog(
         onDismissRequest = { if (!isDeleting) onDismiss() },
-        title = { Text(stringResource(R.string.d1_drop_table_title)) },
+        title = { Text(stringResource(R.string.kv_delete_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(stringResource(R.string.d1_drop_table_warn, tableName), fontSize = 14.sp)
+                Text(stringResource(R.string.kv_delete_warn, namespace.title), fontSize = 14.sp)
                 OutlinedTextField(
                     value = typed,
                     onValueChange = { typed = it },
-                    label = { Text(stringResource(R.string.d1_drop_table_confirm_label)) },
-                    placeholder = { Text(tableName) },
+                    label = { Text(stringResource(R.string.kv_delete_confirm_label)) },
+                    placeholder = { Text(namespace.title) },
                     singleLine = true,
                     textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                     modifier = Modifier.fillMaxWidth(),
@@ -195,7 +209,7 @@ fun D1DropTableDialog(
         },
         confirmButton = {
             TextButton(onClick = onConfirm, enabled = matches && !isDeleting) {
-                Text(stringResource(R.string.d1_delete_button), color = if (matches && !isDeleting) Color(0xFFE5484D) else MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(stringResource(R.string.kv_delete_button), color = if (matches && !isDeleting) Color(0xFFE5484D) else MaterialTheme.colorScheme.onSurfaceVariant)
             }
         },
         dismissButton = {

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageViewModels.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/storage/StorageViewModels.kt
@@ -33,14 +33,73 @@ import javax.inject.Inject
 
 // MARK: - 简单列表（存储桶 / 数据库 / 命名空间）
 
+/** 创建/删除资源的进行态（存储各列表共用）。 */
+data class StorageOpState(
+    val isCreating: Boolean = false,
+    val isDeleting: Boolean = false,
+)
+
+/** 创建/删除资源的一次性事件（存储各列表共用）。 */
+sealed interface StorageOpEvent {
+    data object Created : StorageOpEvent
+    data object Deleted : StorageOpEvent
+    data class Error(val message: String?) : StorageOpEvent
+}
+
 @HiltViewModel
 class R2BucketListViewModel @Inject constructor(
-    accountStore: AccountStore,
+    private val accountStore: AccountStore,
     private val storageRepository: StorageRepository,
     authRepository: AuthRepository,
 ) : StorageListViewModel<R2Bucket>(accountStore, authRepository.hasScope(Scopes.R2_READ)) {
+
+    /** 创建 / 删除桶都需要 workers-r2-storage.write。 */
+    val canWrite: Boolean = authRepository.hasScope(Scopes.R2_WRITE)
+
+    private val _opState = MutableStateFlow(StorageOpState())
+    val opState: StateFlow<StorageOpState> = _opState.asStateFlow()
+
+    private val eventChannel = Channel<StorageOpEvent>(Channel.BUFFERED)
+    val events: Flow<StorageOpEvent> = eventChannel.receiveAsFlow()
+
     override suspend fun fetch(accountId: String) = storageRepository.listBuckets(accountId)
     init { load() }
+
+    /** 创建桶：成功后插到列表顶端。 */
+    fun create(name: String) {
+        if (!canWrite || _opState.value.isCreating) return
+        viewModelScope.launch {
+            _opState.update { it.copy(isCreating = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val created = storageRepository.createBucket(accountId, name)
+                state.update { it.copy(items = listOf(created) + it.items) }
+                eventChannel.send(StorageOpEvent.Created)
+            } catch (e: Exception) {
+                eventChannel.send(StorageOpEvent.Error(e.message))
+            } finally {
+                _opState.update { it.copy(isCreating = false) }
+            }
+        }
+    }
+
+    /** 删除桶：成功后从列表移除。须桶为空，且经二次确认。不可恢复。 */
+    fun delete(bucket: R2Bucket) {
+        if (!canWrite || _opState.value.isDeleting) return
+        viewModelScope.launch {
+            _opState.update { it.copy(isDeleting = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                storageRepository.deleteBucket(accountId, bucket.name)
+                state.update { it.copy(items = it.items.filterNot { b -> b.name == bucket.name }) }
+                eventChannel.send(StorageOpEvent.Deleted)
+            } catch (e: Exception) {
+                eventChannel.send(StorageOpEvent.Error(e.message))
+            } finally {
+                _opState.update { it.copy(isDeleting = false) }
+            }
+        }
+    }
 }
 
 sealed interface D1DbEvent {
@@ -119,12 +178,58 @@ class D1DatabaseListViewModel @Inject constructor(
 
 @HiltViewModel
 class KVNamespaceListViewModel @Inject constructor(
-    accountStore: AccountStore,
+    private val accountStore: AccountStore,
     private val storageRepository: StorageRepository,
     authRepository: AuthRepository,
 ) : StorageListViewModel<KVNamespace>(accountStore, authRepository.hasScope(Scopes.KV_READ)) {
+
+    /** 创建 / 删除命名空间都需要 workers-kv-storage.write。 */
+    val canWrite: Boolean = authRepository.hasScope(Scopes.KV_WRITE)
+
+    private val _opState = MutableStateFlow(StorageOpState())
+    val opState: StateFlow<StorageOpState> = _opState.asStateFlow()
+
+    private val eventChannel = Channel<StorageOpEvent>(Channel.BUFFERED)
+    val events: Flow<StorageOpEvent> = eventChannel.receiveAsFlow()
+
     override suspend fun fetch(accountId: String) = storageRepository.listNamespaces(accountId)
     init { load() }
+
+    /** 创建命名空间：成功后插到列表顶端。 */
+    fun create(title: String) {
+        if (!canWrite || _opState.value.isCreating) return
+        viewModelScope.launch {
+            _opState.update { it.copy(isCreating = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val created = storageRepository.createNamespace(accountId, title)
+                state.update { it.copy(items = listOf(created) + it.items) }
+                eventChannel.send(StorageOpEvent.Created)
+            } catch (e: Exception) {
+                eventChannel.send(StorageOpEvent.Error(e.message))
+            } finally {
+                _opState.update { it.copy(isCreating = false) }
+            }
+        }
+    }
+
+    /** 删除命名空间：成功后从列表移除。连同全部键值，经二次确认。不可恢复。 */
+    fun delete(namespace: KVNamespace) {
+        if (!canWrite || _opState.value.isDeleting) return
+        viewModelScope.launch {
+            _opState.update { it.copy(isDeleting = true) }
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                storageRepository.deleteNamespace(accountId, namespace.id)
+                state.update { it.copy(items = it.items.filterNot { ns -> ns.id == namespace.id }) }
+                eventChannel.send(StorageOpEvent.Deleted)
+            } catch (e: Exception) {
+                eventChannel.send(StorageOpEvent.Error(e.message))
+            } finally {
+                _opState.update { it.copy(isDeleting = false) }
+            }
+        }
+    }
 }
 
 // MARK: - R2 对象（游标分页）
@@ -319,6 +424,11 @@ class R2ObjectListViewModel @Inject constructor(
 
 // MARK: - D1 查询控制台
 
+sealed interface D1QueryEvent {
+    data object TableDropped : D1QueryEvent
+    data class Error(val message: String?) : D1QueryEvent
+}
+
 data class D1QueryUiState(
     val results: List<D1QueryResult> = emptyList(),
     val columns: List<String> = emptyList(),
@@ -327,6 +437,8 @@ data class D1QueryUiState(
     val missingScope: Boolean = false,
     val tables: List<String> = emptyList(),
     val tablesLoaded: Boolean = false,
+    val canWrite: Boolean = false,
+    val droppingTable: String? = null,
 )
 
 @HiltViewModel
@@ -340,9 +452,14 @@ class D1QueryViewModel @Inject constructor(
     val databaseId: String = checkNotNull(savedStateHandle["dbId"])
     val databaseName: String = savedStateHandle.get<String>("dbName").orEmpty()
     private val hasScope = authRepository.hasScope(Scopes.D1_READ)
+    /** 删表需要 d1.write（读权限已是进入 D1 段的前置条件）。 */
+    private val canWrite = authRepository.hasScope(Scopes.D1_WRITE)
 
-    private val _uiState = MutableStateFlow(D1QueryUiState(missingScope = !hasScope))
+    private val _uiState = MutableStateFlow(D1QueryUiState(missingScope = !hasScope, canWrite = canWrite))
     val uiState: StateFlow<D1QueryUiState> = _uiState.asStateFlow()
+
+    private val eventChannel = Channel<D1QueryEvent>(Channel.BUFFERED)
+    val events: Flow<D1QueryEvent> = eventChannel.receiveAsFlow()
 
     init {
         if (hasScope) loadTables()
@@ -379,6 +496,29 @@ class D1QueryViewModel @Inject constructor(
                 _uiState.update { it.copy(error = e.message ?: "error", results = emptyList(), columns = emptyList()) }
             } finally {
                 _uiState.update { it.copy(isRunning = false) }
+            }
+        }
+    }
+
+    /** 标识符加引号并转义内部双引号，防 SQL 注入（对齐 D1TableViewModel.quoted）。 */
+    private fun quoted(identifier: String): String =
+        "\"" + identifier.replace("\"", "\"\"") + "\""
+
+    /** DROP TABLE：删除整张表及其全部数据（d1.write 门控，标识符加引号防注入）。 */
+    fun dropTable(name: String) {
+        if (!canWrite || _uiState.value.droppingTable != null) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(droppingTable = name) }
+            try {
+                accountStore.ensureLoaded()
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                storageRepository.query(accountId, databaseId, "DROP TABLE IF EXISTS ${quoted(name)}")
+                _uiState.update { it.copy(tables = it.tables - name) }
+                eventChannel.send(D1QueryEvent.TableDropped)
+            } catch (e: Exception) {
+                eventChannel.send(D1QueryEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(droppingTable = null) }
             }
         }
     }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerCreateScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerCreateScreen.kt
@@ -52,15 +52,23 @@ fun WorkerCreateScreen(
     viewModel: WorkerCreateViewModel = hiltViewModel(),
 ) {
     val isUploading by viewModel.isUploading.collectAsStateWithLifecycle()
+    val sourceState by viewModel.sourceState.collectAsStateWithLifecycle()
+    val isEdit = viewModel.isEdit
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
     val snackbar = remember { SnackbarHostState() }
 
-    var name by rememberSaveable { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf(viewModel.editScript.orEmpty()) }
     var compatDate by rememberSaveable { mutableStateOf(viewModel.defaultCompatibilityDate) }
-    var code by rememberSaveable { mutableStateOf(SAMPLE_CODE) }
+    // 新建预填示例代码；编辑时初始为空，等 /content/v2 读回后由 LaunchedEffect 填入
+    var code by rememberSaveable { mutableStateOf(if (isEdit) "" else SAMPLE_CODE) }
 
-    val createdMsg = stringResource(R.string.worker_create_ok)
+    // 源码读回后预填一次编辑器
+    LaunchedEffect(sourceState.code) {
+        sourceState.code?.let { code = it }
+    }
+
+    val createdMsg = if (isEdit) stringResource(R.string.worker_edit_ok) else stringResource(R.string.worker_create_ok)
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
@@ -71,14 +79,15 @@ fun WorkerCreateScreen(
     }
 
     val nameValid = name.isBlank() || viewModel.isValidName(name)
-    val canSave = viewModel.isValidName(name) && code.isNotBlank() && !isUploading
+    val canSave = (isEdit || viewModel.isValidName(name)) && code.isNotBlank() &&
+        !isUploading && !sourceState.isLoading && !sourceState.uneditable
 
     SkyBackground(phase = phase) {
         Column(Modifier.fillMaxSize().systemBarsPadding()) {
             SkyHeader(
-                title = stringResource(R.string.worker_create_title),
+                title = if (isEdit) stringResource(R.string.worker_edit_title) else stringResource(R.string.worker_create_title),
                 onSky = onSky,
-                isLoading = isUploading,
+                isLoading = isUploading || sourceState.isLoading,
                 onRefresh = {},
                 onBack = onBack,
                 titleSize = 22,
@@ -88,42 +97,59 @@ fun WorkerCreateScreen(
                 Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                // 编辑现有脚本时名称固定不可改
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it.lowercase() },
                     label = { Text(stringResource(R.string.worker_create_name)) },
                     singleLine = true,
                     isError = !nameValid,
-                    supportingText = { Text(stringResource(R.string.worker_create_name_hint)) },
+                    enabled = !isEdit,
+                    readOnly = isEdit,
+                    supportingText = if (isEdit) null else ({ Text(stringResource(R.string.worker_create_name_hint)) }),
                     modifier = Modifier.fillMaxWidth(),
                 )
-                OutlinedTextField(
-                    value = compatDate,
-                    onValueChange = { compatDate = it },
-                    label = { Text(stringResource(R.string.worker_create_compat)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                if (!isEdit) {
+                    OutlinedTextField(
+                        value = compatDate,
+                        onValueChange = { compatDate = it },
+                        label = { Text(stringResource(R.string.worker_create_compat)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
                 Text(stringResource(R.string.worker_create_code), fontSize = 13.sp, color = onSky)
-                OutlinedTextField(
-                    value = code,
-                    onValueChange = { code = it },
-                    textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                    minLines = 10,
-                    modifier = Modifier.fillMaxWidth(),
+                when {
+                    sourceState.isLoading ->
+                        Text(stringResource(R.string.worker_edit_loading), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    sourceState.uneditable ->
+                        Text(stringResource(R.string.worker_edit_multimodule), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    else -> OutlinedTextField(
+                        value = code,
+                        onValueChange = { code = it },
+                        textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        minLines = 10,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                Text(
+                    if (isEdit) stringResource(R.string.worker_edit_note) else stringResource(R.string.worker_create_note),
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Text(stringResource(R.string.worker_create_note), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Button(
-                    onClick = { viewModel.create(name, code, compatDate) },
-                    enabled = canSave,
-                    colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (isUploading) {
-                        CircularProgressIndicator(Modifier.height(18.dp).width(18.dp), strokeWidth = 2.dp, color = Color.White)
-                        Spacer(Modifier.width(8.dp))
+                if (!sourceState.uneditable) {
+                    Button(
+                        onClick = { viewModel.submit(name, code, compatDate) },
+                        enabled = canSave,
+                        colors = ButtonDefaults.buttonColors(containerColor = OcOrange, contentColor = Color.White),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        if (isUploading) {
+                            CircularProgressIndicator(Modifier.height(18.dp).width(18.dp), strokeWidth = 2.dp, color = Color.White)
+                            Spacer(Modifier.width(8.dp))
+                        }
+                        Text(stringResource(R.string.worker_create_deploy))
                     }
-                    Text(stringResource(R.string.worker_create_deploy))
                 }
             }
             SnackbarHost(snackbar)

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerCreateViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerCreateViewModel.kt
@@ -1,5 +1,6 @@
 package jiamin.chen.orangecloud.ui.workers
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,12 +24,25 @@ sealed interface WorkerCreateEvent {
     data class Error(val message: String?) : WorkerCreateEvent
 }
 
+/** 原地编辑时读取现有源码的状态。 */
+data class WorkerSourceState(
+    val isLoading: Boolean = false,
+    val code: String? = null,        // 预填源码（就绪后非空）
+    val uneditable: Boolean = false, // 多模块打包产物：无法安全原地替换
+    val error: String? = null,
+)
+
 @HiltViewModel
 class WorkerCreateViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val accountStore: AccountStore,
     private val workerRepository: WorkerRepository,
     authRepository: AuthRepository,
 ) : ViewModel() {
+
+    /** 非空 = 原地编辑现有脚本；空 = 新建。 */
+    val editScript: String? = savedStateHandle.get<String>("editScript")?.takeIf { it.isNotBlank() }
+    val isEdit: Boolean = editScript != null
 
     val canWrite: Boolean = authRepository.hasScope(Scopes.WORKERS_WRITE)
     val defaultCompatibilityDate: String = LocalDate.now().toString() // yyyy-MM-dd
@@ -36,13 +50,46 @@ class WorkerCreateViewModel @Inject constructor(
     private val _isUploading = MutableStateFlow(false)
     val isUploading: StateFlow<Boolean> = _isUploading.asStateFlow()
 
+    private val _sourceState = MutableStateFlow(WorkerSourceState(isLoading = isEdit))
+    val sourceState: StateFlow<WorkerSourceState> = _sourceState.asStateFlow()
+    private var isModule = true
+
     private val eventChannel = Channel<WorkerCreateEvent>(Channel.BUFFERED)
     val events: Flow<WorkerCreateEvent> = eventChannel.receiveAsFlow()
+
+    init {
+        if (isEdit) loadSource()
+    }
+
+    /** 原地编辑：读现有源码预填（/content/v2）。多模块产物置 uneditable。 */
+    private fun loadSource() {
+        val script = editScript ?: return
+        viewModelScope.launch {
+            try {
+                accountStore.ensureLoaded()
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val content = workerRepository.content(accountId, script)
+                isModule = content.isModule
+                if (!content.isEditable) {
+                    _sourceState.update { it.copy(isLoading = false, uneditable = true) }
+                } else {
+                    _sourceState.update { it.copy(isLoading = false, code = content.mainModule?.body.orEmpty()) }
+                }
+            } catch (e: Exception) {
+                _sourceState.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
 
     /** Worker 名：小写字母/数字开头，其后可含小写字母/数字/连字符/下划线（对齐 iOS）。 */
     fun isValidName(name: String): Boolean = name.matches(Regex("^[a-z0-9][a-z0-9_-]*$"))
 
-    fun create(name: String, code: String, compatibilityDate: String) {
+    /** 提交：编辑模式走整体替换（保留绑定），否则新建。 */
+    fun submit(name: String, code: String, compatibilityDate: String) {
+        if (isEdit) replace(code) else create(name, code, compatibilityDate)
+    }
+
+    private fun create(name: String, code: String, compatibilityDate: String) {
         if (!canWrite || _isUploading.value) return
         if (!isValidName(name) || code.isBlank()) return
         _isUploading.update { true }
@@ -51,6 +98,24 @@ class WorkerCreateViewModel @Inject constructor(
                 accountStore.ensureLoaded()
                 val accountId = accountStore.selectedAccountId.value ?: error("no account")
                 workerRepository.deployScript(accountId, name, code, compatibilityDate.ifBlank { defaultCompatibilityDate })
+                eventChannel.send(WorkerCreateEvent.Created)
+            } catch (e: Exception) {
+                eventChannel.send(WorkerCreateEvent.Error(e.message))
+            } finally {
+                _isUploading.update { false }
+            }
+        }
+    }
+
+    private fun replace(code: String) {
+        val script = editScript ?: return
+        if (!canWrite || _isUploading.value || code.isBlank()) return
+        _isUploading.update { true }
+        viewModelScope.launch {
+            try {
+                accountStore.ensureLoaded()
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                workerRepository.replaceScript(accountId, script, code, isModule)
                 eventChannel.send(WorkerCreateEvent.Created)
             } catch (e: Exception) {
                 eventChannel.send(WorkerCreateEvent.Error(e.message))

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDeploymentsScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDeploymentsScreen.kt
@@ -1,0 +1,274 @@
+package jiamin.chen.orangecloud.ui.workers
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.History
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jiamin.chen.orangecloud.R
+import jiamin.chen.orangecloud.core.auth.AuthRepository
+import jiamin.chen.orangecloud.core.auth.Scopes
+import jiamin.chen.orangecloud.core.design.SkyBackground
+import jiamin.chen.orangecloud.core.design.SkyEmptyState
+import jiamin.chen.orangecloud.core.design.SkyHeader
+import jiamin.chen.orangecloud.core.design.onSky
+import jiamin.chen.orangecloud.core.design.rememberSkyPhase
+import jiamin.chen.orangecloud.core.design.theme.OcOrange
+import jiamin.chen.orangecloud.data.model.WorkerDeployment
+import jiamin.chen.orangecloud.data.repository.AccountStore
+import jiamin.chen.orangecloud.data.repository.WorkerRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class WorkerDeploymentsUiState(
+    val deployments: List<WorkerDeployment> = emptyList(),
+    val isLoading: Boolean = false,
+    val hasError: Boolean = false,
+    val canWrite: Boolean = false,
+    val busyId: String? = null,
+)
+
+sealed interface WorkerDeploymentEvent {
+    data object Deleted : WorkerDeploymentEvent
+    data class Error(val message: String?) : WorkerDeploymentEvent
+}
+
+@HiltViewModel
+class WorkerDeploymentsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val accountStore: AccountStore,
+    private val workerRepository: WorkerRepository,
+    authRepository: AuthRepository,
+) : ViewModel() {
+
+    val scriptName: String = checkNotNull(savedStateHandle["scriptName"])
+    private val canWrite = authRepository.hasScope(Scopes.WORKERS_WRITE)
+
+    private val _uiState = MutableStateFlow(WorkerDeploymentsUiState(isLoading = true, canWrite = canWrite))
+    val uiState: StateFlow<WorkerDeploymentsUiState> = _uiState.asStateFlow()
+
+    private val eventChannel = Channel<WorkerDeploymentEvent>(Channel.BUFFERED)
+    val events: Flow<WorkerDeploymentEvent> = eventChannel.receiveAsFlow()
+
+    init { load() }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, hasError = false) }
+            try {
+                accountStore.ensureLoaded()
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                val list = workerRepository.listDeployments(accountId, scriptName)
+                _uiState.update { it.copy(deployments = list) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(hasError = true) }
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    /** 删除某次部署。活跃部署 Cloudflare 会拒绝（错误经事件透出）。 */
+    fun delete(deployment: WorkerDeployment) {
+        if (!canWrite || _uiState.value.busyId != null) return
+        _uiState.update { it.copy(busyId = deployment.id) }
+        viewModelScope.launch {
+            try {
+                val accountId = accountStore.selectedAccountId.value ?: error("no account")
+                workerRepository.deleteDeployment(accountId, scriptName, deployment.id)
+                _uiState.update { it.copy(deployments = it.deployments.filterNot { d -> d.id == deployment.id }) }
+                eventChannel.send(WorkerDeploymentEvent.Deleted)
+            } catch (e: Exception) {
+                eventChannel.send(WorkerDeploymentEvent.Error(e.message))
+            } finally {
+                _uiState.update { it.copy(busyId = null) }
+            }
+        }
+    }
+}
+
+@Composable
+fun WorkerDeploymentsScreen(
+    onBack: () -> Unit,
+    viewModel: WorkerDeploymentsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val phase = rememberSkyPhase()
+    val onSky = phase.onSky
+    val snackbar = remember { SnackbarHostState() }
+    var pendingDelete by remember { mutableStateOf<WorkerDeployment?>(null) }
+    val deletedMsg = stringResource(R.string.worker_deployment_deleted)
+    val errMsg = stringResource(R.string.error_generic)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                WorkerDeploymentEvent.Deleted -> snackbar.showSnackbar(deletedMsg)
+                is WorkerDeploymentEvent.Error -> snackbar.showSnackbar(event.message ?: errMsg)
+            }
+        }
+    }
+
+    SkyBackground(phase = phase) {
+        Box(Modifier.fillMaxSize().systemBarsPadding()) {
+            Column(Modifier.fillMaxSize()) {
+                SkyHeader(
+                    title = stringResource(R.string.worker_deployments_title),
+                    onSky = onSky,
+                    isLoading = state.isLoading,
+                    onRefresh = { viewModel.load() },
+                    onBack = onBack,
+                    titleSize = 22,
+                    backDescription = stringResource(R.string.common_back),
+                    refreshDescription = stringResource(R.string.common_refresh),
+                )
+                if (!state.isLoading && state.deployments.isEmpty()) {
+                    SkyEmptyState(
+                        Icons.Outlined.History,
+                        stringResource(R.string.worker_deployments_empty),
+                        onSky,
+                        stringResource(R.string.common_refresh),
+                    ) { viewModel.load() }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        item {
+                            Text(
+                                stringResource(R.string.worker_deployments_note),
+                                color = onSky.copy(alpha = 0.85f),
+                                fontSize = 12.sp,
+                                modifier = Modifier.padding(vertical = 4.dp),
+                            )
+                        }
+                        itemsIndexed(state.deployments, key = { _, d -> d.id }) { index, dep ->
+                            DeploymentRow(
+                                dep = dep,
+                                isActive = index == 0,
+                                canWrite = state.canWrite,
+                                busy = state.busyId == dep.id,
+                                onDelete = { pendingDelete = dep },
+                            )
+                        }
+                    }
+                }
+            }
+            SnackbarHost(snackbar, Modifier.align(Alignment.BottomCenter))
+        }
+    }
+
+    pendingDelete?.let { dep ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text(stringResource(R.string.worker_deployment_delete_title)) },
+            text = { Text(stringResource(R.string.worker_deployment_delete_msg, dep.id.take(8))) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.delete(dep); pendingDelete = null }) {
+                    Text(stringResource(R.string.dns_delete), color = Color(0xFFE5484D))
+                }
+            },
+            dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text(stringResource(R.string.common_cancel)) } },
+        )
+    }
+}
+
+@Composable
+private fun DeploymentRow(
+    dep: WorkerDeployment,
+    isActive: Boolean,
+    canWrite: Boolean,
+    busy: Boolean,
+    onDelete: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainerLow, shape = RoundedCornerShape(16.dp), modifier = Modifier.fillMaxWidth()) {
+        Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (isActive) {
+                        Text(
+                            stringResource(R.string.worker_deployment_active),
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = OcOrange,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                    }
+                    Text(
+                        dep.message ?: dep.source ?: dep.id.take(8),
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Text(
+                    dep.id.take(8) + (dep.authorEmail?.let { " · $it" } ?: ""),
+                    fontSize = 12.sp,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (busy) {
+                CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp, color = OcOrange)
+            } else if (canWrite && !isActive) {
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Outlined.Delete, contentDescription = stringResource(R.string.dns_delete), tint = Color(0xFFE5484D))
+                }
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDetailScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDetailScreen.kt
@@ -21,6 +21,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Schedule
@@ -37,7 +40,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,11 +82,26 @@ fun WorkerDetailScreen(
     onOpenSecrets: () -> Unit = {},
     onOpenTriggers: () -> Unit = {},
     onOpenDomains: () -> Unit = {},
+    onOpenDeployments: () -> Unit = {},
+    onEditCode: () -> Unit = {},
     viewModel: WorkerDetailViewModel = hiltViewModel(),
 ) {
     val worker by viewModel.worker.collectAsStateWithLifecycle()
+    val isDeleting by viewModel.isDeleting.collectAsStateWithLifecycle()
     val phase = rememberSkyPhase()
     val onSky = phase.onSky
+    val snackbar = remember { androidx.compose.material3.SnackbarHostState() }
+    var showDelete by remember { mutableStateOf(false) }
+    val deleteErr = stringResource(R.string.error_generic)
+
+    LaunchedEffect(Unit) {
+        viewModel.deleteEvents.collect { event ->
+            when (event) {
+                WorkerDeleteEvent.Deleted -> { showDelete = false; onBack() }
+                is WorkerDeleteEvent.Error -> { showDelete = false; snackbar.showSnackbar(event.message ?: deleteErr) }
+            }
+        }
+    }
 
     SkyBackground(phase = phase) {
         Column(Modifier.fillMaxSize().systemBarsPadding()) {
@@ -118,9 +140,13 @@ fun WorkerDetailScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Column(Modifier.padding(vertical = 4.dp)) {
+                        if (viewModel.canWrite) {
+                            ManageRow(Icons.Outlined.Edit, stringResource(R.string.worker_manage_edit), onEditCode)
+                        }
                         ManageRow(Icons.Outlined.Key, stringResource(R.string.worker_manage_secrets), onOpenSecrets)
                         ManageRow(Icons.Outlined.Schedule, stringResource(R.string.worker_manage_triggers), onOpenTriggers)
                         ManageRow(Icons.Outlined.Public, stringResource(R.string.worker_manage_domains), onOpenDomains)
+                        ManageRow(Icons.Outlined.History, stringResource(R.string.worker_manage_deployments), onOpenDeployments)
                     }
                 }
 
@@ -204,9 +230,69 @@ fun WorkerDetailScreen(
                         }
                     }
                 }
+
+                if (viewModel.canWrite) {
+                    androidx.compose.material3.OutlinedButton(
+                        onClick = { showDelete = true },
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFFE5484D)),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(Icons.Outlined.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.worker_delete_button))
+                    }
+                }
             }
+            androidx.compose.material3.SnackbarHost(snackbar)
         }
     }
+
+    if (showDelete) {
+        WorkerDeleteDialog(
+            scriptName = viewModel.scriptName,
+            isDeleting = isDeleting,
+            onConfirm = { viewModel.delete() },
+            onDismiss = { if (!isDeleting) showDelete = false },
+        )
+    }
+}
+
+/** 删除 Worker 二次确认：必须原样输入脚本名才启用删除（对齐 iOS / Dashboard）。 */
+@Composable
+private fun WorkerDeleteDialog(
+    scriptName: String,
+    isDeleting: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var typed by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf("") }
+    val matches = typed.trim() == scriptName
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = { if (!isDeleting) onDismiss() },
+        title = { Text(stringResource(R.string.worker_delete_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(stringResource(R.string.worker_delete_warn, scriptName), fontSize = 14.sp)
+                androidx.compose.material3.OutlinedTextField(
+                    value = typed,
+                    onValueChange = { typed = it },
+                    label = { Text(stringResource(R.string.worker_delete_confirm_label)) },
+                    placeholder = { Text(scriptName) },
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            androidx.compose.material3.TextButton(onClick = onConfirm, enabled = matches && !isDeleting) {
+                Text(stringResource(R.string.worker_delete_button), color = if (matches && !isDeleting) Color(0xFFE5484D) else MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(onClick = onDismiss, enabled = !isDeleting) { Text(stringResource(R.string.common_cancel)) }
+        },
+    )
 }
 
 @Composable

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDetailViewModel.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/workers/WorkerDetailViewModel.kt
@@ -13,20 +13,29 @@ import jiamin.chen.orangecloud.data.model.WorkerSeriesPoint
 import jiamin.chen.orangecloud.data.repository.AccountStore
 import jiamin.chen.orangecloud.data.repository.AnalyticsRepository
 import jiamin.chen.orangecloud.data.repository.WorkerRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+sealed interface WorkerDeleteEvent {
+    data object Deleted : WorkerDeleteEvent
+    data class Error(val message: String?) : WorkerDeleteEvent
+}
 
 @HiltViewModel
 class WorkerDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     accountStore: AccountStore,
-    workerRepository: WorkerRepository,
+    private val workerRepository: WorkerRepository,
     private val analyticsRepository: AnalyticsRepository,
     authRepository: AuthRepository,
 ) : ViewModel() {
@@ -34,6 +43,29 @@ class WorkerDetailViewModel @Inject constructor(
     val scriptName: String = checkNotNull(savedStateHandle["scriptName"])
     private val accountId: String? = accountStore.selectedAccountId.value
     val canViewMetrics: Boolean = authRepository.hasScope(Scopes.ANALYTICS_READ)
+    val canWrite: Boolean = authRepository.hasScope(Scopes.WORKERS_WRITE)
+
+    private val _isDeleting = MutableStateFlow(false)
+    val isDeleting: StateFlow<Boolean> = _isDeleting.asStateFlow()
+
+    private val deleteChannel = Channel<WorkerDeleteEvent>(Channel.BUFFERED)
+    val deleteEvents: Flow<WorkerDeleteEvent> = deleteChannel.receiveAsFlow()
+
+    /** 删除整个 Worker（连同部署 / 路由绑定）。须经二次确认，不可恢复。成功后触发返回。 */
+    fun delete() {
+        if (!canWrite || accountId == null || _isDeleting.value) return
+        _isDeleting.update { true }
+        viewModelScope.launch {
+            try {
+                workerRepository.deleteScript(accountId, scriptName)
+                deleteChannel.send(WorkerDeleteEvent.Deleted)
+            } catch (e: Exception) {
+                deleteChannel.send(WorkerDeleteEvent.Error(e.message))
+            } finally {
+                _isDeleting.update { false }
+            }
+        }
+    }
 
     val worker: StateFlow<WorkerScript?> =
         if (accountId == null) {

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -550,6 +550,10 @@
     <string name="d1_delete_warn">يحذف هذا قاعدة البيانات %1$s وكل جداولها وبياناتها نهائيًا. لا يمكن التراجع أو الاسترداد.</string>
     <string name="d1_delete_confirm_label">اكتب اسم قاعدة البيانات للتأكيد</string>
     <string name="d1_delete_button">حذف نهائي</string>
+    <string name="d1_drop_table_title">حذف الجدول</string>
+    <string name="d1_drop_table_warn">يحذف هذا الجدول %1$s وكل بياناته نهائيًا. لا يمكن التراجع أو الاسترداد.</string>
+    <string name="d1_drop_table_confirm_label">اكتب اسم الجدول للتأكيد</string>
+    <string name="d1_table_dropped">تم حذف الجدول</string>
     <string name="worker_manage_secrets">المتغيرات والأسرار</string>
     <string name="worker_manage_triggers">المُشغّلات</string>
     <string name="worker_manage_domains">النطاقات</string>
@@ -984,7 +988,7 @@
     <string name="worker_create_name_hint">يبدأ بحرف صغير/رقم؛ يسمح بالشرطة والشرطة السفلية</string>
     <string name="worker_create_compat">تاريخ التوافق</string>
     <string name="worker_create_code">الكود (ES module)</string>
-    <string name="worker_create_note">ملاحظة: لا يمكن للتطبيق قراءة كود Worker الحالي (يحظر Cloudflare هذه النقطة لـ OAuth)؛ يتطلب الإنشاء أو الاستبدال الكود الكامل. أدِر الارتباطات (المتغيرات/الأسرار/KV) في تفاصيل Worker.</string>
+    <string name="worker_create_note">تلميح: يتطلب الإنشاء أو الاستبدال الكامل الشيفرة الكاملة. أدِر الارتباطات (المتغيرات والأسرار وKV وغيرها) بشكل منفصل في تفاصيل Worker.</string>
     <string name="worker_create_deploy">نشر</string>
     <string name="worker_create_ok">تم النشر</string>
     <string name="pages_deploy_code">نشر الكود</string>
@@ -1137,4 +1141,70 @@
     <string name="sort_default">افتراضي (الاسم)</string>
     <string name="sort_created">تاريخ الإنشاء</string>
     <string name="sort_modified">آخر تحديث</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">تعديل الشيفرة</string>
+    <string name="worker_edit_ok">تم النشر</string>
+    <string name="worker_edit_loading">جارٍ تحميل الشيفرة المصدرية…</string>
+    <string name="worker_edit_multimodule">هذا Worker متعدد الوحدات (مُجمَّع)؛ لا يُدعم التعديل المباشر داخل التطبيق (ستُفقد الوحدات الأخرى).</string>
+    <string name="worker_edit_note">تم تحميل الشيفرة المصدرية الحالية المباشرة. يمكنك تعديلها ونشرها مباشرةً. تُحفظ المتغيرات والأسرار والارتباطات الحالية تلقائيًا.</string>
+    <string name="worker_manage_edit">تعديل الشيفرة</string>
+    <string name="worker_delete_button">حذف Worker</string>
+    <string name="worker_delete_title">حذف Worker</string>
+    <string name="worker_delete_warn">سيؤدي هذا إلى حذف Worker %1$s نهائيًا مع عمليات النشر وارتباطات المسار الخاصة به. لا يمكن التراجع عن ذلك أو استعادته.</string>
+    <string name="worker_delete_confirm_label">أدخل اسم Worker للتأكيد</string>
+    <string name="kv_create_title">إنشاء مساحة أسماء</string>
+    <string name="kv_create">إنشاء</string>
+    <string name="kv_title_label">الاسم</string>
+    <string name="kv_created">تم الإنشاء</string>
+    <string name="kv_deleted">تم الحذف</string>
+    <string name="kv_delete_title">حذف مساحة الأسماء</string>
+    <string name="kv_delete_warn">سيؤدي هذا إلى حذف مساحة الأسماء %1$s وجميع مفاتيحها وقيمها نهائيًا. لا يمكن التراجع عن ذلك أو استعادته.</string>
+    <string name="kv_delete_confirm_label">أدخل اسم مساحة الأسماء للتأكيد</string>
+    <string name="kv_delete_button">حذف نهائي</string>
+    <string name="r2_create_title">إنشاء حاوية تخزين</string>
+    <string name="r2_create">إنشاء</string>
+    <string name="r2_name">الاسم</string>
+    <string name="r2_name_hint">أحرف صغيرة وأرقام وشرطات، من 3 إلى 63 حرفًا.</string>
+    <string name="r2_created">تم الإنشاء</string>
+    <string name="r2_delete_title">حذف حاوية التخزين</string>
+    <string name="r2_delete_warn">سيؤدي هذا إلى حذف الحاوية %1$s نهائيًا. لا يمكن التراجع عن ذلك. يجب أن تكون الحاوية فارغة لحذفها.</string>
+    <string name="r2_delete_confirm_label">أدخل اسم الحاوية للتأكيد</string>
+    <string name="r2_delete_button">حذف نهائي</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">تم حذف النشر</string>
+    <string name="pages_deployment_delete_title">حذف النشر</string>
+    <string name="pages_deployment_delete_msg">سيؤدي هذا إلى حذف النشر %1$s نهائيًا. لا يمكن التراجع عن ذلك. لا يمكن حذف نشر الإنتاج الحالي.</string>
+    <string name="worker_manage_deployments">سجل عمليات النشر</string>
+    <string name="worker_deployments_title">سجل عمليات النشر</string>
+    <string name="worker_deployments_empty">لا توجد عمليات نشر</string>
+    <string name="worker_deployments_note">العنصر الأول هو النشر النشط ولا يمكن حذفه.</string>
+    <string name="worker_deployment_active">نشط</string>
+    <string name="worker_deployment_deleted">تم حذف النشر</string>
+    <string name="worker_deployment_delete_title">حذف النشر</string>
+    <string name="worker_deployment_delete_msg">سيؤدي هذا إلى حذف النشر %1$s نهائيًا. لا يمكن التراجع عن ذلك. لا يمكن حذف النشر النشط.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">الاستخدام</string>
+    <string name="usage_locked">يلزم إذن تحليلات الحركة لعرض استخدام الحساب</string>
+    <string name="usage_unavailable_title">بيانات مستوى الحساب غير متاحة لهذا الحساب</string>
+    <string name="usage_unavailable_body">يتطلب استخدام Workers / R2 / D1 / KV عادةً حساب Cloudflare مدفوعًا؛ ولا يتأثر تحليل حركة النطاقات.</string>
+    <string name="usage_failed">تعذّر تحميل الاستخدام — انقر لإعادة المحاولة</string>
+    <string name="usage_period_month">هذا الشهر</string>
+    <string name="usage_period_cycle">الدورة</string>
+    <string name="usage_today">اليوم</string>
+    <string name="usage_plan_workers">خطة Workers</string>
+    <string name="usage_plan_r2">خطة R2</string>
+    <string name="usage_ctx_requests">الطلبات · %1$s</string>
+    <string name="usage_ctx_cpu">المعالج · %1$s</string>
+    <string name="usage_ctx_r2a">الفئة A · %1$s</string>
+    <string name="usage_ctx_r2b">الفئة B · %1$s</string>
+    <string name="usage_ctx_storage">التخزين</string>
+    <string name="usage_ctx_rows_read">صفوف مقروءة · %1$s</string>
+    <string name="usage_ctx_rows_write">صفوف مكتوبة · %1$s</string>
+    <string name="usage_ctx_reads">القراءات · %1$s</string>
+    <string name="usage_ctx_writes">الكتابات · %1$s</string>
+    <string name="usage_billing_day">يوم الفوترة</string>
+    <string name="usage_billing_natural">الشهر الميلادي</string>
+    <string name="usage_billing_day_n">اليوم %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ar/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ar/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">نظرة عامة على استخدام الحساب</string>
+    <string name="whatsnew_1_6_4_0_detail">أصبحت شاشة النظرة العامة تعرض وحدة استخدام: استخدام Workers وR2 وD1 وKV مقابل الحصص في لمحة، مع تبديل الخطة وتفاصيل لكل مقياس.</string>
+    <string name="whatsnew_1_6_4_1_title">سجل عمليات نشر Worker وحذفه</string>
+    <string name="whatsnew_1_6_4_1_detail">اطّلع على عمليات نشر Worker السابقة واحذف القديمة، مع إمكانية تعديل وحذف Workers.</string>
+    <string name="whatsnew_1_6_4_2_title">مزيد من إدارة التخزين</string>
+    <string name="whatsnew_1_6_4_2_detail">أنشئ واحذف مساحات أسماء KV وحاويات R2، واحذف جداول D1 وعمليات نشر Pages.</string>
     <string name="whatsnew_1_6_0_0_title">نطاقات Pages المخصصة</string>
     <string name="whatsnew_1_6_0_0_detail">أدر النطاقات المخصصة داخل مشروع Pages مباشرة: إضافة وحذف وإعادة تحقق وفحص حالة DNS — مع إضافة سجل CNAME بلمسة واحدة عندما تكون منطقة النطاق ضمن حسابك.</string>
     <string name="whatsnew_1_6_0_1_title">ترتيب القوائم</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -550,6 +550,10 @@
     <string name="d1_delete_warn">Dies löscht die Datenbank %1$s und alle ihre Tabellen und Daten dauerhaft. Dies kann nicht rückgängig gemacht oder wiederhergestellt werden.</string>
     <string name="d1_delete_confirm_label">Datenbanknamen zur Bestätigung eingeben</string>
     <string name="d1_delete_button">Dauerhaft löschen</string>
+    <string name="d1_drop_table_title">Tabelle löschen</string>
+    <string name="d1_drop_table_warn">Dies löscht die Tabelle %1$s und alle ihre Daten dauerhaft. Dies kann nicht rückgängig gemacht oder wiederhergestellt werden.</string>
+    <string name="d1_drop_table_confirm_label">Tabellennamen zur Bestätigung eingeben</string>
+    <string name="d1_table_dropped">Tabelle gelöscht</string>
     <string name="worker_manage_secrets">Variablen &amp; Secrets</string>
     <string name="worker_manage_triggers">Trigger</string>
     <string name="worker_manage_domains">Domains</string>
@@ -984,7 +988,7 @@
     <string name="worker_create_name_hint">Mit Kleinbuchstabe/Ziffer beginnen; Bindestrich/Unterstrich erlaubt</string>
     <string name="worker_create_compat">Kompatibilitätsdatum</string>
     <string name="worker_create_code">Code (ES-Modul)</string>
-    <string name="worker_create_note">Hinweis: Diese App kann den vorhandenen Worker-Quellcode nicht lesen (Cloudflare sperrt diesen Endpunkt für OAuth); Erstellen/Überschreiben erfordert den vollständigen Code. Bindings (Variablen/Secrets/KV) separat in den Worker-Details verwalten.</string>
+    <string name="worker_create_note">Tipp: Zum Erstellen oder vollständigen Ersetzen ist der komplette Code erforderlich. Bindings (Variablen, Secrets, KV usw.) werden separat in den Worker-Details verwaltet.</string>
     <string name="worker_create_deploy">Bereitstellen</string>
     <string name="worker_create_ok">Bereitgestellt</string>
     <string name="pages_deploy_code">Code bereitstellen</string>
@@ -1137,4 +1141,70 @@
     <string name="sort_default">Standard (Name)</string>
     <string name="sort_created">Erstellungsdatum</string>
     <string name="sort_modified">Zuletzt aktualisiert</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Code bearbeiten</string>
+    <string name="worker_edit_ok">Bereitgestellt</string>
+    <string name="worker_edit_loading">Quellcode wird geladen…</string>
+    <string name="worker_edit_multimodule">Dies ist ein Worker mit mehreren Modulen (gebündelt). Direktes Bearbeiten in der App wird nicht unterstützt (andere Module gingen verloren).</string>
+    <string name="worker_edit_note">Aktueller Live-Quellcode geladen. Direkt bearbeiten und bereitstellen. Vorhandene Variablen, Secrets und Bindings bleiben automatisch erhalten.</string>
+    <string name="worker_manage_edit">Code bearbeiten</string>
+    <string name="worker_delete_button">Worker löschen</string>
+    <string name="worker_delete_title">Worker löschen</string>
+    <string name="worker_delete_warn">Dadurch werden der Worker %1$s sowie seine Bereitstellungen und Routen-Bindings dauerhaft gelöscht. Das kann nicht rückgängig gemacht oder wiederhergestellt werden.</string>
+    <string name="worker_delete_confirm_label">Zur Bestätigung den Worker-Namen eingeben</string>
+    <string name="kv_create_title">Namespace erstellen</string>
+    <string name="kv_create">Erstellen</string>
+    <string name="kv_title_label">Name</string>
+    <string name="kv_created">Erstellt</string>
+    <string name="kv_deleted">Gelöscht</string>
+    <string name="kv_delete_title">Namespace löschen</string>
+    <string name="kv_delete_warn">Dadurch werden der Namespace %1$s und alle seine Schlüssel und Werte dauerhaft gelöscht. Das kann nicht rückgängig gemacht oder wiederhergestellt werden.</string>
+    <string name="kv_delete_confirm_label">Zur Bestätigung den Namespace-Namen eingeben</string>
+    <string name="kv_delete_button">Dauerhaft löschen</string>
+    <string name="r2_create_title">Bucket erstellen</string>
+    <string name="r2_create">Erstellen</string>
+    <string name="r2_name">Name</string>
+    <string name="r2_name_hint">Kleinbuchstaben, Zahlen und Bindestriche, 3–63 Zeichen.</string>
+    <string name="r2_created">Erstellt</string>
+    <string name="r2_delete_title">Bucket löschen</string>
+    <string name="r2_delete_warn">Dadurch wird der Bucket %1$s dauerhaft gelöscht. Das kann nicht rückgängig gemacht werden. Der Bucket muss leer sein, um gelöscht zu werden.</string>
+    <string name="r2_delete_confirm_label">Zur Bestätigung den Bucket-Namen eingeben</string>
+    <string name="r2_delete_button">Dauerhaft löschen</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Bereitstellung gelöscht</string>
+    <string name="pages_deployment_delete_title">Bereitstellung löschen</string>
+    <string name="pages_deployment_delete_msg">Dadurch wird die Bereitstellung %1$s dauerhaft gelöscht. Das kann nicht rückgängig gemacht werden. Die aktuelle Produktionsbereitstellung kann nicht gelöscht werden.</string>
+    <string name="worker_manage_deployments">Bereitstellungsverlauf</string>
+    <string name="worker_deployments_title">Bereitstellungsverlauf</string>
+    <string name="worker_deployments_empty">Keine Bereitstellungen</string>
+    <string name="worker_deployments_note">Der erste Eintrag ist die aktive Bereitstellung und kann nicht gelöscht werden.</string>
+    <string name="worker_deployment_active">Aktiv</string>
+    <string name="worker_deployment_deleted">Bereitstellung gelöscht</string>
+    <string name="worker_deployment_delete_title">Bereitstellung löschen</string>
+    <string name="worker_deployment_delete_msg">Dadurch wird die Bereitstellung %1$s dauerhaft gelöscht. Das kann nicht rückgängig gemacht werden. Die aktive Bereitstellung kann nicht gelöscht werden.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Nutzung</string>
+    <string name="usage_locked">Für die Anzeige der Kontonutzung ist die Berechtigung „Traffic-Analyse“ erforderlich</string>
+    <string name="usage_unavailable_title">Für dieses Konto sind keine Daten auf Kontoebene verfügbar</string>
+    <string name="usage_unavailable_body">Die Nutzung von Workers / R2 / D1 / KV erfordert in der Regel ein kostenpflichtiges Cloudflare-Konto; die Domain-Traffic-Analyse ist nicht betroffen.</string>
+    <string name="usage_failed">Nutzung konnte nicht geladen werden – zum Wiederholen tippen</string>
+    <string name="usage_period_month">Diesen Monat</string>
+    <string name="usage_period_cycle">Zeitraum</string>
+    <string name="usage_today">Heute</string>
+    <string name="usage_plan_workers">Workers-Tarif</string>
+    <string name="usage_plan_r2">R2-Tarif</string>
+    <string name="usage_ctx_requests">Anfragen · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">Klasse A · %1$s</string>
+    <string name="usage_ctx_r2b">Klasse B · %1$s</string>
+    <string name="usage_ctx_storage">Speicher</string>
+    <string name="usage_ctx_rows_read">Zeilen gelesen · %1$s</string>
+    <string name="usage_ctx_rows_write">Zeilen geschrieben · %1$s</string>
+    <string name="usage_ctx_reads">Lesevorgänge · %1$s</string>
+    <string name="usage_ctx_writes">Schreibvorgänge · %1$s</string>
+    <string name="usage_billing_day">Abrechnungstag</string>
+    <string name="usage_billing_natural">Kalendermonat</string>
+    <string name="usage_billing_day_n">Tag %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-de/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-de/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Übersicht der Kontonutzung</string>
+    <string name="whatsnew_1_6_4_0_detail">Die Übersicht zeigt jetzt ein Nutzungsmodul – Workers-, R2-, D1- und KV-Nutzung im Verhältnis zu den Kontingenten auf einen Blick, mit Tarifwechsel und Details je Kennzahl.</string>
+    <string name="whatsnew_1_6_4_1_title">Worker-Bereitstellungsverlauf und Löschen</string>
+    <string name="whatsnew_1_6_4_1_detail">Sieh dir frühere Bereitstellungen eines Workers an und lösche alte – außerdem Worker bearbeiten und löschen.</string>
+    <string name="whatsnew_1_6_4_2_title">Mehr Speicherverwaltung</string>
+    <string name="whatsnew_1_6_4_2_detail">KV-Namespaces und R2-Buckets erstellen/löschen, D1-Tabellen löschen und Pages-Bereitstellungen entfernen.</string>
     <string name="whatsnew_1_6_0_0_title">Benutzerdefinierte Domains für Pages</string>
     <string name="whatsnew_1_6_0_0_detail">Verwalte benutzerdefinierte Domains direkt im Pages-Projekt: hinzufügen, entfernen, erneut validieren und DNS-Status prüfen – mit Ein-Tipp-CNAME, wenn die Zone der Domain in deinem Konto liegt.</string>
     <string name="whatsnew_1_6_0_1_title">Listensortierung</string>

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -455,6 +455,10 @@
     <string name="d1_delete_warn">This permanently deletes the database %1$s and all its tables and data. This cannot be undone or recovered.</string>
     <string name="d1_delete_confirm_label">Type the database name to confirm</string>
     <string name="d1_delete_button">Delete permanently</string>
+    <string name="d1_drop_table_title">Delete table</string>
+    <string name="d1_drop_table_warn">This permanently deletes the table %1$s and all its data. This cannot be undone or recovered.</string>
+    <string name="d1_drop_table_confirm_label">Type the table name to confirm</string>
+    <string name="d1_table_dropped">Table deleted</string>
 
     <!-- Worker management -->
     <string name="worker_manage_secrets">Variables &amp; secrets</string>
@@ -1047,7 +1051,7 @@
     <string name="worker_create_name_hint">Start with lowercase letter/digit; may contain hyphen and underscore</string>
     <string name="worker_create_compat">Compatibility date</string>
     <string name="worker_create_code">Code (ES module)</string>
-    <string name="worker_create_note">Note: this app can\'t read existing Worker source (Cloudflare blocks that endpoint for OAuth); creating or replacing requires full code. Manage bindings (vars/secrets/KV) separately in Worker details.</string>
+    <string name="worker_create_note">Tip: Creating or fully replacing requires the complete code. Manage bindings (variables, secrets, KV, etc.) separately in the Worker details.</string>
     <string name="worker_create_deploy">Deploy</string>
     <string name="worker_create_ok">Deployed</string>
     <string name="pages_deploy_code">Deploy code</string>
@@ -1200,4 +1204,70 @@
     <string name="sort_default">Default (name)</string>
     <string name="sort_created">Date created</string>
     <string name="sort_modified">Recently updated</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Edit Code</string>
+    <string name="worker_edit_ok">Deployed</string>
+    <string name="worker_edit_loading">Loading source…</string>
+    <string name="worker_edit_multimodule">This is a multi-module (bundled) Worker; in-app in-place editing isn\'t supported (other modules would be lost).</string>
+    <string name="worker_edit_note">Current live source loaded. Edit and deploy directly. Existing variables, secrets and bindings are kept automatically.</string>
+    <string name="worker_manage_edit">Edit Code</string>
+    <string name="worker_delete_button">Delete Worker</string>
+    <string name="worker_delete_title">Delete Worker</string>
+    <string name="worker_delete_warn">This will permanently delete the Worker %1$s along with its deployments and route bindings. This cannot be undone or recovered.</string>
+    <string name="worker_delete_confirm_label">Enter the Worker name to confirm</string>
+    <string name="kv_create_title">Create Namespace</string>
+    <string name="kv_create">Create</string>
+    <string name="kv_title_label">Name</string>
+    <string name="kv_created">Created</string>
+    <string name="kv_deleted">Deleted</string>
+    <string name="kv_delete_title">Delete Namespace</string>
+    <string name="kv_delete_warn">This will permanently delete the namespace %1$s and all of its keys and values. This cannot be undone or recovered.</string>
+    <string name="kv_delete_confirm_label">Enter the namespace name to confirm</string>
+    <string name="kv_delete_button">Permanently Delete</string>
+    <string name="r2_create_title">Create Bucket</string>
+    <string name="r2_create">Create</string>
+    <string name="r2_name">Name</string>
+    <string name="r2_name_hint">Lowercase letters, numbers and hyphens, 3–63 characters.</string>
+    <string name="r2_created">Created</string>
+    <string name="r2_delete_title">Delete Bucket</string>
+    <string name="r2_delete_warn">This will permanently delete the bucket %1$s. This cannot be undone. The bucket must be empty to delete.</string>
+    <string name="r2_delete_confirm_label">Enter the bucket name to confirm</string>
+    <string name="r2_delete_button">Permanently Delete</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Deployment deleted</string>
+    <string name="pages_deployment_delete_title">Delete Deployment</string>
+    <string name="pages_deployment_delete_msg">This will permanently delete deployment %1$s. This cannot be undone. The current production deployment cannot be deleted.</string>
+    <string name="worker_manage_deployments">Deployment History</string>
+    <string name="worker_deployments_title">Deployment History</string>
+    <string name="worker_deployments_empty">No deployments</string>
+    <string name="worker_deployments_note">The first entry is the active deployment and cannot be deleted.</string>
+    <string name="worker_deployment_active">Active</string>
+    <string name="worker_deployment_deleted">Deployment deleted</string>
+    <string name="worker_deployment_delete_title">Delete Deployment</string>
+    <string name="worker_deployment_delete_msg">This will permanently delete deployment %1$s. This cannot be undone. The active deployment cannot be deleted.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Usage</string>
+    <string name="usage_locked">Traffic analytics permission is required to show account usage</string>
+    <string name="usage_unavailable_title">Account-level data isn\'t available for this account</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV usage usually needs a paid Cloudflare account; domain traffic analytics is unaffected.</string>
+    <string name="usage_failed">Usage failed to load — tap to retry</string>
+    <string name="usage_period_month">This month</string>
+    <string name="usage_period_cycle">Cycle</string>
+    <string name="usage_today">Today</string>
+    <string name="usage_plan_workers">Workers plan</string>
+    <string name="usage_plan_r2">R2 plan</string>
+    <string name="usage_ctx_requests">Requests · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">Class A · %1$s</string>
+    <string name="usage_ctx_r2b">Class B · %1$s</string>
+    <string name="usage_ctx_storage">Storage</string>
+    <string name="usage_ctx_rows_read">Rows read · %1$s</string>
+    <string name="usage_ctx_rows_write">Rows written · %1$s</string>
+    <string name="usage_ctx_reads">Reads · %1$s</string>
+    <string name="usage_ctx_writes">Writes · %1$s</string>
+    <string name="usage_billing_day">Billing day</string>
+    <string name="usage_billing_natural">Calendar month</string>
+    <string name="usage_billing_day_n">Day %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-en/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-en/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Account usage overview</string>
+    <string name="whatsnew_1_6_4_0_detail">The overview now has a usage module — see Workers, R2, D1 and KV usage against their quotas at a glance, with plan switching and per-metric details.</string>
+    <string name="whatsnew_1_6_4_1_title">Worker deployment history and delete</string>
+    <string name="whatsnew_1_6_4_1_detail">View a Worker’s past deployments and delete old ones, plus edit and delete Workers.</string>
+    <string name="whatsnew_1_6_4_2_title">More storage management</string>
+    <string name="whatsnew_1_6_4_2_detail">Create and delete KV namespaces and R2 buckets, drop D1 tables, and delete Pages deployments.</string>
     <string name="whatsnew_1_6_0_0_title">Pages custom domains</string>
     <string name="whatsnew_1_6_0_0_detail">Manage custom domains right inside a Pages project: add, remove, re-validate, and check DNS status — with one-tap CNAME setup when the domain’s zone is on your account.</string>
     <string name="whatsnew_1_6_0_1_title">List sorting</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -432,6 +432,10 @@
     <string name="d1_delete_warn">Esto elimina permanentemente la base de datos %1$s y todas sus tablas y datos. No se puede deshacer ni recuperar.</string>
     <string name="d1_delete_confirm_label">Escribe el nombre de la base de datos para confirmar</string>
     <string name="d1_delete_button">Eliminar definitivamente</string>
+    <string name="d1_drop_table_title">Eliminar tabla</string>
+    <string name="d1_drop_table_warn">Esto elimina permanentemente la tabla %1$s y todos sus datos. No se puede deshacer ni recuperar.</string>
+    <string name="d1_drop_table_confirm_label">Escribe el nombre de la tabla para confirmar</string>
+    <string name="d1_table_dropped">Tabla eliminada</string>
 
     <!-- Gestión de Workers -->
     <string name="worker_manage_secrets">Variables y secretos</string>
@@ -1024,7 +1028,7 @@
     <string name="worker_create_name_hint">Empieza con minúscula/dígito; admite guion y guion bajo</string>
     <string name="worker_create_compat">Fecha de compatibilidad</string>
     <string name="worker_create_code">Código (módulo ES)</string>
-    <string name="worker_create_note">Nota: esta app no puede leer el código de un Worker existente (Cloudflare bloquea ese endpoint para OAuth); crear o reemplazar requiere el código completo. Gestiona los bindings (variables/secretos/KV) en los detalles del Worker.</string>
+    <string name="worker_create_note">Consejo: Crear o reemplazar por completo requiere el código completo. Administra los enlaces (variables, secretos, KV, etc.) por separado en los detalles del Worker.</string>
     <string name="worker_create_deploy">Desplegar</string>
     <string name="worker_create_ok">Desplegado</string>
     <string name="pages_deploy_code">Desplegar código</string>
@@ -1177,4 +1181,70 @@
     <string name="sort_default">Predeterminado (nombre)</string>
     <string name="sort_created">Fecha de creación</string>
     <string name="sort_modified">Actualización reciente</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Editar código</string>
+    <string name="worker_edit_ok">Implementado</string>
+    <string name="worker_edit_loading">Cargando código fuente…</string>
+    <string name="worker_edit_multimodule">Este Worker es de múltiples módulos (empaquetado); no se admite la edición directa en la app (se perderían los demás módulos).</string>
+    <string name="worker_edit_note">Se cargó el código fuente en producción. Edítalo y despliégalo directamente. Las variables, secretos y enlaces existentes se conservan automáticamente.</string>
+    <string name="worker_manage_edit">Editar código</string>
+    <string name="worker_delete_button">Eliminar Worker</string>
+    <string name="worker_delete_title">Eliminar Worker</string>
+    <string name="worker_delete_warn">Esto eliminará permanentemente el Worker %1$s junto con sus implementaciones y enlaces de ruta. No se puede deshacer ni recuperar.</string>
+    <string name="worker_delete_confirm_label">Escribe el nombre del Worker para confirmar</string>
+    <string name="kv_create_title">Crear espacio de nombres</string>
+    <string name="kv_create">Crear</string>
+    <string name="kv_title_label">Nombre</string>
+    <string name="kv_created">Creado</string>
+    <string name="kv_deleted">Eliminado</string>
+    <string name="kv_delete_title">Eliminar espacio de nombres</string>
+    <string name="kv_delete_warn">Esto eliminará permanentemente el espacio de nombres %1$s y todas sus claves y valores. No se puede deshacer ni recuperar.</string>
+    <string name="kv_delete_confirm_label">Escribe el nombre del espacio de nombres para confirmar</string>
+    <string name="kv_delete_button">Eliminar permanentemente</string>
+    <string name="r2_create_title">Crear bucket</string>
+    <string name="r2_create">Crear</string>
+    <string name="r2_name">Nombre</string>
+    <string name="r2_name_hint">Letras minúsculas, números y guiones, 3–63 caracteres.</string>
+    <string name="r2_created">Creado</string>
+    <string name="r2_delete_title">Eliminar bucket</string>
+    <string name="r2_delete_warn">Esto eliminará permanentemente el bucket %1$s. No se puede deshacer. El bucket debe estar vacío para eliminarlo.</string>
+    <string name="r2_delete_confirm_label">Escribe el nombre del bucket para confirmar</string>
+    <string name="r2_delete_button">Eliminar permanentemente</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Despliegue eliminado</string>
+    <string name="pages_deployment_delete_title">Eliminar despliegue</string>
+    <string name="pages_deployment_delete_msg">Esto eliminará permanentemente el despliegue %1$s. No se puede deshacer. El despliegue de producción actual no se puede eliminar.</string>
+    <string name="worker_manage_deployments">Historial de despliegues</string>
+    <string name="worker_deployments_title">Historial de despliegues</string>
+    <string name="worker_deployments_empty">Sin despliegues</string>
+    <string name="worker_deployments_note">La primera entrada es el despliegue activo y no se puede eliminar.</string>
+    <string name="worker_deployment_active">Activo</string>
+    <string name="worker_deployment_deleted">Despliegue eliminado</string>
+    <string name="worker_deployment_delete_title">Eliminar despliegue</string>
+    <string name="worker_deployment_delete_msg">Esto eliminará permanentemente el despliegue %1$s. No se puede deshacer. El despliegue activo no se puede eliminar.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Uso</string>
+    <string name="usage_locked">Se requiere el permiso de análisis de tráfico para mostrar el uso de la cuenta</string>
+    <string name="usage_unavailable_title">Esta cuenta no tiene datos a nivel de cuenta disponibles</string>
+    <string name="usage_unavailable_body">El uso de Workers / R2 / D1 / KV suele requerir una cuenta de Cloudflare de pago; el análisis de tráfico de dominios no se ve afectado.</string>
+    <string name="usage_failed">No se pudo cargar el uso; toca para reintentar</string>
+    <string name="usage_period_month">Este mes</string>
+    <string name="usage_period_cycle">Ciclo</string>
+    <string name="usage_today">Hoy</string>
+    <string name="usage_plan_workers">Plan de Workers</string>
+    <string name="usage_plan_r2">Plan de R2</string>
+    <string name="usage_ctx_requests">Solicitudes · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">Clase A · %1$s</string>
+    <string name="usage_ctx_r2b">Clase B · %1$s</string>
+    <string name="usage_ctx_storage">Almacenamiento</string>
+    <string name="usage_ctx_rows_read">Filas leídas · %1$s</string>
+    <string name="usage_ctx_rows_write">Filas escritas · %1$s</string>
+    <string name="usage_ctx_reads">Lecturas · %1$s</string>
+    <string name="usage_ctx_writes">Escrituras · %1$s</string>
+    <string name="usage_billing_day">Día de facturación</string>
+    <string name="usage_billing_natural">Mes natural</string>
+    <string name="usage_billing_day_n">Día %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-es/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-es/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Resumen de uso de la cuenta</string>
+    <string name="whatsnew_1_6_4_0_detail">La pantalla de resumen ahora incluye un módulo de uso: consulta de un vistazo el uso de Workers, R2, D1 y KV frente a sus límites, con cambio de plan y detalles por métrica.</string>
+    <string name="whatsnew_1_6_4_1_title">Historial de despliegues y eliminación de Workers</string>
+    <string name="whatsnew_1_6_4_1_detail">Consulta los despliegues anteriores de un Worker y elimina los antiguos; además, edita y elimina Workers.</string>
+    <string name="whatsnew_1_6_4_2_title">Más gestión de almacenamiento</string>
+    <string name="whatsnew_1_6_4_2_detail">Crea y elimina espacios de nombres de KV y buckets de R2, elimina tablas de D1 y borra despliegues de Pages.</string>
     <string name="whatsnew_1_6_0_0_title">Dominios personalizados de Pages</string>
     <string name="whatsnew_1_6_0_0_detail">Administra dominios personalizados dentro de un proyecto de Pages: agregar, eliminar, revalidar y comprobar el estado del DNS; si la zona del dominio está en tu cuenta, agrega el registro CNAME con un toque.</string>
     <string name="whatsnew_1_6_0_1_title">Orden de listas</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -550,6 +550,10 @@
     <string name="d1_delete_warn">Cela supprime définitivement la base %1$s et toutes ses tables et données. Irréversible et non récupérable.</string>
     <string name="d1_delete_confirm_label">Tapez le nom de la base pour confirmer</string>
     <string name="d1_delete_button">Supprimer définitivement</string>
+    <string name="d1_drop_table_title">Supprimer la table</string>
+    <string name="d1_drop_table_warn">Cela supprime définitivement la table %1$s et toutes ses données. Irréversible et non récupérable.</string>
+    <string name="d1_drop_table_confirm_label">Tapez le nom de la table pour confirmer</string>
+    <string name="d1_table_dropped">Table supprimée</string>
     <string name="worker_manage_secrets">Variables &amp; secrets</string>
     <string name="worker_manage_triggers">Déclencheurs</string>
     <string name="worker_manage_domains">Domaines</string>
@@ -984,7 +988,7 @@
     <string name="worker_create_name_hint">Commence par minuscule/chiffre ; tiret et tiret bas autorisés</string>
     <string name="worker_create_compat">Date de compatibilité</string>
     <string name="worker_create_code">Code (module ES)</string>
-    <string name="worker_create_note">Remarque : l\'app ne peut pas lire le code d\'un Worker existant (Cloudflare bloque cet endpoint pour OAuth) ; créer ou remplacer exige le code complet. Gérez les bindings (variables/secrets/KV) dans les détails du Worker.</string>
+    <string name="worker_create_note">Astuce : la création ou le remplacement complet nécessite le code complet. Gérez les liaisons (variables, secrets, KV, etc.) séparément dans les détails du Worker.</string>
     <string name="worker_create_deploy">Déployer</string>
     <string name="worker_create_ok">Déployé</string>
     <string name="pages_deploy_code">Déployer le code</string>
@@ -1137,4 +1141,70 @@
     <string name="sort_default">Par défaut (nom)</string>
     <string name="sort_created">Date de création</string>
     <string name="sort_modified">Mise à jour récente</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Modifier le code</string>
+    <string name="worker_edit_ok">Déployé</string>
+    <string name="worker_edit_loading">Chargement du code source…</string>
+    <string name="worker_edit_multimodule">Ce Worker est multi-module (regroupé) ; la modification directe dans l\'app n\'est pas prise en charge (les autres modules seraient perdus).</string>
+    <string name="worker_edit_note">Code source en production chargé. Modifiez et déployez directement. Les variables, secrets et liaisons existants sont conservés automatiquement.</string>
+    <string name="worker_manage_edit">Modifier le code</string>
+    <string name="worker_delete_button">Supprimer le Worker</string>
+    <string name="worker_delete_title">Supprimer le Worker</string>
+    <string name="worker_delete_warn">Cette action supprimera définitivement le Worker %1$s ainsi que ses déploiements et liaisons de route. Elle est irréversible et irrécupérable.</string>
+    <string name="worker_delete_confirm_label">Saisissez le nom du Worker pour confirmer</string>
+    <string name="kv_create_title">Créer un espace de noms</string>
+    <string name="kv_create">Créer</string>
+    <string name="kv_title_label">Nom</string>
+    <string name="kv_created">Créé</string>
+    <string name="kv_deleted">Supprimé</string>
+    <string name="kv_delete_title">Supprimer l\'espace de noms</string>
+    <string name="kv_delete_warn">Cette action supprimera définitivement l\'espace de noms %1$s ainsi que toutes ses clés et valeurs. Elle est irréversible et irrécupérable.</string>
+    <string name="kv_delete_confirm_label">Saisissez le nom de l\'espace de noms pour confirmer</string>
+    <string name="kv_delete_button">Supprimer définitivement</string>
+    <string name="r2_create_title">Créer un bucket</string>
+    <string name="r2_create">Créer</string>
+    <string name="r2_name">Nom</string>
+    <string name="r2_name_hint">Lettres minuscules, chiffres et traits d\'union, 3 à 63 caractères.</string>
+    <string name="r2_created">Créé</string>
+    <string name="r2_delete_title">Supprimer le bucket</string>
+    <string name="r2_delete_warn">Cette action supprimera définitivement le bucket %1$s. Elle est irréversible. Le bucket doit être vide pour être supprimé.</string>
+    <string name="r2_delete_confirm_label">Saisissez le nom du bucket pour confirmer</string>
+    <string name="r2_delete_button">Supprimer définitivement</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Déploiement supprimé</string>
+    <string name="pages_deployment_delete_title">Supprimer le déploiement</string>
+    <string name="pages_deployment_delete_msg">Cette action supprimera définitivement le déploiement %1$s. Elle est irréversible. Le déploiement de production actuel ne peut pas être supprimé.</string>
+    <string name="worker_manage_deployments">Historique des déploiements</string>
+    <string name="worker_deployments_title">Historique des déploiements</string>
+    <string name="worker_deployments_empty">Aucun déploiement</string>
+    <string name="worker_deployments_note">La première entrée est le déploiement actif et ne peut pas être supprimée.</string>
+    <string name="worker_deployment_active">Actif</string>
+    <string name="worker_deployment_deleted">Déploiement supprimé</string>
+    <string name="worker_deployment_delete_title">Supprimer le déploiement</string>
+    <string name="worker_deployment_delete_msg">Cette action supprimera définitivement le déploiement %1$s. Elle est irréversible. Le déploiement actif ne peut pas être supprimé.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Utilisation</string>
+    <string name="usage_locked">L\'autorisation d\'analyse du trafic est nécessaire pour afficher l\'utilisation du compte</string>
+    <string name="usage_unavailable_title">Les données au niveau du compte ne sont pas disponibles pour ce compte</string>
+    <string name="usage_unavailable_body">L\'utilisation de Workers / R2 / D1 / KV nécessite généralement un compte Cloudflare payant ; l\'analyse du trafic des domaines n\'est pas affectée.</string>
+    <string name="usage_failed">Échec du chargement de l\'utilisation — touchez pour réessayer</string>
+    <string name="usage_period_month">Ce mois-ci</string>
+    <string name="usage_period_cycle">Cycle</string>
+    <string name="usage_today">Aujourd\'hui</string>
+    <string name="usage_plan_workers">Forfait Workers</string>
+    <string name="usage_plan_r2">Forfait R2</string>
+    <string name="usage_ctx_requests">Requêtes · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">Classe A · %1$s</string>
+    <string name="usage_ctx_r2b">Classe B · %1$s</string>
+    <string name="usage_ctx_storage">Stockage</string>
+    <string name="usage_ctx_rows_read">Lignes lues · %1$s</string>
+    <string name="usage_ctx_rows_write">Lignes écrites · %1$s</string>
+    <string name="usage_ctx_reads">Lectures · %1$s</string>
+    <string name="usage_ctx_writes">Écritures · %1$s</string>
+    <string name="usage_billing_day">Jour de facturation</string>
+    <string name="usage_billing_natural">Mois civil</string>
+    <string name="usage_billing_day_n">Jour %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-fr/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Aperçu de l’utilisation du compte</string>
+    <string name="whatsnew_1_6_4_0_detail">L’aperçu affiche désormais un module d’utilisation : usage de Workers, R2, D1 et KV par rapport aux quotas d’un coup d’œil, avec changement de forfait et détails par métrique.</string>
+    <string name="whatsnew_1_6_4_1_title">Historique des déploiements et suppression de Workers</string>
+    <string name="whatsnew_1_6_4_1_detail">Consultez les déploiements passés d’un Worker et supprimez les anciens ; modifiez et supprimez aussi des Workers.</string>
+    <string name="whatsnew_1_6_4_2_title">Gestion du stockage étendue</string>
+    <string name="whatsnew_1_6_4_2_detail">Créez et supprimez des namespaces KV et des buckets R2, supprimez des tables D1 et des déploiements Pages.</string>
     <string name="whatsnew_1_6_0_0_title">Domaines personnalisés Pages</string>
     <string name="whatsnew_1_6_0_0_detail">Gérez les domaines personnalisés directement dans un projet Pages : ajout, suppression, revalidation et vérification du DNS — avec création du CNAME en un geste quand la zone du domaine est sur votre compte.</string>
     <string name="whatsnew_1_6_0_1_title">Tri des listes</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -431,6 +431,10 @@
     <string name="d1_delete_warn">データベース %1$s とそのすべてのテーブル・データを完全に削除します。取り消しや復元はできません。</string>
     <string name="d1_delete_confirm_label">確認のためデータベース名を入力</string>
     <string name="d1_delete_button">完全に削除</string>
+    <string name="d1_drop_table_title">テーブルを削除</string>
+    <string name="d1_drop_table_warn">テーブル %1$s とそのすべてのデータを完全に削除します。取り消しや復元はできません。</string>
+    <string name="d1_drop_table_confirm_label">確認のためテーブル名を入力</string>
+    <string name="d1_table_dropped">テーブルを削除しました</string>
 
     <!-- Worker 管理 -->
     <string name="worker_manage_secrets">変数とシークレット</string>
@@ -1023,7 +1027,7 @@
     <string name="worker_create_name_hint">小文字/数字で始め、ハイフン・アンダースコア可</string>
     <string name="worker_create_compat">互換性日付</string>
     <string name="worker_create_code">コード（ES module）</string>
-    <string name="worker_create_note">注意：本アプリは既存 Worker のソースを取得できません（Cloudflare が OAuth に対し当該エンドポイントを禁止）。新規・上書きには完全なコードが必要です。バインディング（変数/シークレット/KV 等）は Worker 詳細で個別に管理してください。</string>
+    <string name="worker_create_note">ヒント：新規作成または全体の置き換えには完全なコードが必要です。バインディング（変数・シークレット・KV など）は Worker の詳細で個別に管理してください。</string>
     <string name="worker_create_deploy">デプロイ</string>
     <string name="worker_create_ok">デプロイしました</string>
     <string name="pages_deploy_code">コードをデプロイ</string>
@@ -1176,4 +1180,70 @@
     <string name="sort_default">デフォルト（名前）</string>
     <string name="sort_created">作成日</string>
     <string name="sort_modified">最近の更新</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">コードを編集</string>
+    <string name="worker_edit_ok">デプロイしました</string>
+    <string name="worker_edit_loading">ソースを読み込み中…</string>
+    <string name="worker_edit_multimodule">これは複数モジュールのバンドル Worker です。アプリ内での直接編集には対応していません（他のモジュールが失われます）。</string>
+    <string name="worker_edit_note">現在の本番ソースを読み込みました。そのまま編集してデプロイできます。既存の変数・シークレット・バインディングは自動的に保持されます。</string>
+    <string name="worker_manage_edit">コードを編集</string>
+    <string name="worker_delete_button">Worker を削除</string>
+    <string name="worker_delete_title">Worker を削除</string>
+    <string name="worker_delete_warn">この操作は Worker %1$s とそのデプロイおよびルートバインディングを完全に削除します。取り消しも復元もできません。</string>
+    <string name="worker_delete_confirm_label">確認のため Worker 名を入力</string>
+    <string name="kv_create_title">名前空間を作成</string>
+    <string name="kv_create">作成</string>
+    <string name="kv_title_label">名前</string>
+    <string name="kv_created">作成しました</string>
+    <string name="kv_deleted">削除しました</string>
+    <string name="kv_delete_title">名前空間を削除</string>
+    <string name="kv_delete_warn">この操作は名前空間 %1$s とそのすべてのキーと値を完全に削除します。取り消しも復元もできません。</string>
+    <string name="kv_delete_confirm_label">確認のため名前空間名を入力</string>
+    <string name="kv_delete_button">完全に削除</string>
+    <string name="r2_create_title">バケットを作成</string>
+    <string name="r2_create">作成</string>
+    <string name="r2_name">名前</string>
+    <string name="r2_name_hint">小文字・数字・ハイフン、3〜63 文字。</string>
+    <string name="r2_created">作成しました</string>
+    <string name="r2_delete_title">バケットを削除</string>
+    <string name="r2_delete_warn">この操作はバケット %1$s を完全に削除します。取り消せません。削除するにはバケットが空である必要があります。</string>
+    <string name="r2_delete_confirm_label">確認のためバケット名を入力</string>
+    <string name="r2_delete_button">完全に削除</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">デプロイを削除しました</string>
+    <string name="pages_deployment_delete_title">デプロイを削除</string>
+    <string name="pages_deployment_delete_msg">デプロイ %1$s を完全に削除します。元に戻せません。現在の本番デプロイは削除できません。</string>
+    <string name="worker_manage_deployments">デプロイ履歴</string>
+    <string name="worker_deployments_title">デプロイ履歴</string>
+    <string name="worker_deployments_empty">デプロイがありません</string>
+    <string name="worker_deployments_note">先頭は稼働中のデプロイで、削除できません。</string>
+    <string name="worker_deployment_active">稼働中</string>
+    <string name="worker_deployment_deleted">デプロイを削除しました</string>
+    <string name="worker_deployment_delete_title">デプロイを削除</string>
+    <string name="worker_deployment_delete_msg">デプロイ %1$s を完全に削除します。元に戻せません。稼働中のデプロイは削除できません。</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">使用量</string>
+    <string name="usage_locked">アカウントの使用量を表示するには「トラフィック分析」権限が必要です</string>
+    <string name="usage_unavailable_title">このアカウントではアカウントレベルのデータを取得できません</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV の使用量は通常、有料版の Cloudflare アカウントが必要です。ドメインのトラフィック分析には影響しません。</string>
+    <string name="usage_failed">使用量の読み込みに失敗しました。タップして再試行</string>
+    <string name="usage_period_month">今月</string>
+    <string name="usage_period_cycle">期間</string>
+    <string name="usage_today">今日</string>
+    <string name="usage_plan_workers">Workers プラン</string>
+    <string name="usage_plan_r2">R2 プラン</string>
+    <string name="usage_ctx_requests">リクエスト · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">クラス A · %1$s</string>
+    <string name="usage_ctx_r2b">クラス B · %1$s</string>
+    <string name="usage_ctx_storage">ストレージ</string>
+    <string name="usage_ctx_rows_read">行の読み取り · %1$s</string>
+    <string name="usage_ctx_rows_write">行の書き込み · %1$s</string>
+    <string name="usage_ctx_reads">読み取り · %1$s</string>
+    <string name="usage_ctx_writes">書き込み · %1$s</string>
+    <string name="usage_billing_day">請求日</string>
+    <string name="usage_billing_natural">暦月</string>
+    <string name="usage_billing_day_n">%1$d 日</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ja/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ja/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">アカウント使用量の概要</string>
+    <string name="whatsnew_1_6_4_0_detail">概要画面に使用量モジュールを追加。Workers・R2・D1・KV の使用量と上限をひと目で確認でき、プラン切り替えと項目ごとの詳細に対応します。</string>
+    <string name="whatsnew_1_6_4_1_title">Worker のデプロイ履歴と削除</string>
+    <string name="whatsnew_1_6_4_1_detail">各 Worker の過去のデプロイを確認して古いものを削除できるほか、Worker の編集・削除にも対応します。</string>
+    <string name="whatsnew_1_6_4_2_title">ストレージ管理の強化</string>
+    <string name="whatsnew_1_6_4_2_detail">KV 名前空間と R2 バケットの作成・削除、D1 テーブルの削除、Pages デプロイの削除に対応しました。</string>
     <string name="whatsnew_1_6_0_0_title">Pages カスタムドメイン</string>
     <string name="whatsnew_1_6_0_0_detail">Pages プロジェクト内でカスタムドメインを直接管理：追加・削除・再検証と DNS 状態の確認に対応。ドメインが現在のアカウントにある場合は、プロジェクトへ向ける CNAME レコードをワンタップで追加できます。</string>
     <string name="whatsnew_1_6_0_1_title">リストの並べ替え</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -431,6 +431,10 @@
     <string name="d1_delete_warn">데이터베이스 %1$s와 모든 테이블 및 데이터를 영구적으로 삭제합니다. 취소하거나 복구할 수 없습니다.</string>
     <string name="d1_delete_confirm_label">확인을 위해 데이터베이스 이름 입력</string>
     <string name="d1_delete_button">영구 삭제</string>
+    <string name="d1_drop_table_title">테이블 삭제</string>
+    <string name="d1_drop_table_warn">테이블 %1$s와 모든 데이터를 영구적으로 삭제합니다. 취소하거나 복구할 수 없습니다.</string>
+    <string name="d1_drop_table_confirm_label">확인을 위해 테이블 이름 입력</string>
+    <string name="d1_table_dropped">테이블 삭제됨</string>
 
     <!-- Worker 관리 -->
     <string name="worker_manage_secrets">변수 및 시크릿</string>
@@ -1023,7 +1027,7 @@
     <string name="worker_create_name_hint">소문자/숫자로 시작, 하이픈·밑줄 가능</string>
     <string name="worker_create_compat">호환성 날짜</string>
     <string name="worker_create_code">코드(ES module)</string>
-    <string name="worker_create_note">참고: 이 앱은 기존 Worker 소스를 읽을 수 없습니다(Cloudflare가 OAuth에 대해 해당 엔드포인트를 차단). 생성/덮어쓰기에는 전체 코드가 필요합니다. 바인딩(변수/시크릿/KV)은 Worker 세부정보에서 관리하세요.</string>
+    <string name="worker_create_note">팁: 새로 만들거나 전체를 교체하려면 전체 코드가 필요합니다. 바인딩(변수, 시크릿, KV 등)은 Worker 세부 정보에서 별도로 관리하세요.</string>
     <string name="worker_create_deploy">배포</string>
     <string name="worker_create_ok">배포됨</string>
     <string name="pages_deploy_code">코드 배포</string>
@@ -1176,4 +1180,70 @@
     <string name="sort_default">기본(이름)</string>
     <string name="sort_created">생성일</string>
     <string name="sort_modified">최근 업데이트</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">코드 편집</string>
+    <string name="worker_edit_ok">배포됨</string>
+    <string name="worker_edit_loading">소스 불러오는 중…</string>
+    <string name="worker_edit_multimodule">이 Worker는 다중 모듈(번들) 형식으로, 앱 내 직접 편집을 지원하지 않습니다(다른 모듈이 사라집니다).</string>
+    <string name="worker_edit_note">현재 라이브 소스를 불러왔습니다. 바로 수정해 배포할 수 있습니다. 기존 변수·시크릿·바인딩은 자동으로 유지됩니다.</string>
+    <string name="worker_manage_edit">코드 편집</string>
+    <string name="worker_delete_button">Worker 삭제</string>
+    <string name="worker_delete_title">Worker 삭제</string>
+    <string name="worker_delete_warn">이 작업은 Worker %1$s 및 배포와 라우트 바인딩을 영구적으로 삭제합니다. 되돌리거나 복구할 수 없습니다.</string>
+    <string name="worker_delete_confirm_label">확인하려면 Worker 이름을 입력하세요</string>
+    <string name="kv_create_title">네임스페이스 만들기</string>
+    <string name="kv_create">만들기</string>
+    <string name="kv_title_label">이름</string>
+    <string name="kv_created">생성됨</string>
+    <string name="kv_deleted">삭제됨</string>
+    <string name="kv_delete_title">네임스페이스 삭제</string>
+    <string name="kv_delete_warn">이 작업은 네임스페이스 %1$s와 모든 키와 값을 영구적으로 삭제합니다. 되돌리거나 복구할 수 없습니다.</string>
+    <string name="kv_delete_confirm_label">확인하려면 네임스페이스 이름을 입력하세요</string>
+    <string name="kv_delete_button">영구 삭제</string>
+    <string name="r2_create_title">버킷 만들기</string>
+    <string name="r2_create">만들기</string>
+    <string name="r2_name">이름</string>
+    <string name="r2_name_hint">소문자, 숫자, 하이픈, 3–63자.</string>
+    <string name="r2_created">생성됨</string>
+    <string name="r2_delete_title">버킷 삭제</string>
+    <string name="r2_delete_warn">이 작업은 버킷 %1$s를 영구적으로 삭제합니다. 되돌릴 수 없습니다. 삭제하려면 버킷이 비어 있어야 합니다.</string>
+    <string name="r2_delete_confirm_label">확인하려면 버킷 이름을 입력하세요</string>
+    <string name="r2_delete_button">영구 삭제</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">배포 삭제됨</string>
+    <string name="pages_deployment_delete_title">배포 삭제</string>
+    <string name="pages_deployment_delete_msg">배포 %1$s를 영구적으로 삭제합니다. 되돌릴 수 없습니다. 현재 프로덕션 배포는 삭제할 수 없습니다.</string>
+    <string name="worker_manage_deployments">배포 기록</string>
+    <string name="worker_deployments_title">배포 기록</string>
+    <string name="worker_deployments_empty">배포 없음</string>
+    <string name="worker_deployments_note">첫 번째 항목은 활성 배포로 삭제할 수 없습니다.</string>
+    <string name="worker_deployment_active">활성</string>
+    <string name="worker_deployment_deleted">배포 삭제됨</string>
+    <string name="worker_deployment_delete_title">배포 삭제</string>
+    <string name="worker_deployment_delete_msg">배포 %1$s를 영구적으로 삭제합니다. 되돌릴 수 없습니다. 활성 배포는 삭제할 수 없습니다.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">사용량</string>
+    <string name="usage_locked">계정 사용량을 표시하려면 트래픽 분석 권한이 필요합니다</string>
+    <string name="usage_unavailable_title">이 계정은 계정 수준 데이터를 사용할 수 없습니다</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV 사용량은 보통 유료 Cloudflare 계정이 필요합니다. 도메인 트래픽 분석에는 영향이 없습니다.</string>
+    <string name="usage_failed">사용량을 불러오지 못했습니다. 눌러서 다시 시도</string>
+    <string name="usage_period_month">이번 달</string>
+    <string name="usage_period_cycle">청구 주기</string>
+    <string name="usage_today">오늘</string>
+    <string name="usage_plan_workers">Workers 요금제</string>
+    <string name="usage_plan_r2">R2 요금제</string>
+    <string name="usage_ctx_requests">요청 · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">클래스 A · %1$s</string>
+    <string name="usage_ctx_r2b">클래스 B · %1$s</string>
+    <string name="usage_ctx_storage">저장용량</string>
+    <string name="usage_ctx_rows_read">행 읽기 · %1$s</string>
+    <string name="usage_ctx_rows_write">행 쓰기 · %1$s</string>
+    <string name="usage_ctx_reads">읽기 · %1$s</string>
+    <string name="usage_ctx_writes">쓰기 · %1$s</string>
+    <string name="usage_billing_day">청구일</string>
+    <string name="usage_billing_natural">역월</string>
+    <string name="usage_billing_day_n">%1$d일</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ko/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">계정 사용량 개요</string>
+    <string name="whatsnew_1_6_4_0_detail">개요 화면에 사용량 모듈이 추가되어 Workers, R2, D1, KV 사용량과 한도를 한눈에 확인하고 요금제 전환과 항목별 세부 정보를 볼 수 있습니다.</string>
+    <string name="whatsnew_1_6_4_1_title">Worker 배포 기록 및 삭제</string>
+    <string name="whatsnew_1_6_4_1_detail">Worker의 과거 배포를 확인하고 이전 배포를 삭제할 수 있으며 Worker 편집과 삭제도 지원합니다.</string>
+    <string name="whatsnew_1_6_4_2_title">스토리지 관리 강화</string>
+    <string name="whatsnew_1_6_4_2_detail">KV 네임스페이스와 R2 버킷 생성/삭제, D1 테이블 삭제, Pages 배포 삭제를 지원합니다.</string>
     <string name="whatsnew_1_6_0_0_title">Pages 사용자 지정 도메인</string>
     <string name="whatsnew_1_6_0_0_detail">Pages 프로젝트에서 사용자 지정 도메인을 직접 관리하세요: 추가·삭제·재확인과 DNS 상태 확인을 지원하며, 도메인이 현재 계정에 있으면 프로젝트를 가리키는 CNAME 레코드를 한 번에 추가할 수 있습니다.</string>
     <string name="whatsnew_1_6_0_1_title">목록 정렬</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -431,6 +431,10 @@
     <string name="d1_delete_warn">Isso exclui permanentemente o banco de dados %1$s e todas as suas tabelas e dados. Não é possível desfazer nem recuperar.</string>
     <string name="d1_delete_confirm_label">Digite o nome do banco de dados para confirmar</string>
     <string name="d1_delete_button">Excluir permanentemente</string>
+    <string name="d1_drop_table_title">Excluir tabela</string>
+    <string name="d1_drop_table_warn">Isso exclui permanentemente a tabela %1$s e todos os seus dados. Não é possível desfazer nem recuperar.</string>
+    <string name="d1_drop_table_confirm_label">Digite o nome da tabela para confirmar</string>
+    <string name="d1_table_dropped">Tabela excluída</string>
 
     <!-- Gerenciamento de Workers -->
     <string name="worker_manage_secrets">Variáveis e segredos</string>
@@ -1023,7 +1027,7 @@
     <string name="worker_create_name_hint">Começa com minúscula/dígito; aceita hífen e sublinhado</string>
     <string name="worker_create_compat">Data de compatibilidade</string>
     <string name="worker_create_code">Código (módulo ES)</string>
-    <string name="worker_create_note">Nota: o app não consegue ler o código de um Worker existente (a Cloudflare bloqueia esse endpoint para OAuth); criar ou substituir exige o código completo. Gerencie os bindings (variáveis/segredos/KV) nos detalhes do Worker.</string>
+    <string name="worker_create_note">Dica: Criar ou substituir por completo requer o código completo. Gerencie as vinculações (variáveis, segredos, KV etc.) separadamente nos detalhes do Worker.</string>
     <string name="worker_create_deploy">Implantar</string>
     <string name="worker_create_ok">Implantado</string>
     <string name="pages_deploy_code">Implantar código</string>
@@ -1176,4 +1180,70 @@
     <string name="sort_default">Padrão (nome)</string>
     <string name="sort_created">Data de criação</string>
     <string name="sort_modified">Atualização recente</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Editar código</string>
+    <string name="worker_edit_ok">Implantado</string>
+    <string name="worker_edit_loading">Carregando código-fonte…</string>
+    <string name="worker_edit_multimodule">Este Worker é de múltiplos módulos (empacotado); a edição direta no app não é compatível (os outros módulos seriam perdidos).</string>
+    <string name="worker_edit_note">Código-fonte em produção carregado. Edite e implante diretamente. Variáveis, segredos e vinculações existentes são mantidos automaticamente.</string>
+    <string name="worker_manage_edit">Editar código</string>
+    <string name="worker_delete_button">Excluir Worker</string>
+    <string name="worker_delete_title">Excluir Worker</string>
+    <string name="worker_delete_warn">Isso excluirá permanentemente o Worker %1$s e suas implantações e vinculações de rota. Não é possível desfazer nem recuperar.</string>
+    <string name="worker_delete_confirm_label">Digite o nome do Worker para confirmar</string>
+    <string name="kv_create_title">Criar namespace</string>
+    <string name="kv_create">Criar</string>
+    <string name="kv_title_label">Nome</string>
+    <string name="kv_created">Criado</string>
+    <string name="kv_deleted">Excluído</string>
+    <string name="kv_delete_title">Excluir namespace</string>
+    <string name="kv_delete_warn">Isso excluirá permanentemente o namespace %1$s e todas as suas chaves e valores. Não é possível desfazer nem recuperar.</string>
+    <string name="kv_delete_confirm_label">Digite o nome do namespace para confirmar</string>
+    <string name="kv_delete_button">Excluir permanentemente</string>
+    <string name="r2_create_title">Criar bucket</string>
+    <string name="r2_create">Criar</string>
+    <string name="r2_name">Nome</string>
+    <string name="r2_name_hint">Letras minúsculas, números e hifens, 3–63 caracteres.</string>
+    <string name="r2_created">Criado</string>
+    <string name="r2_delete_title">Excluir bucket</string>
+    <string name="r2_delete_warn">Isso excluirá permanentemente o bucket %1$s. Não é possível desfazer. O bucket deve estar vazio para ser excluído.</string>
+    <string name="r2_delete_confirm_label">Digite o nome do bucket para confirmar</string>
+    <string name="r2_delete_button">Excluir permanentemente</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Implantação excluída</string>
+    <string name="pages_deployment_delete_title">Excluir implantação</string>
+    <string name="pages_deployment_delete_msg">Isso excluirá permanentemente a implantação %1$s. Não é possível desfazer. A implantação de produção atual não pode ser excluída.</string>
+    <string name="worker_manage_deployments">Histórico de implantações</string>
+    <string name="worker_deployments_title">Histórico de implantações</string>
+    <string name="worker_deployments_empty">Nenhuma implantação</string>
+    <string name="worker_deployments_note">A primeira entrada é a implantação ativa e não pode ser excluída.</string>
+    <string name="worker_deployment_active">Ativo</string>
+    <string name="worker_deployment_deleted">Implantação excluída</string>
+    <string name="worker_deployment_delete_title">Excluir implantação</string>
+    <string name="worker_deployment_delete_msg">Isso excluirá permanentemente a implantação %1$s. Não é possível desfazer. A implantação ativa não pode ser excluída.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Uso</string>
+    <string name="usage_locked">A permissão de análise de tráfego é necessária para mostrar o uso da conta</string>
+    <string name="usage_unavailable_title">Dados no nível da conta não estão disponíveis para esta conta</string>
+    <string name="usage_unavailable_body">O uso de Workers / R2 / D1 / KV normalmente exige uma conta paga da Cloudflare; a análise de tráfego de domínios não é afetada.</string>
+    <string name="usage_failed">Falha ao carregar o uso — toque para tentar novamente</string>
+    <string name="usage_period_month">Este mês</string>
+    <string name="usage_period_cycle">Ciclo</string>
+    <string name="usage_today">Hoje</string>
+    <string name="usage_plan_workers">Plano do Workers</string>
+    <string name="usage_plan_r2">Plano do R2</string>
+    <string name="usage_ctx_requests">Solicitações · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">Classe A · %1$s</string>
+    <string name="usage_ctx_r2b">Classe B · %1$s</string>
+    <string name="usage_ctx_storage">Armazenamento</string>
+    <string name="usage_ctx_rows_read">Linhas lidas · %1$s</string>
+    <string name="usage_ctx_rows_write">Linhas gravadas · %1$s</string>
+    <string name="usage_ctx_reads">Leituras · %1$s</string>
+    <string name="usage_ctx_writes">Gravações · %1$s</string>
+    <string name="usage_billing_day">Dia de cobrança</string>
+    <string name="usage_billing_natural">Mês civil</string>
+    <string name="usage_billing_day_n">Dia %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Visão geral de uso da conta</string>
+    <string name="whatsnew_1_6_4_0_detail">A tela de visão geral agora tem um módulo de uso: veja de relance o uso de Workers, R2, D1 e KV em relação às cotas, com troca de plano e detalhes por métrica.</string>
+    <string name="whatsnew_1_6_4_1_title">Histórico de implantações e exclusão de Workers</string>
+    <string name="whatsnew_1_6_4_1_detail">Veja as implantações anteriores de um Worker e exclua as antigas; também dá para editar e excluir Workers.</string>
+    <string name="whatsnew_1_6_4_2_title">Mais gerenciamento de armazenamento</string>
+    <string name="whatsnew_1_6_4_2_detail">Crie e exclua namespaces de KV e buckets de R2, exclua tabelas do D1 e apague implantações do Pages.</string>
     <string name="whatsnew_1_6_0_0_title">Domínios personalizados do Pages</string>
     <string name="whatsnew_1_6_0_0_detail">Gerencie domínios personalizados dentro de um projeto do Pages: adicionar, remover, revalidar e verificar o status do DNS — com criação do registro CNAME em um toque quando a zona do domínio está na sua conta.</string>
     <string name="whatsnew_1_6_0_1_title">Ordenação de listas</string>

--- a/apps/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -432,6 +432,10 @@
     <string name="d1_delete_warn">Esta ação elimina permanentemente a base de dados %1$s e todas as suas tabelas e dados. Não é possível anular nem recuperar.</string>
     <string name="d1_delete_confirm_label">Escreva o nome da base de dados para confirmar</string>
     <string name="d1_delete_button">Eliminar permanentemente</string>
+    <string name="d1_drop_table_title">Eliminar tabela</string>
+    <string name="d1_drop_table_warn">Esta ação elimina permanentemente a tabela %1$s e todos os seus dados. Não é possível anular nem recuperar.</string>
+    <string name="d1_drop_table_confirm_label">Escreva o nome da tabela para confirmar</string>
+    <string name="d1_table_dropped">Tabela eliminada</string>
 
     <!-- Gestão de Workers -->
     <string name="worker_manage_secrets">Variáveis e segredos</string>
@@ -1024,7 +1028,7 @@
     <string name="worker_create_name_hint">Começa com minúscula/dígito; aceita hífen e sublinhado</string>
     <string name="worker_create_compat">Data de compatibilidade</string>
     <string name="worker_create_code">Código (módulo ES)</string>
-    <string name="worker_create_note">Nota: a app não consegue ler o código de um Worker existente (a Cloudflare bloqueia esse endpoint para OAuth); criar ou substituir exige o código completo. Faça a gestão dos bindings (variáveis/segredos/KV) nos detalhes do Worker.</string>
+    <string name="worker_create_note">Dica: Criar ou substituir por completo requer o código completo. Faça a gestão das ligações (variáveis, segredos, KV, etc.) separadamente nos detalhes do Worker.</string>
     <string name="worker_create_deploy">Implementar</string>
     <string name="worker_create_ok">Implementado</string>
     <string name="pages_deploy_code">Implementar código</string>
@@ -1177,4 +1181,70 @@
     <string name="sort_default">Predefinição (nome)</string>
     <string name="sort_created">Data de criação</string>
     <string name="sort_modified">Atualização recente</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Editar código</string>
+    <string name="worker_edit_ok">Implementado</string>
+    <string name="worker_edit_loading">A carregar código-fonte…</string>
+    <string name="worker_edit_multimodule">Este Worker é de múltiplos módulos (empacotado); a edição direta na app não é suportada (os outros módulos seriam perdidos).</string>
+    <string name="worker_edit_note">Código-fonte em produção carregado. Edite e implemente diretamente. As variáveis, segredos e ligações existentes são mantidos automaticamente.</string>
+    <string name="worker_manage_edit">Editar código</string>
+    <string name="worker_delete_button">Eliminar Worker</string>
+    <string name="worker_delete_title">Eliminar Worker</string>
+    <string name="worker_delete_warn">Isto eliminará permanentemente o Worker %1$s e as respetivas implementações e ligações de rota. Não é possível anular nem recuperar.</string>
+    <string name="worker_delete_confirm_label">Introduza o nome do Worker para confirmar</string>
+    <string name="kv_create_title">Criar namespace</string>
+    <string name="kv_create">Criar</string>
+    <string name="kv_title_label">Nome</string>
+    <string name="kv_created">Criado</string>
+    <string name="kv_deleted">Eliminado</string>
+    <string name="kv_delete_title">Eliminar namespace</string>
+    <string name="kv_delete_warn">Isto eliminará permanentemente o namespace %1$s e todas as suas chaves e valores. Não é possível anular nem recuperar.</string>
+    <string name="kv_delete_confirm_label">Introduza o nome do namespace para confirmar</string>
+    <string name="kv_delete_button">Eliminar permanentemente</string>
+    <string name="r2_create_title">Criar bucket</string>
+    <string name="r2_create">Criar</string>
+    <string name="r2_name">Nome</string>
+    <string name="r2_name_hint">Letras minúsculas, números e hífens, 3–63 caracteres.</string>
+    <string name="r2_created">Criado</string>
+    <string name="r2_delete_title">Eliminar bucket</string>
+    <string name="r2_delete_warn">Isto eliminará permanentemente o bucket %1$s. Não é possível anular. O bucket tem de estar vazio para ser eliminado.</string>
+    <string name="r2_delete_confirm_label">Introduza o nome do bucket para confirmar</string>
+    <string name="r2_delete_button">Eliminar permanentemente</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Implementação eliminada</string>
+    <string name="pages_deployment_delete_title">Eliminar implementação</string>
+    <string name="pages_deployment_delete_msg">Isto eliminará permanentemente a implementação %1$s. Não é possível anular. A implementação de produção atual não pode ser eliminada.</string>
+    <string name="worker_manage_deployments">Histórico de implementações</string>
+    <string name="worker_deployments_title">Histórico de implementações</string>
+    <string name="worker_deployments_empty">Nenhuma implementação</string>
+    <string name="worker_deployments_note">A primeira entrada é a implementação ativa e não pode ser eliminada.</string>
+    <string name="worker_deployment_active">Ativo</string>
+    <string name="worker_deployment_deleted">Implementação eliminada</string>
+    <string name="worker_deployment_delete_title">Eliminar implementação</string>
+    <string name="worker_deployment_delete_msg">Isto eliminará permanentemente a implementação %1$s. Não é possível anular. A implementação ativa não pode ser eliminada.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Utilização</string>
+    <string name="usage_locked">É necessária a permissão de análise de tráfego para mostrar a utilização da conta</string>
+    <string name="usage_unavailable_title">Os dados ao nível da conta não estão disponíveis para esta conta</string>
+    <string name="usage_unavailable_body">A utilização de Workers / R2 / D1 / KV normalmente requer uma conta paga da Cloudflare; a análise de tráfego de domínios não é afetada.</string>
+    <string name="usage_failed">Falha ao carregar a utilização — toque para tentar novamente</string>
+    <string name="usage_period_month">Este mês</string>
+    <string name="usage_period_cycle">Ciclo</string>
+    <string name="usage_today">Hoje</string>
+    <string name="usage_plan_workers">Plano do Workers</string>
+    <string name="usage_plan_r2">Plano do R2</string>
+    <string name="usage_ctx_requests">Pedidos · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">Classe A · %1$s</string>
+    <string name="usage_ctx_r2b">Classe B · %1$s</string>
+    <string name="usage_ctx_storage">Armazenamento</string>
+    <string name="usage_ctx_rows_read">Linhas lidas · %1$s</string>
+    <string name="usage_ctx_rows_write">Linhas escritas · %1$s</string>
+    <string name="usage_ctx_reads">Leituras · %1$s</string>
+    <string name="usage_ctx_writes">Escritas · %1$s</string>
+    <string name="usage_billing_day">Dia de faturação</string>
+    <string name="usage_billing_natural">Mês civil</string>
+    <string name="usage_billing_day_n">Dia %1$d</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Visão geral da utilização da conta</string>
+    <string name="whatsnew_1_6_4_0_detail">O ecrã de visão geral passa a ter um módulo de utilização: veja num relance o uso de Workers, R2, D1 e KV face às quotas, com troca de plano e detalhes por métrica.</string>
+    <string name="whatsnew_1_6_4_1_title">Histórico de implementações e eliminação de Workers</string>
+    <string name="whatsnew_1_6_4_1_detail">Veja as implementações anteriores de um Worker e elimine as antigas; também pode editar e eliminar Workers.</string>
+    <string name="whatsnew_1_6_4_2_title">Mais gestão de armazenamento</string>
+    <string name="whatsnew_1_6_4_2_detail">Crie e elimine namespaces de KV e buckets de R2, elimine tabelas do D1 e apague implementações do Pages.</string>
     <string name="whatsnew_1_6_0_0_title">Domínios personalizados do Pages</string>
     <string name="whatsnew_1_6_0_0_detail">Faça a gestão de domínios personalizados dentro de um projeto do Pages: adicionar, remover, revalidar e verificar o estado do DNS — com criação do registo CNAME num toque quando a zona do domínio está na sua conta.</string>
     <string name="whatsnew_1_6_0_1_title">Ordenação de listas</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -550,6 +550,10 @@
     <string name="d1_delete_warn">Bu, %1$s veritabanını ve tüm tablo ve verilerini kalıcı olarak siler. Geri alınamaz veya kurtarılamaz.</string>
     <string name="d1_delete_confirm_label">Onaylamak için veritabanı adını yazın</string>
     <string name="d1_delete_button">Kalıcı olarak sil</string>
+    <string name="d1_drop_table_title">Tabloyu sil</string>
+    <string name="d1_drop_table_warn">Bu, %1$s tablosunu ve tüm verilerini kalıcı olarak siler. Geri alınamaz veya kurtarılamaz.</string>
+    <string name="d1_drop_table_confirm_label">Onaylamak için tablo adını yazın</string>
+    <string name="d1_table_dropped">Tablo silindi</string>
     <string name="worker_manage_secrets">Değişkenler ve sırlar</string>
     <string name="worker_manage_triggers">Tetikleyiciler</string>
     <string name="worker_manage_domains">Alan adları</string>
@@ -984,7 +988,7 @@
     <string name="worker_create_name_hint">Küçük harf/rakamla başlar; tire ve alt çizgi olabilir</string>
     <string name="worker_create_compat">Uyumluluk tarihi</string>
     <string name="worker_create_code">Kod (ES module)</string>
-    <string name="worker_create_note">Not: Bu uygulama mevcut Worker kaynağını okuyamaz (Cloudflare bu uç noktayı OAuth için engeller); oluşturma veya değiştirme tam kod gerektirir. Bağlamaları (değişkenler/sırlar/KV) Worker ayrıntılarında yönetin.</string>
+    <string name="worker_create_note">İpucu: Oluşturmak veya tamamen değiştirmek için kodun tamamı gerekir. Bağlamaları (değişkenler, gizli anahtarlar, KV vb.) Worker ayrıntılarında ayrıca yönetin.</string>
     <string name="worker_create_deploy">Dağıt</string>
     <string name="worker_create_ok">Dağıtıldı</string>
     <string name="pages_deploy_code">Kodu dağıt</string>
@@ -1137,4 +1141,70 @@
     <string name="sort_default">Varsayılan (ad)</string>
     <string name="sort_created">Oluşturma tarihi</string>
     <string name="sort_modified">Son güncelleme</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">Kodu düzenle</string>
+    <string name="worker_edit_ok">Dağıtıldı</string>
+    <string name="worker_edit_loading">Kaynak kodu yükleniyor…</string>
+    <string name="worker_edit_multimodule">Bu, çok modüllü (paketlenmiş) bir Worker\'dır; uygulama içinde yerinde düzenleme desteklenmez (diğer modüller kaybolur).</string>
+    <string name="worker_edit_note">Geçerli canlı kaynak yüklendi. Doğrudan düzenleyip dağıtabilirsiniz. Mevcut değişkenler, gizli anahtarlar ve bağlamalar otomatik olarak korunur.</string>
+    <string name="worker_manage_edit">Kodu düzenle</string>
+    <string name="worker_delete_button">Worker\'ı sil</string>
+    <string name="worker_delete_title">Worker\'ı sil</string>
+    <string name="worker_delete_warn">Bu işlem, %1$s adlı Worker\'ı, dağıtımlarını ve rota bağlamalarını kalıcı olarak siler. Geri alınamaz ve kurtarılamaz.</string>
+    <string name="worker_delete_confirm_label">Onaylamak için Worker adını girin</string>
+    <string name="kv_create_title">Ad alanı oluştur</string>
+    <string name="kv_create">Oluştur</string>
+    <string name="kv_title_label">Ad</string>
+    <string name="kv_created">Oluşturuldu</string>
+    <string name="kv_deleted">Silindi</string>
+    <string name="kv_delete_title">Ad alanını sil</string>
+    <string name="kv_delete_warn">Bu işlem, %1$s ad alanını ve tüm anahtar ve değerlerini kalıcı olarak siler. Geri alınamaz ve kurtarılamaz.</string>
+    <string name="kv_delete_confirm_label">Onaylamak için ad alanı adını girin</string>
+    <string name="kv_delete_button">Kalıcı olarak sil</string>
+    <string name="r2_create_title">Bucket oluştur</string>
+    <string name="r2_create">Oluştur</string>
+    <string name="r2_name">Ad</string>
+    <string name="r2_name_hint">Küçük harfler, rakamlar ve tireler, 3–63 karakter.</string>
+    <string name="r2_created">Oluşturuldu</string>
+    <string name="r2_delete_title">Bucket\'ı sil</string>
+    <string name="r2_delete_warn">Bu işlem, %1$s bucket\'ını kalıcı olarak siler. Geri alınamaz. Silmek için bucket boş olmalıdır.</string>
+    <string name="r2_delete_confirm_label">Onaylamak için bucket adını girin</string>
+    <string name="r2_delete_button">Kalıcı olarak sil</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">Dağıtım silindi</string>
+    <string name="pages_deployment_delete_title">Dağıtımı sil</string>
+    <string name="pages_deployment_delete_msg">%1$s dağıtımını kalıcı olarak siler. Geri alınamaz. Mevcut üretim dağıtımı silinemez.</string>
+    <string name="worker_manage_deployments">Dağıtım geçmişi</string>
+    <string name="worker_deployments_title">Dağıtım geçmişi</string>
+    <string name="worker_deployments_empty">Dağıtım yok</string>
+    <string name="worker_deployments_note">İlk giriş etkin dağıtımdır ve silinemez.</string>
+    <string name="worker_deployment_active">Etkin</string>
+    <string name="worker_deployment_deleted">Dağıtım silindi</string>
+    <string name="worker_deployment_delete_title">Dağıtımı sil</string>
+    <string name="worker_deployment_delete_msg">%1$s dağıtımını kalıcı olarak siler. Geri alınamaz. Etkin dağıtım silinemez.</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">Kullanım</string>
+    <string name="usage_locked">Hesap kullanımını göstermek için trafik analizi izni gerekir</string>
+    <string name="usage_unavailable_title">Bu hesap için hesap düzeyinde veri kullanılamıyor</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV kullanımı genellikle ücretli bir Cloudflare hesabı gerektirir; alan adı trafik analizi bundan etkilenmez.</string>
+    <string name="usage_failed">Kullanım yüklenemedi — yeniden denemek için dokunun</string>
+    <string name="usage_period_month">Bu ay</string>
+    <string name="usage_period_cycle">Dönem</string>
+    <string name="usage_today">Bugün</string>
+    <string name="usage_plan_workers">Workers planı</string>
+    <string name="usage_plan_r2">R2 planı</string>
+    <string name="usage_ctx_requests">İstekler · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">A Sınıfı · %1$s</string>
+    <string name="usage_ctx_r2b">B Sınıfı · %1$s</string>
+    <string name="usage_ctx_storage">Depolama</string>
+    <string name="usage_ctx_rows_read">Okunan satır · %1$s</string>
+    <string name="usage_ctx_rows_write">Yazılan satır · %1$s</string>
+    <string name="usage_ctx_reads">Okumalar · %1$s</string>
+    <string name="usage_ctx_writes">Yazmalar · %1$s</string>
+    <string name="usage_billing_day">Faturalama günü</string>
+    <string name="usage_billing_natural">Takvim ayı</string>
+    <string name="usage_billing_day_n">%1$d. gün</string>
 </resources>

--- a/apps/android/app/src/main/res/values-tr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-tr/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">Hesap kullanımı özeti</string>
+    <string name="whatsnew_1_6_4_0_detail">Genel bakış ekranı artık bir kullanım modülü gösteriyor: Workers, R2, D1 ve KV kullanımını kotalara göre tek bakışta görün; plan değiştirme ve metrik ayrıntıları dahil.</string>
+    <string name="whatsnew_1_6_4_1_title">Worker dağıtım geçmişi ve silme</string>
+    <string name="whatsnew_1_6_4_1_detail">Bir Worker’ın geçmiş dağıtımlarını görüp eskileri silin; ayrıca Worker düzenleyip silebilirsiniz.</string>
+    <string name="whatsnew_1_6_4_2_title">Daha fazla depolama yönetimi</string>
+    <string name="whatsnew_1_6_4_2_detail">KV ad alanları ve R2 paketleri oluşturup silin, D1 tablolarını silin ve Pages dağıtımlarını kaldırın.</string>
     <string name="whatsnew_1_6_0_0_title">Pages özel alan adları</string>
     <string name="whatsnew_1_6_0_0_detail">Özel alan adlarını doğrudan Pages projesi içinde yönetin: ekleme, silme, yeniden doğrulama ve DNS durumu kontrolü — alan adının bölgesi hesabınızdaysa tek dokunuşla CNAME kaydı ekleyin.</string>
     <string name="whatsnew_1_6_0_1_title">Liste sıralama</string>

--- a/apps/android/app/src/main/res/values-zh-rHK/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/strings.xml
@@ -431,6 +431,10 @@
     <string name="d1_delete_warn">此操作將永久刪除資料庫 %1$s 及其全部資料表與資料，無法復原，也無法還原。</string>
     <string name="d1_delete_confirm_label">輸入資料庫名稱以確認</string>
     <string name="d1_delete_button">永久刪除</string>
+    <string name="d1_drop_table_title">刪除資料表</string>
+    <string name="d1_drop_table_warn">此操作將永久刪除資料表 %1$s 及其全部資料，無法復原，也無法還原。</string>
+    <string name="d1_drop_table_confirm_label">輸入資料表名稱以確認</string>
+    <string name="d1_table_dropped">資料表已刪除</string>
 
     <!-- Worker 管理 -->
     <string name="worker_manage_secrets">變數與密鑰</string>
@@ -1023,7 +1027,7 @@
     <string name="worker_create_name_hint">小寫字母/數字開頭，可含連字號、底線</string>
     <string name="worker_create_compat">兼容性日期</string>
     <string name="worker_create_code">代碼（ES module）</string>
-    <string name="worker_create_note">提示：本應用無法讀取現有 Worker 源碼（Cloudflare 對 OAuth 封鎖該端點），新建或覆寫都需提供完整代碼。綁定（變數/密鑰/KV 等）請在 Worker 詳情中單獨管理。</string>
+    <string name="worker_create_note">提示：新增或整體覆寫都需提供完整代碼。綁定（變數/密鑰/KV 等）請在 Worker 詳情裡單獨管理。</string>
     <string name="worker_create_deploy">部署</string>
     <string name="worker_create_ok">已部署</string>
     <string name="pages_deploy_code">部署代碼</string>
@@ -1176,4 +1180,70 @@
     <string name="sort_default">默認（名稱）</string>
     <string name="sort_created">創建日期</string>
     <string name="sort_modified">最近更新</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">編輯代碼</string>
+    <string name="worker_edit_ok">已部署</string>
+    <string name="worker_edit_loading">正在讀取原始碼…</string>
+    <string name="worker_edit_multimodule">這是多模組打包 Worker，暫不支援在應用程式內原地編輯（會遺失其他模組）。</string>
+    <string name="worker_edit_note">已載入目前線上原始碼，可直接修改後部署。現有變數 / 密鑰 / 綁定會自動保留。</string>
+    <string name="worker_manage_edit">編輯代碼</string>
+    <string name="worker_delete_button">刪除 Worker</string>
+    <string name="worker_delete_title">刪除 Worker</string>
+    <string name="worker_delete_warn">此操作將永久刪除 Worker %1$s 及其部署與路由綁定，無法復原，也無法還原。</string>
+    <string name="worker_delete_confirm_label">輸入 Worker 名稱以確認</string>
+    <string name="kv_create_title">建立命名空間</string>
+    <string name="kv_create">建立</string>
+    <string name="kv_title_label">名稱</string>
+    <string name="kv_created">已建立</string>
+    <string name="kv_deleted">已刪除</string>
+    <string name="kv_delete_title">刪除命名空間</string>
+    <string name="kv_delete_warn">此操作將永久刪除命名空間 %1$s 及其全部鍵值，無法復原，也無法還原。</string>
+    <string name="kv_delete_confirm_label">輸入命名空間名稱以確認</string>
+    <string name="kv_delete_button">永久刪除</string>
+    <string name="r2_create_title">建立儲存桶</string>
+    <string name="r2_create">建立</string>
+    <string name="r2_name">名稱</string>
+    <string name="r2_name_hint">小寫字母、數字與連字號，3–63 位。</string>
+    <string name="r2_created">已建立</string>
+    <string name="r2_delete_title">刪除儲存桶</string>
+    <string name="r2_delete_warn">此操作將永久刪除儲存桶 %1$s，無法復原。儲存桶必須為空才能刪除。</string>
+    <string name="r2_delete_confirm_label">輸入儲存桶名稱以確認</string>
+    <string name="r2_delete_button">永久刪除</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">已刪除部署</string>
+    <string name="pages_deployment_delete_title">刪除部署</string>
+    <string name="pages_deployment_delete_msg">將永久刪除部署 %1$s，無法復原。目前的生產部署無法刪除。</string>
+    <string name="worker_manage_deployments">部署歷史</string>
+    <string name="worker_deployments_title">部署歷史</string>
+    <string name="worker_deployments_empty">尚無部署記錄</string>
+    <string name="worker_deployments_note">第一項為目前使用中的部署，無法刪除。</string>
+    <string name="worker_deployment_active">使用中</string>
+    <string name="worker_deployment_deleted">已刪除部署</string>
+    <string name="worker_deployment_delete_title">刪除部署</string>
+    <string name="worker_deployment_delete_msg">將永久刪除部署 %1$s，無法復原。目前使用中的部署無法刪除。</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">用量</string>
+    <string name="usage_locked">需要「流量分析」權限才能顯示帳戶用量</string>
+    <string name="usage_unavailable_title">此帳戶暫無帳戶層級資料查詢權限</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV 用量通常需要付費版 Cloudflare 帳戶；域名流量分析不受影響。</string>
+    <string name="usage_failed">用量載入失敗，點此重試</string>
+    <string name="usage_period_month">本月</string>
+    <string name="usage_period_cycle">帳期</string>
+    <string name="usage_today">今日</string>
+    <string name="usage_plan_workers">Workers 計劃</string>
+    <string name="usage_plan_r2">R2 計劃</string>
+    <string name="usage_ctx_requests">請求 · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">A 類 · %1$s</string>
+    <string name="usage_ctx_r2b">B 類 · %1$s</string>
+    <string name="usage_ctx_storage">儲存</string>
+    <string name="usage_ctx_rows_read">列讀取 · %1$s</string>
+    <string name="usage_ctx_rows_write">列寫入 · %1$s</string>
+    <string name="usage_ctx_reads">讀取 · %1$s</string>
+    <string name="usage_ctx_writes">寫入 · %1$s</string>
+    <string name="usage_billing_day">帳單日</string>
+    <string name="usage_billing_natural">自然月</string>
+    <string name="usage_billing_day_n">%1$d 日</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">帳戶用量總覽</string>
+    <string name="whatsnew_1_6_4_0_detail">概覽頁新增用量模組，一眼看清 Workers、R2、D1、KV 的用量與額度，可切換計劃並查看各項明細。</string>
+    <string name="whatsnew_1_6_4_1_title">Worker 部署歷史與刪除</string>
+    <string name="whatsnew_1_6_4_1_detail">查看每個 Worker 的歷次部署並刪除舊部署，同時支援編輯與刪除 Worker。</string>
+    <string name="whatsnew_1_6_4_2_title">儲存管理增強</string>
+    <string name="whatsnew_1_6_4_2_detail">新增 KV 命名空間與 R2 儲存桶的建立/刪除、D1 資料表刪除，以及 Pages 部署刪除。</string>
     <string name="whatsnew_1_6_0_0_title">Pages 自訂域名</string>
     <string name="whatsnew_1_6_0_0_detail">Pages 項目現可直接管理自訂域名：新增、刪除、重新驗證並檢查解析狀態；域名在當前帳戶時，還能一鍵新增指向項目的 CNAME 記錄。</string>
     <string name="whatsnew_1_6_0_1_title">列表排序</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -431,6 +431,10 @@
     <string name="d1_delete_warn">此操作將永久刪除資料庫 %1$s 及其全部資料表與資料，無法復原，也無法還原。</string>
     <string name="d1_delete_confirm_label">輸入資料庫名稱以確認</string>
     <string name="d1_delete_button">永久刪除</string>
+    <string name="d1_drop_table_title">刪除資料表</string>
+    <string name="d1_drop_table_warn">此操作將永久刪除資料表 %1$s 及其全部資料，無法復原，也無法還原。</string>
+    <string name="d1_drop_table_confirm_label">輸入資料表名稱以確認</string>
+    <string name="d1_table_dropped">資料表已刪除</string>
 
     <!-- Worker 管理 -->
     <string name="worker_manage_secrets">變數與密鑰</string>
@@ -1023,7 +1027,7 @@
     <string name="worker_create_name_hint">小寫字母/數字開頭，可含連字號、底線</string>
     <string name="worker_create_compat">相容性日期</string>
     <string name="worker_create_code">程式碼（ES module）</string>
-    <string name="worker_create_note">提示：本應用無法讀取現有 Worker 原始碼（Cloudflare 對 OAuth 封鎖該端點），新建或覆寫都需提供完整程式碼。綁定（變數/密鑰/KV 等）請在 Worker 詳情中單獨管理。</string>
+    <string name="worker_create_note">提示：新增或整體覆寫都需提供完整程式碼。綁定（變數/密鑰/KV 等）請在 Worker 詳情裡單獨管理。</string>
     <string name="worker_create_deploy">部署</string>
     <string name="worker_create_ok">已部署</string>
     <string name="pages_deploy_code">部署程式碼</string>
@@ -1176,4 +1180,70 @@
     <string name="sort_default">預設（名稱）</string>
     <string name="sort_created">建立日期</string>
     <string name="sort_modified">最近更新</string>
+
+    <!-- issue #55: Worker 编辑/删除 + KV/R2 增删 -->
+    <string name="worker_edit_title">編輯程式碼</string>
+    <string name="worker_edit_ok">已部署</string>
+    <string name="worker_edit_loading">正在讀取原始碼…</string>
+    <string name="worker_edit_multimodule">這是多模組打包 Worker，暫不支援在應用程式內原地編輯（會遺失其他模組）。</string>
+    <string name="worker_edit_note">已載入目前線上原始碼，可直接修改後部署。現有變數 / 密鑰 / 綁定會自動保留。</string>
+    <string name="worker_manage_edit">編輯程式碼</string>
+    <string name="worker_delete_button">刪除 Worker</string>
+    <string name="worker_delete_title">刪除 Worker</string>
+    <string name="worker_delete_warn">此操作將永久刪除 Worker %1$s 及其部署與路由綁定，無法復原，也無法還原。</string>
+    <string name="worker_delete_confirm_label">輸入 Worker 名稱以確認</string>
+    <string name="kv_create_title">建立命名空間</string>
+    <string name="kv_create">建立</string>
+    <string name="kv_title_label">名稱</string>
+    <string name="kv_created">已建立</string>
+    <string name="kv_deleted">已刪除</string>
+    <string name="kv_delete_title">刪除命名空間</string>
+    <string name="kv_delete_warn">此操作將永久刪除命名空間 %1$s 及其全部鍵值，無法復原，也無法還原。</string>
+    <string name="kv_delete_confirm_label">輸入命名空間名稱以確認</string>
+    <string name="kv_delete_button">永久刪除</string>
+    <string name="r2_create_title">建立儲存桶</string>
+    <string name="r2_create">建立</string>
+    <string name="r2_name">名稱</string>
+    <string name="r2_name_hint">小寫字母、數字與連字號，3–63 位。</string>
+    <string name="r2_created">已建立</string>
+    <string name="r2_delete_title">刪除儲存桶</string>
+    <string name="r2_delete_warn">此操作將永久刪除儲存桶 %1$s，無法復原。儲存桶必須為空才能刪除。</string>
+    <string name="r2_delete_confirm_label">輸入儲存桶名稱以確認</string>
+    <string name="r2_delete_button">永久刪除</string>
+
+    <!-- issue #55: 部署删除 -->
+    <string name="pages_deployment_deleted">已刪除部署</string>
+    <string name="pages_deployment_delete_title">刪除部署</string>
+    <string name="pages_deployment_delete_msg">將永久刪除部署 %1$s，無法復原。目前的生產部署無法刪除。</string>
+    <string name="worker_manage_deployments">部署歷史</string>
+    <string name="worker_deployments_title">部署歷史</string>
+    <string name="worker_deployments_empty">尚無部署記錄</string>
+    <string name="worker_deployments_note">第一項為目前使用中的部署，無法刪除。</string>
+    <string name="worker_deployment_active">使用中</string>
+    <string name="worker_deployment_deleted">已刪除部署</string>
+    <string name="worker_deployment_delete_title">刪除部署</string>
+    <string name="worker_deployment_delete_msg">將永久刪除部署 %1$s，無法復原。目前使用中的部署無法刪除。</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">用量</string>
+    <string name="usage_locked">需要「流量分析」權限才能顯示帳戶用量</string>
+    <string name="usage_unavailable_title">此帳戶暫無帳戶層級資料查詢權限</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV 用量通常需要付費版 Cloudflare 帳戶；網域流量分析不受影響。</string>
+    <string name="usage_failed">用量載入失敗，點此重試</string>
+    <string name="usage_period_month">本月</string>
+    <string name="usage_period_cycle">帳期</string>
+    <string name="usage_today">今日</string>
+    <string name="usage_plan_workers">Workers 方案</string>
+    <string name="usage_plan_r2">R2 方案</string>
+    <string name="usage_ctx_requests">請求 · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">A 類 · %1$s</string>
+    <string name="usage_ctx_r2b">B 類 · %1$s</string>
+    <string name="usage_ctx_storage">儲存</string>
+    <string name="usage_ctx_rows_read">列讀取 · %1$s</string>
+    <string name="usage_ctx_rows_write">列寫入 · %1$s</string>
+    <string name="usage_ctx_reads">讀取 · %1$s</string>
+    <string name="usage_ctx_writes">寫入 · %1$s</string>
+    <string name="usage_billing_day">帳單日</string>
+    <string name="usage_billing_natural">自然月</string>
+    <string name="usage_billing_day_n">%1$d 日</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">帳戶用量總覽</string>
+    <string name="whatsnew_1_6_4_0_detail">總覽頁新增用量模組，一眼看清 Workers、R2、D1、KV 的用量與額度，可切換方案並檢視各項明細。</string>
+    <string name="whatsnew_1_6_4_1_title">Worker 部署歷史與刪除</string>
+    <string name="whatsnew_1_6_4_1_detail">檢視每個 Worker 的歷次部署並刪除舊部署，同時支援編輯與刪除 Worker。</string>
+    <string name="whatsnew_1_6_4_2_title">儲存管理增強</string>
+    <string name="whatsnew_1_6_4_2_detail">新增 KV 命名空間與 R2 儲存桶的建立/刪除、D1 資料表刪除，以及 Pages 部署刪除。</string>
     <string name="whatsnew_1_6_0_0_title">Pages 自訂網域</string>
     <string name="whatsnew_1_6_0_0_detail">Pages 專案現可直接管理自訂網域：新增、刪除、重新驗證並檢查解析狀態；網域在目前帳號時，還能一鍵新增指向專案的 CNAME 記錄。</string>
     <string name="whatsnew_1_6_0_1_title">清單排序</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -653,6 +653,10 @@
     <string name="d1_delete_warn">此操作将永久删除数据库 %1$s 及其全部表和数据，无法撤销，也无法恢复。</string>
     <string name="d1_delete_confirm_label">输入数据库名称以确认</string>
     <string name="d1_delete_button">永久删除</string>
+    <string name="d1_drop_table_title">删除表</string>
+    <string name="d1_drop_table_warn">此操作将永久删除表 %1$s 及其全部数据，无法撤销，也无法恢复。</string>
+    <string name="d1_drop_table_confirm_label">输入表名以确认</string>
+    <string name="d1_table_dropped">表已删除</string>
 
     <!-- Worker 管理：变量与密钥 / 触发器 / 域名 -->
     <string name="worker_manage_secrets">变量与密钥</string>
@@ -987,6 +991,9 @@
     <string name="pages_empty">暂无 Pages 项目</string>
     <string name="pages_retried">已触发重新部署</string>
     <string name="pages_rolled_back">已回滚</string>
+    <string name="pages_deployment_deleted">已删除部署</string>
+    <string name="pages_deployment_delete_title">删除部署</string>
+    <string name="pages_deployment_delete_msg">将永久删除部署 %1$s，无法恢复。当前生产部署无法删除。</string>
     <string name="pages_deployments">部署记录</string>
     <string name="pages_production">生产</string>
     <string name="pages_preview">预览</string>
@@ -1059,9 +1066,49 @@
     <string name="worker_create_name_hint">小写字母/数字开头，可含连字符、下划线</string>
     <string name="worker_create_compat">兼容性日期</string>
     <string name="worker_create_code">代码（ES module）</string>
-    <string name="worker_create_note">提示：本应用无法读取现有 Worker 源码（Cloudflare 对 OAuth 封禁该端点），新建或覆盖都需提供完整代码。绑定（变量/密钥/KV 等）请在 Worker 详情里单独管理。</string>
+    <string name="worker_create_note">提示：新建或整体覆盖都需提供完整代码。绑定（变量/密钥/KV 等）请在 Worker 详情里单独管理。</string>
     <string name="worker_create_deploy">部署</string>
     <string name="worker_create_ok">已部署</string>
+
+    <!-- Worker 原地编辑 / 删除（issue #55） -->
+    <string name="worker_edit_title">编辑代码</string>
+    <string name="worker_edit_ok">已部署</string>
+    <string name="worker_edit_loading">正在读取源码…</string>
+    <string name="worker_edit_multimodule">这是多模块打包 Worker，暂不支持在应用内原地编辑（会丢失其它模块）。</string>
+    <string name="worker_edit_note">已载入当前线上源码，可直接修改后部署。现有变量 / 密钥 / 绑定会自动保留。</string>
+    <string name="worker_manage_edit">编辑代码</string>
+    <string name="worker_manage_deployments">部署历史</string>
+    <string name="worker_deployments_title">部署历史</string>
+    <string name="worker_deployments_empty">暂无部署记录</string>
+    <string name="worker_deployments_note">首项为当前活跃部署，不可删除。</string>
+    <string name="worker_deployment_active">活跃</string>
+    <string name="worker_deployment_deleted">已删除部署</string>
+    <string name="worker_deployment_delete_title">删除部署</string>
+    <string name="worker_deployment_delete_msg">将永久删除部署 %1$s，无法恢复。当前活跃部署无法删除。</string>
+    <string name="worker_delete_button">删除 Worker</string>
+    <string name="worker_delete_title">删除 Worker</string>
+    <string name="worker_delete_warn">此操作将永久删除 Worker %1$s 及其部署与路由绑定，无法撤销，也无法恢复。</string>
+    <string name="worker_delete_confirm_label">输入 Worker 名称以确认</string>
+
+    <!-- KV 命名空间 / R2 桶 增删（issue #55） -->
+    <string name="kv_create_title">创建命名空间</string>
+    <string name="kv_create">创建</string>
+    <string name="kv_title_label">名称</string>
+    <string name="kv_created">已创建</string>
+    <string name="kv_deleted">已删除</string>
+    <string name="kv_delete_title">删除命名空间</string>
+    <string name="kv_delete_warn">此操作将永久删除命名空间 %1$s 及其全部键值，无法撤销，也无法恢复。</string>
+    <string name="kv_delete_confirm_label">输入命名空间名称以确认</string>
+    <string name="kv_delete_button">永久删除</string>
+    <string name="r2_create_title">创建存储桶</string>
+    <string name="r2_create">创建</string>
+    <string name="r2_name">名称</string>
+    <string name="r2_name_hint">小写字母、数字与连字符，3–63 位。</string>
+    <string name="r2_created">已创建</string>
+    <string name="r2_delete_title">删除存储桶</string>
+    <string name="r2_delete_warn">此操作将永久删除存储桶 %1$s，无法撤销。桶必须为空才能删除。</string>
+    <string name="r2_delete_confirm_label">输入存储桶名称以确认</string>
+    <string name="r2_delete_button">永久删除</string>
 
     <!-- WAF 可视化表达式构建器 -->
     <string name="wafb_open">可视化构建表达式</string>
@@ -1265,4 +1312,27 @@
     <string name="sort_default">默认（名称）</string>
     <string name="sort_created">创建日期</string>
     <string name="sort_modified">最近更新</string>
+    <!-- Dashboard 用量模块 -->
+    <string name="usage_title">用量</string>
+    <string name="usage_locked">需要「流量分析」权限才能展示账号用量</string>
+    <string name="usage_unavailable_title">此账号暂无账户级数据查询权限</string>
+    <string name="usage_unavailable_body">Workers / R2 / D1 / KV 用量通常需要付费版 Cloudflare 账号；域名流量分析不受影响。</string>
+    <string name="usage_failed">用量加载失败，点此重试</string>
+    <string name="usage_period_month">本月</string>
+    <string name="usage_period_cycle">账期</string>
+    <string name="usage_today">今日</string>
+    <string name="usage_plan_workers">Workers 套餐</string>
+    <string name="usage_plan_r2">R2 套餐</string>
+    <string name="usage_ctx_requests">请求 · %1$s</string>
+    <string name="usage_ctx_cpu">CPU · %1$s</string>
+    <string name="usage_ctx_r2a">A 类 · %1$s</string>
+    <string name="usage_ctx_r2b">B 类 · %1$s</string>
+    <string name="usage_ctx_storage">存储</string>
+    <string name="usage_ctx_rows_read">行读取 · %1$s</string>
+    <string name="usage_ctx_rows_write">行写入 · %1$s</string>
+    <string name="usage_ctx_reads">读取 · %1$s</string>
+    <string name="usage_ctx_writes">写入 · %1$s</string>
+    <string name="usage_billing_day">账单日</string>
+    <string name="usage_billing_natural">自然月</string>
+    <string name="usage_billing_day_n">%1$d 日</string>
 </resources>

--- a/apps/android/app/src/main/res/values/whatsnew.xml
+++ b/apps/android/app/src/main/res/values/whatsnew.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_6_4_0_title">账号用量总览</string>
+    <string name="whatsnew_1_6_4_0_detail">概览页新增用量模块，一眼看清 Workers、R2、D1、KV 的用量与额度，可切换套餐并查看各项明细。</string>
+    <string name="whatsnew_1_6_4_1_title">Worker 部署历史与删除</string>
+    <string name="whatsnew_1_6_4_1_detail">查看每个 Worker 的历次部署并删除旧部署，同时支持编辑与删除 Worker。</string>
+    <string name="whatsnew_1_6_4_2_title">存储管理增强</string>
+    <string name="whatsnew_1_6_4_2_detail">新增 KV 命名空间与 R2 存储桶的创建/删除、D1 数据表删除，以及 Pages 部署删除。</string>
     <string name="whatsnew_1_6_0_0_title">Pages 自定义域名</string>
     <string name="whatsnew_1_6_0_0_detail">Pages 项目现可直接管理自定义域名：添加、删除、重新验证并检查解析状态；域名在当前账号时，还能一键添加指向项目的 CNAME 记录。</string>
     <string name="whatsnew_1_6_0_1_title">列表排序</string>

--- a/apps/android/fastlane/README.md
+++ b/apps/android/fastlane/README.md
@@ -1,0 +1,17 @@
+# fastlane 商店元数据（Android / Google Play）
+
+## 用法
+
+```bash
+brew install fastlane          # 或 gem install fastlane
+cd apps/android
+export SUPPLY_JSON_KEY="…service-account.json"
+fastlane metadata   # 只推商店文案 + 版本说明 + 截图，不传二进制
+fastlane deploy track:internal   # 传 AAB + 元数据 + 截图到指定轨道（internal/alpha/beta/production）
+```
+
+## 注意
+
+- 元数据在 `metadata/android/<locale>/`，版本说明在 `changelogs/<versionCode>.txt`。
+- 截图已就绪（`phoneScreenshots`）；icon / featureGraphic 暂缺，放好 `metadata/android/<locale>/images/` 后把 `Fastfile` 里的 `skip_upload_images` 改 `false`。
+- `deploy` 传到 `production` 轨道后会自动回调官网 `/api/play/release`，翻出该版本更新历史（Play 无发布 webhook，故主动通知），需环境变量 `PLAY_RELEASE_SECRET`（与 Worker secret 同值）。

--- a/packages/changelog/android.json
+++ b/packages/changelog/android.json
@@ -1,5 +1,108 @@
 [
   {
+    "version": "1.6.4",
+    "date": "2026.07.18",
+    "channel": "Google Play",
+    "items": [
+      {
+        "title": {
+          "zh-Hans": "账号用量总览",
+          "en": "Account usage overview",
+          "zh-Hant": "帳戶用量總覽",
+          "zh-HK": "帳戶用量總覽",
+          "ja": "アカウント使用量の概要",
+          "es-MX": "Resumen de uso de la cuenta",
+          "ko": "계정 사용량 개요",
+          "pt-BR": "Visão geral de uso da conta",
+          "pt-PT": "Visão geral da utilização da conta",
+          "de": "Übersicht der Kontonutzung",
+          "fr": "Aperçu de l’utilisation du compte",
+          "ar": "نظرة عامة على استخدام الحساب",
+          "tr": "Hesap kullanımı özeti"
+        },
+        "detail": {
+          "zh-Hans": "概览页新增用量模块，一眼看清 Workers、R2、D1、KV 的用量与额度，可切换套餐并查看各项明细。",
+          "en": "The overview now has a usage module — see Workers, R2, D1 and KV usage against their quotas at a glance, with plan switching and per-metric details.",
+          "zh-Hant": "總覽頁新增用量模組，一眼看清 Workers、R2、D1、KV 的用量與額度，可切換方案並檢視各項明細。",
+          "zh-HK": "概覽頁新增用量模組，一眼看清 Workers、R2、D1、KV 的用量與額度，可切換計劃並查看各項明細。",
+          "ja": "概要画面に使用量モジュールを追加。Workers・R2・D1・KV の使用量と上限をひと目で確認でき、プラン切り替えと項目ごとの詳細に対応します。",
+          "es-MX": "La pantalla de resumen ahora incluye un módulo de uso: consulta de un vistazo el uso de Workers, R2, D1 y KV frente a sus límites, con cambio de plan y detalles por métrica.",
+          "ko": "개요 화면에 사용량 모듈이 추가되어 Workers, R2, D1, KV 사용량과 한도를 한눈에 확인하고 요금제 전환과 항목별 세부 정보를 볼 수 있습니다.",
+          "pt-BR": "A tela de visão geral agora tem um módulo de uso: veja de relance o uso de Workers, R2, D1 e KV em relação às cotas, com troca de plano e detalhes por métrica.",
+          "pt-PT": "O ecrã de visão geral passa a ter um módulo de utilização: veja num relance o uso de Workers, R2, D1 e KV face às quotas, com troca de plano e detalhes por métrica.",
+          "de": "Die Übersicht zeigt jetzt ein Nutzungsmodul – Workers-, R2-, D1- und KV-Nutzung im Verhältnis zu den Kontingenten auf einen Blick, mit Tarifwechsel und Details je Kennzahl.",
+          "fr": "L’aperçu affiche désormais un module d’utilisation : usage de Workers, R2, D1 et KV par rapport aux quotas d’un coup d’œil, avec changement de forfait et détails par métrique.",
+          "ar": "أصبحت شاشة النظرة العامة تعرض وحدة استخدام: استخدام Workers وR2 وD1 وKV مقابل الحصص في لمحة، مع تبديل الخطة وتفاصيل لكل مقياس.",
+          "tr": "Genel bakış ekranı artık bir kullanım modülü gösteriyor: Workers, R2, D1 ve KV kullanımını kotalara göre tek bakışta görün; plan değiştirme ve metrik ayrıntıları dahil."
+        }
+      },
+      {
+        "title": {
+          "zh-Hans": "Worker 部署历史与删除",
+          "en": "Worker deployment history and delete",
+          "zh-Hant": "Worker 部署歷史與刪除",
+          "zh-HK": "Worker 部署歷史與刪除",
+          "ja": "Worker のデプロイ履歴と削除",
+          "es-MX": "Historial de despliegues y eliminación de Workers",
+          "ko": "Worker 배포 기록 및 삭제",
+          "pt-BR": "Histórico de implantações e exclusão de Workers",
+          "pt-PT": "Histórico de implementações e eliminação de Workers",
+          "de": "Worker-Bereitstellungsverlauf und Löschen",
+          "fr": "Historique des déploiements et suppression de Workers",
+          "ar": "سجل عمليات نشر Worker وحذفه",
+          "tr": "Worker dağıtım geçmişi ve silme"
+        },
+        "detail": {
+          "zh-Hans": "查看每个 Worker 的历次部署并删除旧部署，同时支持编辑与删除 Worker。",
+          "en": "View a Worker’s past deployments and delete old ones, plus edit and delete Workers.",
+          "zh-Hant": "檢視每個 Worker 的歷次部署並刪除舊部署，同時支援編輯與刪除 Worker。",
+          "zh-HK": "查看每個 Worker 的歷次部署並刪除舊部署，同時支援編輯與刪除 Worker。",
+          "ja": "各 Worker の過去のデプロイを確認して古いものを削除できるほか、Worker の編集・削除にも対応します。",
+          "es-MX": "Consulta los despliegues anteriores de un Worker y elimina los antiguos; además, edita y elimina Workers.",
+          "ko": "Worker의 과거 배포를 확인하고 이전 배포를 삭제할 수 있으며 Worker 편집과 삭제도 지원합니다.",
+          "pt-BR": "Veja as implantações anteriores de um Worker e exclua as antigas; também dá para editar e excluir Workers.",
+          "pt-PT": "Veja as implementações anteriores de um Worker e elimine as antigas; também pode editar e eliminar Workers.",
+          "de": "Sieh dir frühere Bereitstellungen eines Workers an und lösche alte – außerdem Worker bearbeiten und löschen.",
+          "fr": "Consultez les déploiements passés d’un Worker et supprimez les anciens ; modifiez et supprimez aussi des Workers.",
+          "ar": "اطّلع على عمليات نشر Worker السابقة واحذف القديمة، مع إمكانية تعديل وحذف Workers.",
+          "tr": "Bir Worker’ın geçmiş dağıtımlarını görüp eskileri silin; ayrıca Worker düzenleyip silebilirsiniz."
+        }
+      },
+      {
+        "title": {
+          "zh-Hans": "存储管理增强",
+          "en": "More storage management",
+          "zh-Hant": "儲存管理增強",
+          "zh-HK": "儲存管理增強",
+          "ja": "ストレージ管理の強化",
+          "es-MX": "Más gestión de almacenamiento",
+          "ko": "스토리지 관리 강화",
+          "pt-BR": "Mais gerenciamento de armazenamento",
+          "pt-PT": "Mais gestão de armazenamento",
+          "de": "Mehr Speicherverwaltung",
+          "fr": "Gestion du stockage étendue",
+          "ar": "مزيد من إدارة التخزين",
+          "tr": "Daha fazla depolama yönetimi"
+        },
+        "detail": {
+          "zh-Hans": "新增 KV 命名空间与 R2 存储桶的创建/删除、D1 数据表删除，以及 Pages 部署删除。",
+          "en": "Create and delete KV namespaces and R2 buckets, drop D1 tables, and delete Pages deployments.",
+          "zh-Hant": "新增 KV 命名空間與 R2 儲存桶的建立/刪除、D1 資料表刪除，以及 Pages 部署刪除。",
+          "zh-HK": "新增 KV 命名空間與 R2 儲存桶的建立/刪除、D1 資料表刪除，以及 Pages 部署刪除。",
+          "ja": "KV 名前空間と R2 バケットの作成・削除、D1 テーブルの削除、Pages デプロイの削除に対応しました。",
+          "es-MX": "Crea y elimina espacios de nombres de KV y buckets de R2, elimina tablas de D1 y borra despliegues de Pages.",
+          "ko": "KV 네임스페이스와 R2 버킷 생성/삭제, D1 테이블 삭제, Pages 배포 삭제를 지원합니다.",
+          "pt-BR": "Crie e exclua namespaces de KV e buckets de R2, exclua tabelas do D1 e apague implantações do Pages.",
+          "pt-PT": "Crie e elimine namespaces de KV e buckets de R2, elimine tabelas do D1 e apague implementações do Pages.",
+          "de": "KV-Namespaces und R2-Buckets erstellen/löschen, D1-Tabellen löschen und Pages-Bereitstellungen entfernen.",
+          "fr": "Créez et supprimez des namespaces KV et des buckets R2, supprimez des tables D1 et des déploiements Pages.",
+          "ar": "أنشئ واحذف مساحات أسماء KV وحاويات R2، واحذف جداول D1 وعمليات نشر Pages.",
+          "tr": "KV ad alanları ve R2 paketleri oluşturup silin, D1 tablolarını silin ve Pages dağıtımlarını kaldırın."
+        }
+      }
+    ]
+  },
+  {
     "version": "1.6.0",
     "date": "2026.07.03",
     "channel": "Google Play",


### PR DESCRIPTION
## Android 1.6.4(13)

**新功能**
- **Dashboard 用量模块**：Workers/R2/D1/KV 用量环形仪表 + 点开明细四态；手动套餐菜单（Workers/R2 付费 + 账单日 picker）、用量缓存落盘（DataStore）
- **Worker 部署历史与删除**，编辑/删除 Worker
- **存储管理增强**：KV 命名空间与 R2 存储桶创建/删除、D1 删表、Pages 部署删除

**发版**
- 版本号 1.6.3→1.6.4（versionCode 12→13）
- What's New 13 语（单一数据源 `packages/changelog/android.json` → codegen，`changelog:check` 通过）

**验证**：`oss`+`play` 两风味 `compileKotlin`/`processResources` + `assembleOssDebug` → BUILD SUCCESSFUL。Play AAB 上传为手动步骤。

> 含此前工作区累积的 Worker 部署/存储 CRUD 批次；用量模块 + D1 删表为本次新增。
