### PR TITLE
feat(ios): 快速绑定 R2 存储桶（1.8.7 build 34）

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -4333,6 +4333,82 @@
         }
       }
     },
+    "快速绑定 R2 存储桶": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quickly bind R2 buckets"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速綁定 R2 儲存桶"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速綁定 R2 儲存桶"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 バケットをすばやくバインド"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincula buckets R2 rápidamente"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 버킷 빠른 바인딩"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule buckets R2 rapidamente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule buckets R2 rapidamente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2-Buckets schnell binden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lier rapidement des buckets R2"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ربط حاويات R2 بسرعة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 bucket’larını hızlıca bağla"
+          }
+        }
+      }
+    },
     "把 Cloudflare 告警推到手机": {
       "localizations": {
         "en": {
@@ -7977,6 +8053,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Yük dengeleme"
+          }
+        }
+      }
+    },
+    "资源绑定新增 R2：可把现有存储桶直接绑定到 Worker，与 D1 / KV 一样支持一键解除。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resource bindings now cover R2 — attach an existing bucket to a Worker, and unbind it just like D1 / KV."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "資源綁定新增 R2：可把現有儲存桶直接綁定到 Worker，與 D1 / KV 一樣支援一鍵解除。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "資源綁定新增 R2：可把現有儲存桶直接綁定到 Worker，與 D1 / KV 一樣支援一鍵解除。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リソースバインディングに R2 を追加。既存のバケットを Worker にバインドでき、D1 / KV と同様に解除もできます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los vínculos de recursos ahora incluyen R2: conecta un bucket existente a un Worker y desvincúlalo igual que D1 / KV."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "리소스 바인딩에 R2가 추가되었습니다. 기존 버킷을 Worker에 연결하고 D1 / KV처럼 해제할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os vínculos de recursos agora incluem R2: conecte um bucket existente a um Worker e desvincule como em D1 / KV."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As ligações de recursos agora incluem R2: ligue um bucket existente a um Worker e desvincule como em D1 / KV."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ressourcenbindungen umfassen jetzt R2: Hänge einen vorhandenen Bucket an einen Worker und löse ihn wie bei D1 / KV wieder."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les liaisons de ressources couvrent désormais R2 : rattachez un bucket existant à un Worker et dissociez-le comme D1 / KV."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صارت روابط الموارد تشمل R2: اربط حاوية موجودة بأحد Workers وألغِ الربط كما في D1 / KV."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak bağlamaları artık R2’yi de kapsıyor: mevcut bir bucket’ı Worker’a bağlayın, D1 / KV gibi kaldırın."
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,7 +10,7 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
-        WhatsNewRelease(version: "1.8.6", items: [
+        WhatsNewRelease(version: "1.8.7", items: [
             WhatsNewItem(
                 icon:   "globe",
                 title:  String(localized: "workers.dev 子域直达", table: "WhatsNew"),
@@ -20,6 +20,11 @@ nonisolated enum WhatsNewGenerated {
                 icon:   "cube.fill",
                 title:  String(localized: "快速绑定 D1 / KV", table: "WhatsNew"),
                 detail: String(localized: "在变量与密钥页直接把现有 D1 数据库或 KV 命名空间绑定到 Worker，也能一键解除。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "shippingbox.fill",
+                title:  String(localized: "快速绑定 R2 存储桶", table: "WhatsNew"),
+                detail: String(localized: "资源绑定新增 R2：可把现有存储桶直接绑定到 Worker，与 D1 / KV 一样支持一键解除。", table: "WhatsNew")
             )
         ]),
         WhatsNewRelease(version: "1.8.5", items: [

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -147151,6 +147151,314 @@
           }
         }
       }
+    },
+    "该账号暂无 R2 存储桶": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد حاويات R2 في هذا الحساب"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine R2-Buckets in diesem Konto"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No R2 buckets in this account"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay buckets R2 en esta cuenta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun bucket R2 dans ce compte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアカウントに R2 バケットがありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 계정에 R2 버킷이 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum bucket R2 nesta conta"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum bucket R2 nesta conta"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu hesapta R2 bucket yok"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此帳戶尚無 R2 儲存桶"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此帳戶尚無 R2 儲存桶"
+          }
+        }
+      }
+    },
+    "R2 存储桶": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حاوية R2"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2-Bucket"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 bucket"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bucket R2"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bucket R2"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 バケット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 버킷"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bucket R2"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bucket R2"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 bucket"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 儲存桶"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 儲存桶"
+          }
+        }
+      }
+    },
+    "绑定 D1 / KV / R2": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ربط D1 / KV / R2"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 / KV / R2 binden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bind D1 / KV / R2"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincular D1 / KV / R2"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lier D1 / KV / R2"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 / KV / R2 をバインド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 / KV / R2 바인딩"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincular D1 / KV / R2"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincular D1 / KV / R2"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 / KV / R2 bağla"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "綁定 D1 / KV / R2"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "綁定 D1 / KV / R2"
+          }
+        }
+      }
+    },
+    "可绑定既有 D1 数据库 / KV 命名空间 / R2 存储桶；队列、Durable Object 等其它资源仍为只读，请用 Wrangler 或 Dashboard。": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط قاعدة بيانات D1 أو مساحة أسماء KV أو حاوية R2 موجودة. تبقى الموارد الأخرى مثل Queues وDurable Objects للقراءة فقط — استخدم Wrangler أو لوحة التحكم."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Binde eine vorhandene D1-Datenbank, einen KV-Namespace oder einen R2-Bucket ein. Andere Ressourcen wie Queues und Durable Objects bleiben schreibgeschützt – nutze Wrangler oder das Dashboard."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bind an existing D1 database, KV namespace or R2 bucket. Other resources like Queues and Durable Objects stay read-only — use Wrangler or the Dashboard."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincula una base de datos D1, un espacio de nombres KV o un bucket R2 existente. Otros recursos como Queues y Durable Objects siguen siendo de solo lectura: usa Wrangler o el Dashboard."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liez une base de données D1, un espace de noms KV ou un bucket R2 existant. Les autres ressources comme les Queues et Durable Objects restent en lecture seule — utilisez Wrangler ou le Dashboard."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既存の D1 データベース / KV ネームスペース / R2 バケットをバインドできます。キューや Durable Object など他のリソースは読み取り専用で、Wrangler か Dashboard をご利用ください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기존 D1 데이터베이스 / KV 네임스페이스 / R2 버킷을 바인딩합니다. 큐, Durable Object 등 다른 리소스는 읽기 전용이며 Wrangler 또는 Dashboard를 사용하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule um banco de dados D1, namespace KV ou bucket R2 existente. Outros recursos como Queues e Durable Objects permanecem somente leitura — use o Wrangler ou o Dashboard."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule uma base de dados D1, namespace KV ou bucket R2 existente. Outros recursos como Queues e Durable Objects permanecem só de leitura — use o Wrangler ou o Dashboard."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut bir D1 veritabanını, KV ad alanını veya R2 bucket'ını bağlayın. Queues ve Durable Objects gibi diğer kaynaklar salt okunur kalır — Wrangler veya Dashboard kullanın."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可綁定既有 D1 資料庫 / KV 命名空間 / R2 儲存桶；佇列、Durable Object 等其它資源仍為唯讀，請用 Wrangler 或 Dashboard。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可綁定既有 D1 資料庫 / KV 命名空間 / R2 儲存桶；佇列、Durable Object 等其它資源仍為唯讀，請用 Wrangler 或 Dashboard。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerConfigModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerConfigModels.swift
@@ -148,8 +148,8 @@ nonisolated struct WorkerBinding: Codable, Identifiable, Hashable, Sendable {
 
     var isSecret:    Bool { type == "secret_text" || type == "secrets_store_secret" }
     var isPlainText: Bool { type == "plain_text" }
-    /// 本客户端可原地增删的资源绑定（D1 / KV）——其余类型仍只读
-    var isQuickManaged: Bool { type == "kv_namespace" || type == "d1" }
+    /// 本客户端可原地增删的资源绑定（D1 / KV / R2）——其余类型仍只读
+    var isQuickManaged: Bool { type == "kv_namespace" || type == "d1" || type == "r2_bucket" }
 
     /// 人类可读的绑定类型标签
     var typeLabel: String {
@@ -211,25 +211,32 @@ nonisolated struct WorkerSettings: Codable, Sendable {
 // MARK: - 上传 / 写入请求体
 
 /// 上传 / patch settings 时的单条绑定。inherit 只发 {type,name}；plain_text 发 {type,name,text}；
-/// kv_namespace 发 {type,name,namespace_id}；d1 发 {type,name,id}。可选字段为 nil 时不编码（omitted）。
+/// kv_namespace 发 {type,name,namespace_id}；d1 发 {type,name,id}；r2_bucket 发 {type,name,bucket_name}
+/// （R2 按**桶名**引用，不是 ID）。可选字段为 nil 时不编码（omitted）。
 nonisolated struct WorkerBindingInput: Codable, Sendable {
     let type: String
     let name: String
     let text: String?
     let namespaceId: String?    // kv_namespace 绑定的命名空间 ID
     let id: String?             // d1 绑定的数据库 UUID
+    let bucketName: String?     // r2_bucket 绑定的桶名
 
-    init(type: String, name: String, text: String? = nil, namespaceId: String? = nil, id: String? = nil) {
+    init(
+        type: String, name: String, text: String? = nil,
+        namespaceId: String? = nil, id: String? = nil, bucketName: String? = nil
+    ) {
         self.type = type
         self.name = name
         self.text = text
         self.namespaceId = namespaceId
         self.id = id
+        self.bucketName = bucketName
     }
 
     enum CodingKeys: String, CodingKey {
         case type, name, text, id
         case namespaceId = "namespace_id"
+        case bucketName  = "bucket_name"
     }
 
     /// 绑定既有 KV 命名空间
@@ -240,6 +247,11 @@ nonisolated struct WorkerBindingInput: Codable, Sendable {
     /// 绑定既有 D1 数据库
     static func d1(name: String, databaseId: String) -> WorkerBindingInput {
         WorkerBindingInput(type: "d1", name: name, id: databaseId)
+    }
+
+    /// 绑定既有 R2 存储桶（按桶名）
+    static func r2(name: String, bucketName: String) -> WorkerBindingInput {
+        WorkerBindingInput(type: "r2_bucket", name: name, bucketName: bucketName)
     }
 }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerBindingsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerBindingsViewModel.swift
@@ -23,19 +23,25 @@ final class WorkerBindingsViewModel {
     // 快速绑定用的可选资源（打开绑定选择器时惰性加载）
     private(set) var d1Databases:  [D1Database] = []
     private(set) var kvNamespaces: [KVNamespace] = []
+    private(set) var r2Buckets:    [R2Bucket] = []
     private(set) var resourcesLoaded = false
     var loadingResources = false
 
     private let service:   WorkerService
     private let d1Service: D1Service
     private let kvService: KVService
+    private let r2Service: R2Service
     let accountId:  String
     let scriptName: String
 
-    init(service: WorkerService, d1Service: D1Service, kvService: KVService, accountId: String, scriptName: String) {
+    init(
+        service: WorkerService, d1Service: D1Service, kvService: KVService, r2Service: R2Service,
+        accountId: String, scriptName: String
+    ) {
         self.service    = service
         self.d1Service  = d1Service
         self.kvService  = kvService
+        self.r2Service  = r2Service
         self.accountId  = accountId
         self.scriptName = scriptName
     }
@@ -126,7 +132,7 @@ final class WorkerBindingsViewModel {
     // MARK: - 快速绑定 D1 / KV
 
     /// 打开绑定选择器时按需加载可选资源（各类型读权限缺失时静默跳过对应列表）
-    func loadResources(canReadD1: Bool, canReadKV: Bool) async {
+    func loadResources(canReadD1: Bool, canReadKV: Bool, canReadR2: Bool) async {
         guard !loadingResources else { return }
         loadingResources = true
         defer { loadingResources = false }
@@ -135,6 +141,9 @@ final class WorkerBindingsViewModel {
         }
         if canReadKV {
             kvNamespaces = (try? await kvService.listNamespaces(accountId: accountId)) ?? kvNamespaces
+        }
+        if canReadR2 {
+            r2Buckets = (try? await r2Service.listBuckets(accountId: accountId)) ?? r2Buckets
         }
         resourcesLoaded = true
     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerSecretsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerSecretsView.swift
@@ -20,15 +20,16 @@ struct WorkerSecretsView: View {
     init(accountId: String, scriptName: String, session: SessionStore) {
         _viewModel = State(initialValue: WorkerBindingsViewModel(
             service: session.workerService, d1Service: session.d1Service, kvService: session.kvService,
-            accountId: accountId, scriptName: scriptName
+            r2Service: session.r2Service, accountId: accountId, scriptName: scriptName
         ))
     }
 
     private var canWrite:   Bool { auth.hasScope("workers-scripts.write") }
     private var canReadD1:  Bool { auth.hasScope("d1.read") }
     private var canReadKV:  Bool { auth.hasScope("workers-kv-storage.read") }
+    private var canReadR2:  Bool { auth.hasScope("workers-r2.read") }
     /// 能读到至少一类资源才提供快速绑定入口
-    private var canBind:    Bool { canWrite && (canReadD1 || canReadKV) }
+    private var canBind:    Bool { canWrite && (canReadD1 || canReadKV || canReadR2) }
 
     var body: some View {
         Group {
@@ -95,7 +96,7 @@ struct WorkerSecretsView: View {
             case .bulkImport:
                 WorkerBulkImportSheet(viewModel: viewModel)
             case .bindResource:
-                WorkerBindResourceSheet(viewModel: viewModel, canReadD1: canReadD1, canReadKV: canReadKV)
+                WorkerBindResourceSheet(viewModel: viewModel, canReadD1: canReadD1, canReadKV: canReadKV, canReadR2: canReadR2)
             default:
                 WorkerValueEditorSheet(kind: kind, viewModel: viewModel)
             }
@@ -230,14 +231,14 @@ struct WorkerSecretsView: View {
                 Button {
                     sheet = .bindResource
                 } label: {
-                    Label("绑定 D1 / KV", systemImage: "plus")
+                    Label("绑定 D1 / KV / R2", systemImage: "plus")
                 }
             }
         } header: {
             Text("资源绑定")
         } footer: {
             Text(canBind
-                 ? String(localized: "可绑定既有 D1 数据库 / KV 命名空间；R2 等其它资源仍为只读，请用 Wrangler 或 Dashboard。")
+                 ? String(localized: "可绑定既有 D1 数据库 / KV 命名空间 / R2 存储桶；队列、Durable Object 等其它资源仍为只读，请用 Wrangler 或 Dashboard。")
                  : String(localized: "KV / D1 / R2 等资源绑定在此查看，编辑请用 Wrangler 或 Dashboard。"))
         }
         .glassRow()
@@ -517,7 +518,7 @@ private struct WorkerBulkImportSheet: View {
     }
 }
 
-// MARK: - 快速绑定 D1 / KV
+// MARK: - 快速绑定 D1 / KV / R2
 
 /// 绑定既有 D1 数据库 / KV 命名空间：选类型 → 选资源 → 填绑定变量名 → PATCH settings（其余绑定 inherit）
 private struct WorkerBindResourceSheet: View {
@@ -525,6 +526,7 @@ private struct WorkerBindResourceSheet: View {
     let viewModel: WorkerBindingsViewModel
     let canReadD1: Bool
     let canReadKV: Bool
+    let canReadR2: Bool
 
     @Environment(\.dismiss) private var dismiss
     @State private var kind: ResourceKind = .kv
@@ -533,9 +535,15 @@ private struct WorkerBindResourceSheet: View {
     @State private var nameEditedManually = false
 
     private enum ResourceKind: String, CaseIterable, Identifiable {
-        case kv, d1
+        case kv, d1, r2
         var id: String { rawValue }
-        var label: String { self == .kv ? "KV" : "D1" }
+        var label: String {
+            switch self {
+            case .kv: "KV"
+            case .d1: "D1"
+            case .r2: "R2"
+            }
+        }
     }
 
     /// 仅展示有读权限的类型
@@ -543,14 +551,43 @@ private struct WorkerBindResourceSheet: View {
         var kinds: [ResourceKind] = []
         if canReadKV { kinds.append(.kv) }
         if canReadD1 { kinds.append(.d1) }
+        if canReadR2 { kinds.append(.r2) }
         return kinds
     }
 
-    /// 当前类型下可选资源：(id, 显示名)
+    /// 当前类型下可选资源：(id, 显示名)。R2 按桶名引用，故 id 即桶名。
     private var options: [(id: String, title: String)] {
         switch kind {
         case .kv: viewModel.kvNamespaces.map { ($0.id, $0.title) }
         case .d1: viewModel.d1Databases.map { ($0.uuid, $0.name) }
+        case .r2: viewModel.r2Buckets.map { ($0.name, $0.name) }
+        }
+    }
+
+    /// 无可选资源时的空态文案
+    private var emptyText: String {
+        switch kind {
+        case .kv: String(localized: "该账号暂无 KV 命名空间")
+        case .d1: String(localized: "该账号暂无 D1 数据库")
+        case .r2: String(localized: "该账号暂无 R2 存储桶")
+        }
+    }
+
+    /// 资源选择器行标题
+    private var pickerLabel: String {
+        switch kind {
+        case .kv: String(localized: "命名空间")
+        case .d1: String(localized: "数据库")
+        case .r2: String(localized: "存储桶")
+        }
+    }
+
+    /// 资源选择区段头
+    private var sectionHeader: String {
+        switch kind {
+        case .kv: String(localized: "KV 命名空间")
+        case .d1: String(localized: "D1 数据库")
+        case .r2: String(localized: "R2 存储桶")
         }
     }
 
@@ -584,10 +621,9 @@ private struct WorkerBindResourceSheet: View {
                     if viewModel.loadingResources && options.isEmpty {
                         HStack { ProgressView(); Text("加载中…").foregroundStyle(.secondary) }
                     } else if options.isEmpty {
-                        Text(kind == .kv ? String(localized: "该账号暂无 KV 命名空间") : String(localized: "该账号暂无 D1 数据库"))
-                            .font(.callout).foregroundStyle(.secondary)
+                        Text(emptyText).font(.callout).foregroundStyle(.secondary)
                     } else {
-                        Picker(kind == .kv ? String(localized: "命名空间") : String(localized: "数据库"), selection: $selectedId) {
+                        Picker(pickerLabel, selection: $selectedId) {
                             Text("请选择").tag("")
                             ForEach(options, id: \.id) { option in
                                 Text(option.title).tag(option.id)
@@ -595,7 +631,7 @@ private struct WorkerBindResourceSheet: View {
                         }
                     }
                 } header: {
-                    Text(kind == .kv ? String(localized: "KV 命名空间") : String(localized: "D1 数据库"))
+                    Text(sectionHeader)
                 }
 
                 Section {
@@ -618,7 +654,7 @@ private struct WorkerBindResourceSheet: View {
                     Section { Text(error).font(.footnote).foregroundStyle(.red) }
                 }
             }
-            .navigationTitle("绑定 D1 / KV")
+            .navigationTitle("绑定 D1 / KV / R2")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -636,7 +672,7 @@ private struct WorkerBindResourceSheet: View {
             .interactiveDismissDisabled(viewModel.isSaving)
             .task {
                 kind = availableKinds.first ?? .kv
-                await viewModel.loadResources(canReadD1: canReadD1, canReadKV: canReadKV)
+                await viewModel.loadResources(canReadD1: canReadD1, canReadKV: canReadKV, canReadR2: canReadR2)
             }
             .onChange(of: selectedId) { _, newValue in
                 // 未手动改过名字时，用所选资源名推导一个合法默认绑定名
@@ -650,9 +686,11 @@ private struct WorkerBindResourceSheet: View {
 
     private func save() async {
         viewModel.error = nil
-        let resource: WorkerBindingInput = kind == .kv
-            ? .kv(name: name, namespaceId: selectedId)
-            : .d1(name: name, databaseId: selectedId)
+        let resource: WorkerBindingInput = switch kind {
+        case .kv: .kv(name: name, namespaceId: selectedId)
+        case .d1: .d1(name: name, databaseId: selectedId)
+        case .r2: .r2(name: name, bucketName: selectedId)   // R2 按桶名引用
+        }
         if await viewModel.bindResource(resource) { dismiss() }
     }
 


### PR DESCRIPTION
## iOS 1.8.7 (build 34)

- **快速绑定 R2 存储桶**：资源绑定新增 R2，可把现有存储桶（按桶名引用）绑定到 Worker，并与 D1 / KV 一样一键解除；走 settings inherit 回写，零丢绑定。
- 绑定选择器按 `workers-r2.read` 门控，现支持 KV / D1 / R2 三类。
- 新文案补齐 13 语；1.8.7 What's New 生成物入库；版本号 12 处同步 1.8.7 / build 34。

> 1.8.6 未送审即作废，其条目已并入本版（ASC 侧已把该版本改名 1.8.7，release notes 12 语已推送）。

对应 issue #61。`xcodebuild` 编译通过，无版本不匹配 warning。