### PR TITLE
feat(ios): 命令搜索 / 告警中心 / 日志筛选 / D1 历史 / 文生图（1.9.0 build 35）

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardAlerts.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardAlerts.swift
@@ -1,0 +1,95 @@
+//
+//  DashboardAlerts.swift
+//  Orange Cloud
+//
+//  概览页告警中心的规则集：只用**已经在手上的数据**推导（域名缓存 / Tunnel 列表 / Workers 缓存），
+//  不额外发任何请求。纯函数，方便后续补测试。
+//
+
+import Foundation
+import SwiftData
+
+/// 一条告警。`route` 为空表示无处可跳（如「还没有部署 Worker」）。
+struct DashboardAlert: Identifiable, Hashable {
+
+    /// 严重度（rawValue 越小越靠前；排序统一比 rawValue，不额外做 Comparable conformance）
+    enum Severity: Int, Hashable {
+        case critical = 0
+        case warn     = 1
+        case info     = 2
+        case ok       = 3
+    }
+
+    let id: String
+    let severity: Severity
+    let title: String
+    let detail: String
+    let route: DashboardResourceRoute?
+}
+
+enum DashboardAlerts {
+
+    /// 最多返回 `limit` 条，按严重度排序（同级保持输入顺序）。全部正常时返回空数组，由卡片显示「暂无告警」。
+    static func build(
+        zones: [CachedZone],
+        tunnels: [Tunnel],
+        workerCount: Int?,
+        limit: Int = 5
+    ) -> [DashboardAlert] {
+        var alerts: [DashboardAlert] = []
+
+        // ① 未激活 / 已暂停的域名
+        for zone in zones where zone.status != "active" {
+            let pendingLike = zone.status == "pending" || zone.status == "initializing"
+            alerts.append(DashboardAlert(
+                id: "zone|\(zone.id)",
+                severity: pendingLike ? .warn : .critical,
+                title: zone.name,
+                detail: pendingLike
+                    ? String(localized: "域名待激活，检查域名服务器是否已指向 Cloudflare")
+                    : String(localized: "域名未处于启用状态（\(zone.status)）"),
+                route: .zone(zone)
+            ))
+        }
+
+        // ② 非 healthy 的 Tunnel
+        for tunnel in tunnels where (tunnel.status ?? "") != "healthy" {
+            let severity: DashboardAlert.Severity
+            switch tunnel.status {
+            case "down":     severity = .critical
+            case "degraded": severity = .warn
+            default:         severity = .info      // inactive / 未知
+            }
+            alerts.append(DashboardAlert(
+                id: "tunnel|\(tunnel.id)",
+                severity: severity,
+                title: tunnel.name,
+                detail: String(localized: "隧道状态：\(tunnel.statusText)"),
+                route: .tunnel(tunnel)
+            ))
+        }
+
+        // ③ 一个 Worker 都没有（有权限读取时才提示，nil = 未知/无权限）
+        if let workerCount, workerCount == 0 {
+            alerts.append(DashboardAlert(
+                id: "workers|empty",
+                severity: .info,
+                title: String(localized: "还没有部署 Worker"),
+                detail: String(localized: "当前账号下没有 Workers 脚本"),
+                route: nil
+            ))
+        }
+
+        return Array(
+            alerts
+                .enumerated()
+                .sorted { lhs, rhs in
+                    lhs.element.severity == rhs.element.severity
+                        ? lhs.offset < rhs.offset
+                        : lhs.element.severity.rawValue < rhs.element.severity.rawValue
+                }
+                .map(\.element)
+                .prefix(limit)
+        )
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardResource.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardResource.swift
@@ -1,0 +1,151 @@
+//
+//  DashboardResource.swift
+//  Orange Cloud
+//
+//  概览页「跨类型资源」的统一视图模型：把域名 / Workers / R2 / D1 / KV / Tunnel
+//  归一成同一种可搜索、可固定、可跳转的条目，供命令搜索面板、置顶区与告警中心共用。
+//
+//  路由一律走**值式** + 概览栈根的 `.navigationDestination`：
+//  这些目的页内部还要继续 push（Worker 详情、R2 对象、D1 表…），
+//  eager `NavigationLink(destination:)` 在 iOS 17.0 会整 App 冻结（见 DashboardView 注释）。
+//
+
+import Foundation
+import SwiftData
+
+/// 概览页可直接 push 的资源目的地（栈根 navdest 承接）。
+/// 载荷是 SwiftData 模型 / 值模型，故本枚举跟随工程默认 MainActor 隔离，不标 nonisolated。
+enum DashboardResourceRoute: Hashable, Identifiable {
+    case zone(CachedZone)
+    case worker(CachedWorkerScript)
+    case bucket(R2Bucket)
+    case database(D1Database)
+    case namespace(KVNamespace)
+    case tunnel(Tunnel)
+
+    var id: String {
+        switch self {
+        case .zone(let zone):           "zone|\(zone.id)"
+        case .worker(let script):       "worker|\(script.id)"
+        case .bucket(let bucket):       "r2|\(bucket.name)"
+        case .database(let database):   "d1|\(database.uuid)"
+        case .namespace(let namespace): "kv|\(namespace.id)"
+        case .tunnel(let tunnel):       "tunnel|\(tunnel.id)"
+        }
+    }
+
+    /// 打开该资源所需的 Pro 场景；域名与 Workers 详情是免费功能，返回 nil。
+    ///
+    /// 口径与 Android 对齐：免费层**能搜到**全部资源（清单照拉、告警照出），
+    /// 只在「点进去」这一步撞付费墙——所以闸门挂在跳转派发处，不挂在搜索结果行上
+    /// （不标灰、不加锁图标，作者已拍板）。
+    var proFeature: ProFeature? {
+        switch self {
+        case .zone, .worker:                 nil
+        case .bucket, .database, .namespace: .storage
+        case .tunnel:                        .tunnel
+        }
+    }
+}
+
+/// 归一化的资源条目：搜索面板、置顶区共用一行的数据
+struct DashboardResourceItem: Identifiable, Hashable {
+
+    /// 持久化标识（type + resourceId），星标直接拿它去 PinnedResourceStore 切换
+    let pin: PinnedResource
+    let title: String
+    let subtitle: String
+    let route: DashboardResourceRoute
+
+    var id: String { pin.id }
+    var type: PinnedResourceType { pin.type }
+
+    /// 大小写不敏感匹配标题或副标题
+    func matches(_ query: String) -> Bool {
+        guard !query.isEmpty else { return true }
+        return title.localizedCaseInsensitiveContains(query)
+            || subtitle.localizedCaseInsensitiveContains(query)
+    }
+}
+
+/// 由各数据源拼出统一条目列表（纯映射，无网络）
+enum DashboardResourceCatalog {
+
+    static func items(
+        zones: [CachedZone],
+        workers: [CachedWorkerScript],
+        buckets: [R2Bucket],
+        databases: [D1Database],
+        namespaces: [KVNamespace],
+        tunnels: [Tunnel]
+    ) -> [DashboardResourceItem] {
+        var items: [DashboardResourceItem] = []
+        items.reserveCapacity(zones.count + workers.count + buckets.count + databases.count + namespaces.count + tunnels.count)
+
+        for zone in zones {
+            items.append(DashboardResourceItem(
+                pin: PinnedResource(type: .zone, resourceId: zone.id),
+                title: zone.name,
+                subtitle: "\(planShort(zone.planName)) · \(zoneStatusText(zone.status))",
+                route: .zone(zone)
+            ))
+        }
+        for script in workers {
+            items.append(DashboardResourceItem(
+                pin: PinnedResource(type: .worker, resourceId: script.id),
+                title: script.id,
+                subtitle: script.handlers.isEmpty
+                    ? String(localized: "Workers 脚本")
+                    : script.handlers.joined(separator: " · "),
+                route: .worker(script)
+            ))
+        }
+        for bucket in buckets {
+            items.append(DashboardResourceItem(
+                pin: PinnedResource(type: .r2, resourceId: bucket.name),
+                title: bucket.name,
+                subtitle: bucket.location ?? String(localized: "R2 存储桶"),
+                route: .bucket(bucket)
+            ))
+        }
+        for database in databases {
+            items.append(DashboardResourceItem(
+                pin: PinnedResource(type: .d1, resourceId: database.uuid),
+                title: database.name,
+                subtitle: database.numTables.map { String(localized: "\($0) 张表") } ?? String(localized: "D1 数据库"),
+                route: .database(database)
+            ))
+        }
+        for namespace in namespaces {
+            items.append(DashboardResourceItem(
+                pin: PinnedResource(type: .kv, resourceId: namespace.id),
+                title: namespace.title,
+                subtitle: namespace.id,
+                route: .namespace(namespace)
+            ))
+        }
+        for tunnel in tunnels {
+            items.append(DashboardResourceItem(
+                pin: PinnedResource(type: .tunnel, resourceId: tunnel.id),
+                title: tunnel.name,
+                subtitle: tunnel.statusText,
+                route: .tunnel(tunnel)
+            ))
+        }
+        return items
+    }
+
+    /// 套餐取首词（"Free Website" → "Free"），与 DashboardZoneCard 口径一致
+    static func planShort(_ planName: String) -> String {
+        planName.components(separatedBy: " ").first ?? planName
+    }
+
+    /// 与 StatusDot / ZoneDetailView 同一组状态文案
+    static func zoneStatusText(_ status: String) -> String {
+        switch status {
+        case "active":                  String(localized: "已启用")
+        case "pending", "initializing": String(localized: "待激活")
+        default:                        String(localized: "已暂停")
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/PinnedResource.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/PinnedResource.swift
@@ -1,0 +1,166 @@
+//
+//  PinnedResource.swift
+//  Orange Cloud
+//
+//  跨资源类型的「固定到首页」：域名 / Workers / R2 / D1 / KV / Tunnel 六类共用一套置顶模型。
+//
+//  **只持久化 type + resourceId**，标题/副标题一律在展示时从当前数据源现查：
+//  资源改名后置顶依旧有效（把展示文案编进持久化 key 的做法会让改名即失效），
+//  查不到的固定项在首页显示为「未找到」并允许一键取消固定。
+//
+
+import Foundation
+import Observation
+
+/// 可固定的资源类型（rawValue 进持久化，勿改）
+nonisolated enum PinnedResourceType: String, Codable, Sendable, Hashable, CaseIterable {
+    case zone
+    case worker
+    case r2
+    case d1
+    case kv
+    case tunnel
+
+    var symbolName: String {
+        switch self {
+        case .zone:   "globe"
+        case .worker: "bolt.fill"
+        case .r2:     "externaldrive"
+        case .d1:     "cylinder"
+        case .kv:     "key"
+        case .tunnel: "arrow.triangle.2.circlepath"
+        }
+    }
+
+    /// 分类名（搜索面板分组标签用）
+    var label: String {
+        switch self {
+        case .zone:   String(localized: "域名")
+        case .worker: "Workers"
+        case .r2:     "R2"
+        case .d1:     "D1"
+        case .kv:     "KV"
+        case .tunnel: "Tunnel"
+        }
+    }
+}
+
+/// 一条固定记录：类型 + 资源标识（不含任何会变的展示文案）
+nonisolated struct PinnedResource: Codable, Hashable, Identifiable, Sendable {
+
+    let type: PinnedResourceType
+    /// 资源在其类型内的稳定标识：zone id / worker 脚本名 / bucket 名 / d1 uuid / kv namespace id / tunnel id
+    let resourceId: String
+
+    var id: String { "\(type.rawValue)|\(resourceId)" }
+
+    init(type: PinnedResourceType, resourceId: String) {
+        self.type = type
+        self.resourceId = resourceId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case resourceId
+    }
+}
+
+/// 按 Cloudflare 账户隔离的置顶存储（仿 AccountPrefsStore 的写法：账号维度字典 + UserDefaults）。
+///
+/// 未与 AccountPrefsStore 合并的原因：Prefs 是套餐 / 账单日这类**低频配置**且整块镜像给 Widget，
+/// 置顶是高频增删的资源状态，混进去会让每次点星标都重写 App Group 镜像，
+/// 也要冒着往已持久化的 Prefs JSON 里加非可选字段的解码迁移风险。
+@Observable
+@MainActor
+final class PinnedResourceStore {
+
+    static let shared = PinnedResourceStore()
+
+    /// accountId -> 有序固定列表（保持用户固定的先后顺序）
+    private(set) var all: [String: [PinnedResource]] = [:]
+
+    private static let storeKey = "pinnedResourcesByAccountId"
+    private static let migratedKey = "pinnedZonesMigratedAccountIds"
+
+    private init() {
+        if let data = UserDefaults.standard.data(forKey: Self.storeKey),
+           let decoded = try? JSONDecoder().decode([String: [PinnedResource]].self, from: data) {
+            all = decoded
+        }
+    }
+
+    // MARK: - 读
+
+    func pins(for accountId: String) -> [PinnedResource] {
+        all[accountId] ?? []
+    }
+
+    func pins(for accountId: String, type: PinnedResourceType) -> [PinnedResource] {
+        pins(for: accountId).filter { $0.type == type }
+    }
+
+    func isPinned(_ resource: PinnedResource, accountId: String) -> Bool {
+        pins(for: accountId).contains(resource)
+    }
+
+    // MARK: - 写
+
+    /// 切换固定状态，返回切换后的状态（true = 现在已固定）
+    @discardableResult
+    func toggle(_ resource: PinnedResource, accountId: String) -> Bool {
+        guard !accountId.isEmpty else { return false }
+        var list = pins(for: accountId)
+        if let index = list.firstIndex(of: resource) {
+            list.remove(at: index)
+            all[accountId] = list
+            persist()
+            return false
+        }
+        list.append(resource)
+        all[accountId] = list
+        persist()
+        return true
+    }
+
+    func unpin(_ resource: PinnedResource, accountId: String) {
+        guard !accountId.isEmpty else { return }
+        var list = pins(for: accountId)
+        guard let index = list.firstIndex(of: resource) else { return }
+        list.remove(at: index)
+        all[accountId] = list
+        persist()
+    }
+
+    // MARK: - 旧数据迁移（CachedZone.pinned → 统一置顶）
+
+    /// 一次性把旧的 `CachedZone.pinned` 迁移进本 store（按账号只做一次）。
+    ///
+    /// 迁移而非「双读去重」的理由：双读要求两处写入永远同步，一旦某个入口只写一边就会出现
+    /// 「首页还固定着、详情页显示未固定」的分裂态；一次性迁移后统一以本 store 为准，
+    /// `CachedZone.pinned` 字段保留（不删，老版本回滚/其它入口仍能读到）并在置顶按钮处镜像写入。
+    ///
+    /// - Parameter pinnedZoneIds: 当前账号下 `pinned == true` 的域名 id
+    /// - Parameter hasZoneData: 该账号的域名缓存是否已就绪（为 false 时不落迁移标记，等数据到位再迁）
+    func migrateZonePinsIfNeeded(accountId: String, pinnedZoneIds: [String], hasZoneData: Bool) {
+        guard !accountId.isEmpty, hasZoneData else { return }
+        var migrated = Set(UserDefaults.standard.stringArray(forKey: Self.migratedKey) ?? [])
+        guard !migrated.contains(accountId) else { return }
+
+        var list = pins(for: accountId)
+        for zoneId in pinnedZoneIds {
+            let resource = PinnedResource(type: .zone, resourceId: zoneId)
+            if !list.contains(resource) { list.append(resource) }
+        }
+        all[accountId] = list
+        persist()
+
+        migrated.insert(accountId)
+        UserDefaults.standard.set(Array(migrated), forKey: Self.migratedKey)
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(all) {
+            UserDefaults.standard.set(data, forKey: Self.storeKey)
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
@@ -59,6 +59,15 @@ actor CFAPIClient {
         try await performRequest(method: "GET", path: path, queryItems: queryItems, body: nil, contentType: nil)
     }
 
+    /// JSON 请求体、原始响应体的 POST（Workers AI 文生图等 2xx 直接返回二进制、不走 CF 信封的端点）。
+    /// 非 2xx 仍由 performRequest 统一抛 APIError（含 CF 业务错误信息）。
+    func postRaw<B: Codable & Sendable>(_ path: String, body: B) async throws -> Data {
+        let encoded = try JSONEncoder().encode(body)
+        return try await performRequest(
+            method: "POST", path: path, queryItems: [], body: encoded, contentType: "application/json"
+        ).0
+    }
+
     /// 原始字节 PUT（R2 对象上传等），自带 Content-Type
     func putRaw<T: Codable & Sendable>(_ path: String, body: Data, contentType: String) async throws -> T {
         let (data, _) = try await performRequest(

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Storage/D1QueryHistoryStore.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Storage/D1QueryHistoryStore.swift
@@ -1,0 +1,177 @@
+//
+//  D1QueryHistoryStore.swift
+//  Orange Cloud
+//
+//  D1 查询控制台的「最近执行」与「SQL 收藏」本机持久化。
+//  按数据库（databaseId）分键，不同库的历史互不串；仅本机保存，不跨设备同步。
+//
+//  膨胀防线（UserDefaults 不适合放大对象）：
+//  单条 SQL 截断到 maxSQLLength、每库历史 maxHistory 条 / 收藏 maxFavorites 条、
+//  最多保留 maxDatabases 个库（按最近使用淘汰），编码后再按 maxPayloadBytes 兜底裁剪。
+//
+
+import Foundation
+import Observation
+
+/// 单个数据库的历史 + 收藏
+nonisolated struct D1QueryBook: Codable, Sendable, Equatable {
+    var history:   [String] = []
+    var favorites: [String] = []
+    /// 最近一次写入时间，用于超额时淘汰最久未用的库
+    var updatedAt: Date = .distantPast
+
+    enum CodingKeys: String, CodingKey {
+        case history
+        case favorites
+        case updatedAt = "updated_at"
+    }
+
+    init(history: [String] = [], favorites: [String] = [], updatedAt: Date = .distantPast) {
+        self.history = history
+        self.favorites = favorites
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        history   = (try? container.decode([String].self, forKey: .history))   ?? []
+        favorites = (try? container.decode([String].self, forKey: .favorites)) ?? []
+        updatedAt = (try? container.decode(Date.self,     forKey: .updatedAt)) ?? .distantPast
+    }
+}
+
+@Observable
+@MainActor
+final class D1QueryHistoryStore {
+
+    static let shared = D1QueryHistoryStore()
+
+    /// 每库最近执行条数
+    static let maxHistory = 12
+    /// 每库收藏条数上限
+    static let maxFavorites = 20
+    /// 单条 SQL 字符上限（超长语句只留前段，避免 UserDefaults 被撑大）
+    static let maxSQLLength = 2_000
+    /// 保留的数据库数量上限（超出按 updatedAt 淘汰最久未用）
+    static let maxDatabases = 12
+    /// 编码后总字节兜底
+    static let maxPayloadBytes = 256 * 1024
+
+    private static let storeKey = "d1QueryBooksByDatabase"
+
+    private(set) var books: [String: D1QueryBook] = [:]
+
+    private init() {
+        if let data = UserDefaults.standard.data(forKey: Self.storeKey),
+           let decoded = try? JSONDecoder().decode([String: D1QueryBook].self, from: data) {
+            books = decoded
+        }
+    }
+
+    // MARK: - 读
+
+    func history(for databaseId: String) -> [String] {
+        books[databaseId]?.history ?? []
+    }
+
+    func favorites(for databaseId: String) -> [String] {
+        books[databaseId]?.favorites ?? []
+    }
+
+    func isFavorite(_ sql: String, in databaseId: String) -> Bool {
+        guard let key = Self.normalize(sql) else { return false }
+        return favorites(for: databaseId).contains(key)
+    }
+
+    // MARK: - 写
+
+    /// 记一条执行成功的 SQL：去重后顶到最前，超额丢最旧
+    func record(_ sql: String, in databaseId: String) {
+        guard !databaseId.isEmpty, let entry = Self.normalize(sql) else { return }
+        update(databaseId) { book in
+            book.history.removeAll { $0 == entry }
+            book.history.insert(entry, at: 0)
+            if book.history.count > Self.maxHistory {
+                book.history.removeLast(book.history.count - Self.maxHistory)
+            }
+        }
+    }
+
+    /// 切换收藏，返回切换后的状态（收藏满时丢最旧一条腾位）
+    @discardableResult
+    func toggleFavorite(_ sql: String, in databaseId: String) -> Bool {
+        guard !databaseId.isEmpty, let entry = Self.normalize(sql) else { return false }
+        var isOn = false
+        update(databaseId) { book in
+            if let index = book.favorites.firstIndex(of: entry) {
+                book.favorites.remove(at: index)
+                isOn = false
+            } else {
+                book.favorites.insert(entry, at: 0)
+                if book.favorites.count > Self.maxFavorites {
+                    book.favorites.removeLast(book.favorites.count - Self.maxFavorites)
+                }
+                isOn = true
+            }
+        }
+        return isOn
+    }
+
+    func removeHistory(_ sql: String, in databaseId: String) {
+        guard let entry = Self.normalize(sql) else { return }
+        update(databaseId) { $0.history.removeAll { $0 == entry } }
+    }
+
+    func clearHistory(in databaseId: String) {
+        update(databaseId) { $0.history.removeAll() }
+    }
+
+    // MARK: - 内部
+
+    /// 去首尾空白 + 单条长度封顶；空串返回 nil
+    private static func normalize(_ sql: String) -> String? {
+        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard trimmed.count > maxSQLLength else { return trimmed }
+        return String(trimmed.prefix(maxSQLLength))
+    }
+
+    private func update(_ databaseId: String, _ mutate: (inout D1QueryBook) -> Void) {
+        var book = books[databaseId] ?? D1QueryBook()
+        mutate(&book)
+        book.updatedAt = Date()
+        if book.history.isEmpty && book.favorites.isEmpty {
+            books.removeValue(forKey: databaseId)
+        } else {
+            books[databaseId] = book
+        }
+        trimDatabases()
+        persist()
+    }
+
+    /// 库数量超额：淘汰最久未使用的
+    private func trimDatabases() {
+        guard books.count > Self.maxDatabases else { return }
+        let stale = books
+            .sorted { $0.value.updatedAt < $1.value.updatedAt }
+            .prefix(books.count - Self.maxDatabases)
+            .map(\.key)
+        for key in stale { books.removeValue(forKey: key) }
+    }
+
+    private func persist() {
+        let defaults = UserDefaults.standard
+        guard var data = try? JSONEncoder().encode(books) else { return }
+        // 兜底：极端长语句堆叠时按最久未用继续丢库，直到落进预算
+        while data.count > Self.maxPayloadBytes, books.count > 1 {
+            if let oldest = books.min(by: { $0.value.updatedAt < $1.value.updatedAt })?.key {
+                books.removeValue(forKey: oldest)
+            } else {
+                break
+            }
+            guard let shrunk = try? JSONEncoder().encode(books) else { return }
+            data = shrunk
+        }
+        defaults.set(data, forKey: Self.storeKey)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/BackgroundRefresh.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/BackgroundRefresh.swift
@@ -15,25 +15,33 @@ enum BackgroundRefresh {
 
     static let taskIdentifier = "jiamin.chen.Orange-Cloud.refresh"
 
-    /// App 启动时注册（必须在 didFinishLaunching 前，App.init 中调用）
-    static func register(authManager: AuthManager) {
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { task in
+    /// 已注册标记：BGTaskScheduler 同一标识符重复注册会直接崩溃，注册必须幂等
+    private static var didRegister = false
+
+    /// 弱持有：注册发生在 App.init 最前（AuthManager 尚未构造），
+    /// 且 enum 的静态闭包若强引用 AuthManager 会让它随进程永生。
+    private static weak var authManager: AuthManager?
+
+    /// App 启动时注册（必须在 didFinishLaunching 前，App.init 中调用）。
+    /// 不依赖 AuthManager——注册只关心处理器登记成败，身份稍后用 `setAuthManager` 补上。
+    static func register() {
+        guard !didRegister else {
+            AppLog.background.info("BGAppRefresh register skipped (already registered)")
+            return
+        }
+        didRegister = true
+        // 返回值必须记日志：注册失败（标识符未登记进 Info.plist / 调用时机过晚）
+        // 是「后台刷新为何不跑」最常见的根因，丢弃它等于放弃排查
+        let registered = BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: taskIdentifier,
+            using: nil
+        ) { task in
             guard let refreshTask = task as? BGAppRefreshTask else {
                 task.setTaskCompleted(success: false)
                 return
             }
             let work = Task { @MainActor in
-                schedule()   // 链式排下一次
-                AppLog.background.notice("BGAppRefresh fired, loggedIn=\(authManager.isLoggedIn)")
-                if authManager.isLoggedIn {
-                    _ = try? await authManager.refreshAccessToken()
-                    // 预热当前账号域名快照，让用户切回前台 / 小组件刷新时直接见到最新数据
-                    await prewarmWidgetSnapshot(authManager: authManager)
-                    // 顺带做通知检测（Zone 状态变化 / Worker 错误）
-                    await AppNotifications.runBackgroundChecks(authManager: authManager)
-                }
-                refreshTask.setTaskCompleted(success: true)
-                AppLog.background.info("BGAppRefresh completed")
+                await run(task: refreshTask)
             }
             refreshTask.expirationHandler = {
                 AppLog.background.error("BGAppRefresh expired (system cut off)")
@@ -41,6 +49,34 @@ enum BackgroundRefresh {
                 refreshTask.setTaskCompleted(success: false)
             }
         }
+        AppLog.background.info("BGAppRefresh register(\(taskIdentifier)) -> \(registered)")
+    }
+
+    /// AuthManager 构造完成后回填（弱引用）
+    static func setAuthManager(_ manager: AuthManager) {
+        authManager = manager
+        AppLog.background.info("BGAppRefresh auth manager attached")
+    }
+
+    /// 后台任务主体
+    private static func run(task: BGAppRefreshTask) async {
+        schedule()   // 链式排下一次
+        guard let authManager else {
+            // 理论不可达：App.init 里注册完立刻回填。真出现说明启动顺序被改坏了。
+            AppLog.background.error("BGAppRefresh fired but no AuthManager attached")
+            task.setTaskCompleted(success: false)
+            return
+        }
+        AppLog.background.notice("BGAppRefresh fired, loggedIn=\(authManager.isLoggedIn)")
+        if authManager.isLoggedIn {
+            _ = try? await authManager.refreshAccessToken()
+            // 预热当前账号域名快照，让用户切回前台 / 小组件刷新时直接见到最新数据
+            await prewarmWidgetSnapshot(authManager: authManager)
+            // 顺带做通知检测（Zone 状态变化 / Worker 错误）
+            await AppNotifications.runBackgroundChecks(authManager: authManager)
+        }
+        task.setTaskCompleted(success: true)
+        AppLog.background.info("BGAppRefresh completed")
     }
 
     /// 后台预热：刷新「当前账号」（Widget 默认展示的账号）的 Zone 列表进缓存 + Widget 总览快照，

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -229,6 +229,82 @@
         }
       }
     },
+    "D1 查询自动记录最近 12 条，常用语句可收藏（按数据库分别保存）；查询结果一键导出 CSV，表详情还能查看索引。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 keeps your last 12 queries and lets you favorite the ones you reuse (saved per database). Results export to CSV in a tap, and table details now list indexes."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 查詢會自動記錄最近 12 筆，常用語句可收藏（依資料庫分別儲存）；查詢結果一鍵匯出 CSV，資料表詳情還能檢視索引。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 查詢會自動記錄最近 12 條，常用語句可收藏（按資料庫分別儲存）；查詢結果一鍵匯出 CSV，資料表詳情還可查看索引。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 は直近 12 件のクエリを自動で記録し、よく使う文はお気に入りに登録できます（データベースごとに保存）。結果はワンタップで CSV に書き出せ、テーブル詳細ではインデックスも確認できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 guarda tus últimas 12 consultas y te deja marcar como favoritas las que más usas (por base de datos). Los resultados se exportan a CSV con un toque y el detalle de la tabla ya muestra los índices."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1이 최근 12개의 쿼리를 자동으로 기록하고, 자주 쓰는 문장은 즐겨찾기에 담을 수 있습니다(데이터베이스별로 저장). 결과는 한 번에 CSV로 내보낼 수 있고, 테이블 상세에서 인덱스도 볼 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O D1 guarda suas últimas 12 consultas e deixa favoritar as que você mais usa (salvas por banco). Os resultados viram CSV com um toque e o detalhe da tabela agora mostra os índices."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O D1 guarda as suas últimas 12 consultas e permite marcar como favoritas as mais usadas (guardadas por base de dados). Os resultados exportam para CSV com um toque e o detalhe da tabela mostra agora os índices."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 merkt sich die letzten 12 Abfragen, häufig genutzte lassen sich als Favorit sichern (je Datenbank getrennt). Ergebnisse exportierst du mit einem Tippen als CSV, und die Tabellendetails zeigen jetzt auch Indizes."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 conserve vos 12 dernières requêtes et permet de mettre en favori celles que vous réutilisez (par base de données). Les résultats s’exportent en CSV d’un geste, et le détail d’une table affiche désormais les index."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتفظ D1 بآخر 12 استعلامًا تلقائيًا، ويمكنك إضافة العبارات المتكررة إلى المفضلة (تُحفظ لكل قاعدة بيانات على حدة). صدّر النتائج إلى CSV بنقرة، وتعرض تفاصيل الجدول الآن الفهارس أيضًا."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D1 son 12 sorgunuzu otomatik saklar, sık kullandıklarınızı favorilere ekleyebilirsiniz (her veritabanı için ayrı). Sonuçlar tek dokunuşla CSV olarak dışa aktarılır, tablo ayrıntılarında artık dizinler de görünür."
+          }
+        }
+      }
+    },
     "Email Routing": {
       "localizations": {
         "en": {
@@ -837,6 +913,82 @@
         }
       }
     },
+    "SQL 历史与收藏": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL history and favorites"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL 記錄與收藏"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL 記錄與收藏"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL の履歴とお気に入り"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial y favoritos de SQL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL 기록과 즐겨찾기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico e favoritos de SQL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico e favoritos de SQL"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL-Verlauf und Favoriten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique et favoris SQL"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجل SQL والمفضلة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SQL geçmişi ve favoriler"
+          }
+        }
+      }
+    },
     "SSL 证书与加密设置": {
       "localizations": {
         "en": {
@@ -1369,6 +1521,82 @@
         }
       }
     },
+    "Worker 实时日志支持关键词搜索与级别筛选；长按复制整行，轻点展开完整详情并选取片段。「暂停」现在只冻结画面、日志照常接收，恢复后能看到完整记录。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live Worker logs now support keyword search and level filtering; long-press to copy a whole line, tap to expand the full detail and select any part of it. Pause now only freezes the view — logs keep arriving, so nothing is missing when you resume."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 即時日誌支援關鍵字搜尋與等級篩選；長按複製整行，輕點展開完整詳情並選取片段。「暫停」現在只凍結畫面、日誌照常接收，恢復後能看到完整記錄。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 實時日誌支援關鍵字搜尋與級別篩選；長按複製整行，輕點展開完整詳情並選取片段。「暫停」現在只凍結畫面、日誌照常接收，恢復後可看到完整記錄。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker のリアルタイムログでキーワード検索とレベル絞り込みができるようになりました。長押しで 1 行コピー、タップで詳細を開いて一部を選択できます。「一時停止」は表示を止めるだけになり、ログは受信し続けるため再開後もすべて確認できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los registros en vivo de Worker ahora tienen búsqueda por palabra clave y filtro por nivel; mantén presionada una línea para copiarla o tócala para ver el detalle completo y seleccionar fragmentos. Pausar solo congela la vista: los registros siguen llegando y no se pierde nada."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 실시간 로그에서 키워드 검색과 레벨 필터를 쓸 수 있습니다. 길게 눌러 한 줄을 복사하고, 탭하면 전체 내용을 펼쳐 일부만 선택할 수도 있습니다. 일시정지는 이제 화면만 멈추고 로그는 계속 수신되어 재개하면 빠짐없이 확인할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os logs ao vivo do Worker agora têm busca por palavra-chave e filtro por nível; segure para copiar a linha inteira ou toque para abrir o detalhe completo e selecionar trechos. Pausar apenas congela a tela — os logs continuam chegando e nada se perde."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os registos em direto do Worker têm agora pesquisa por palavra-chave e filtro por nível; toque sem soltar para copiar a linha ou toque para abrir o detalhe completo e selecionar excertos. Pausar apenas congela o ecrã — os registos continuam a chegar e nada se perde."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live-Logs eines Workers lassen sich jetzt nach Stichwort durchsuchen und nach Level filtern; langes Tippen kopiert die ganze Zeile, kurzes Tippen öffnet das vollständige Detail zum Markieren. Die Pause friert nur die Ansicht ein – Logs laufen weiter ein, beim Fortsetzen fehlt nichts."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les journaux en direct d’un Worker acceptent désormais la recherche par mot-clé et le filtre par niveau ; appui long pour copier toute la ligne, appui simple pour ouvrir le détail complet et en sélectionner un extrait. La pause ne fige que l’affichage : les journaux continuent d’arriver, rien ne manque à la reprise."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صارت سجلات Worker المباشرة تدعم البحث بالكلمات المفتاحية والتصفية حسب المستوى؛ اضغط مطوّلًا لنسخ السطر كاملًا، أو انقر لعرض التفاصيل كاملة وتحديد جزء منها. ولم يعد الإيقاف المؤقت سوى تجميد للعرض — تستمر السجلات في الوصول فلا يفوتك شيء عند المتابعة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker canlı günlüklerinde artık anahtar kelime araması ve seviye filtresi var; uzun basınca satırın tamamı kopyalanır, dokununca tüm ayrıntı açılır ve içinden seçim yapılabilir. Duraklatma yalnızca görüntüyü dondurur; günlükler gelmeye devam eder, devam ettiğinizde hiçbir şey eksik olmaz."
+          }
+        }
+      }
+    },
     "Worker 开启 workers.dev 子域后，直接显示完整访问地址，点一下即可打开。": {
       "localizations": {
         "en": {
@@ -1517,6 +1745,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Worker dağıtım geçmişi"
+          }
+        }
+      }
+    },
+    "Workers AI 文生图": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate images with Workers AI"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers AI 文字生圖"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers AI 文字生圖"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers AI で画像生成"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genera imágenes con Workers AI"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers AI로 이미지 생성"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gere imagens com Workers AI"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gere imagens com Workers AI"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilder mit Workers AI erzeugen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Générer des images avec Workers AI"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توليد الصور عبر Workers AI"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers AI ile görsel üretin"
           }
         }
       }
@@ -1821,6 +2125,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "workers.dev alt alan adına doğrudan erişim"
+          }
+        }
+      }
+    },
+    "一处搜遍所有资源": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search everything from one place"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一處搜遍所有資源"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一處搜遍所有資源"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのリソースをまとめて検索"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca todo desde un solo lugar"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 리소스를 한 곳에서 검색"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busque tudo em um só lugar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquise tudo num só lugar"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles an einer Stelle suchen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout chercher au même endroit"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابحث في كل شيء من مكان واحد"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Her şeyi tek yerden arayın"
           }
         }
       }
@@ -3193,6 +3573,82 @@
         }
       }
     },
+    "告警中心": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alert center"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "告警中心"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "告警中心"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アラートセンター"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro de alertas"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림 센터"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Central de alertas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro de alertas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnungszentrale"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centre d’alertes"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مركز التنبيهات"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyarı merkezi"
+          }
+        }
+      }
+    },
     "在 App 里把已注册的域名加入账号，并拿到要去注册商处配置的名称服务器。": {
       "localizations": {
         "en": {
@@ -4025,6 +4481,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cron Tetikleyicileri"
+          }
+        }
+      }
+    },
+    "实时日志更好用": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Better live logs"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時日誌更好用"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "實時日誌更好用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リアルタイムログが使いやすく"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros en vivo mejorados"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간 로그 개선"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs ao vivo melhores"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registos em direto melhorados"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bessere Live-Logs"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journaux en direct améliorés"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجلات مباشرة أفضل"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daha iyi canlı günlükler"
           }
         }
       }
@@ -6609,6 +7141,234 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bazı kullanıcıların beklenmedik şekilde oturumdan çıkarılması sorununu kökten çözer: yetkilendirme akışı artık uzun ömürlü kimlik bilgileri alır, bu yüzden oturum belirteç süresi dolunca kapanmaz. Yetki yine geçersiz olursa Genel Bakış tek dokunuşla yeniden yetkilendirme sunar."
+          }
+        }
+      }
+    },
+    "概览页新增告警卡片，汇总需要注意的资源——未启用的域名、状态异常的隧道等，点一下直达。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The overview now gathers what needs attention — inactive domains, tunnels in a bad state and more — into a single card. Tap an item to jump right to it."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總覽頁新增告警卡片，彙整需要留意的資源——未啟用的網域、狀態異常的通道等，點一下直達。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概覽頁新增告警卡片，彙整需要留意的資源——未啟用的域名、狀態異常的隧道等，點一下直達。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要ページに、注意が必要なリソース（有効になっていないドメイン、状態が異常なトンネルなど）をまとめるカードを追加しました。タップするとその場所へ移動します。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La pantalla de resumen reúne en una tarjeta lo que necesita atención: dominios sin activar, túneles con estado anómalo y más. Toca uno para ir directo."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면에 주의가 필요한 리소스(활성화되지 않은 도메인, 상태가 비정상인 터널 등)를 모아 보여주는 카드가 추가되었습니다. 탭하면 바로 이동합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A visão geral agora reúne num cartão o que precisa de atenção: domínios não ativados, túneis com estado anormal e mais. Toque para ir direto."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A descrição geral reúne agora num cartão o que precisa de atenção: domínios não ativados, túneis com estado anómalo e mais. Toque para ir direto."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Übersicht bündelt jetzt in einer Karte, was Aufmerksamkeit braucht – nicht aktivierte Domains, Tunnel in auffälligem Zustand und mehr. Ein Tippen führt direkt hin."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’aperçu regroupe désormais dans une carte ce qui mérite votre attention : domaines non activés, tunnels en état anormal, etc. Touchez pour y accéder."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تجمع صفحة النظرة العامة الآن في بطاقة واحدة ما يحتاج انتباهك: النطاقات غير المفعّلة، والأنفاق ذات الحالة غير الطبيعية وغيرها. انقر على البند للانتقال إليه مباشرة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakış artık dikkat gerektirenleri tek kartta topluyor: etkinleştirilmemiş alan adları, durumu bozuk tüneller ve daha fazlası. Dokununca doğrudan açılır."
+          }
+        }
+      }
+    },
+    "概览页顶栏的放大镜可一次搜索域名、Worker、R2 存储桶、D1 数据库、KV 命名空间与隧道，点一下直达；任意资源都能星标固定到概览页。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The magnifier on the overview searches domains, Workers, R2 buckets, D1 databases, KV namespaces and tunnels at once — tap a result to go straight there. And any resource can now be starred to the overview."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總覽頁頂端的放大鏡可一次搜尋網域、Worker、R2 儲存桶、D1 資料庫、KV 命名空間與通道，點一下直達；任何資源都能加上星號固定到總覽頁。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概覽頁頂部的放大鏡可一次搜尋域名、Worker、R2 儲存桶、D1 資料庫、KV 命名空間與隧道，點一下直達；任何資源都可以加星固定到概覽頁。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要ページの虫めがねから、ドメイン・Worker・R2 バケット・D1 データベース・KV ネームスペース・トンネルをまとめて検索でき、タップですぐ移動できます。どのリソースもスターを付けて概要ページに固定できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La lupa de la pantalla de resumen busca a la vez dominios, Workers, buckets R2, bases de datos D1, espacios de nombres KV y túneles; toca un resultado para ir directo. Además, ahora puedes fijar cualquier recurso al resumen con una estrella."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면 상단의 돋보기로 도메인, Worker, R2 버킷, D1 데이터베이스, KV 네임스페이스, 터널을 한 번에 검색하고 바로 이동할 수 있습니다. 이제 어떤 리소스든 별표로 개요 화면에 고정할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A lupa na tela de visão geral busca de uma vez domínios, Workers, buckets R2, bancos D1, namespaces KV e túneis — toque para ir direto. E agora dá para fixar qualquer recurso na visão geral com uma estrela."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A lupa no ecrã de descrição geral pesquisa de uma vez domínios, Workers, buckets R2, bases de dados D1, namespaces KV e túneis — toque para ir direto. E agora pode fixar qualquer recurso com uma estrela."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über die Lupe in der Übersicht durchsuchst du Domains, Workers, R2-Buckets, D1-Datenbanken, KV-Namespaces und Tunnel auf einmal – ein Tippen führt direkt hin. Und jede Ressource lässt sich per Stern an die Übersicht heften."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La loupe de l’aperçu recherche d’un coup les domaines, Workers, buckets R2, bases D1, espaces de noms KV et tunnels : touchez un résultat pour y aller. Et n’importe quelle ressource peut désormais être épinglée à l’aperçu."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبحث العدسة في صفحة النظرة العامة دفعة واحدة في النطاقات وWorkers وحاويات R2 وقواعد بيانات D1 ومساحات أسماء KV والأنفاق، وانقر على النتيجة للانتقال مباشرة. ويمكن الآن تثبيت أي مورد في الصفحة بنجمة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakıştaki büyüteç; alan adlarını, Worker’ları, R2 bucket’larını, D1 veritabanlarını, KV ad alanlarını ve tünelleri tek seferde arar, dokununca doğrudan açar. Artık her kaynağı yıldızlayıp genel bakışa sabitleyebilirsiniz."
+          }
+        }
+      }
+    },
+    "模型试运行新增文生图：输入提示词直接出图，可分享保存。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The model playground now covers text-to-image models — type a prompt, get a picture, then share or save it."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型試執行新增文字生圖：輸入提示詞直接產生圖片，可分享或儲存。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型試執行新增文字生圖：輸入提示詞直接生成圖片，可分享或儲存。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルの試し実行が画像生成モデルに対応。プロンプトを入力するだけで画像ができ、共有や保存もできます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La prueba de modelos ahora incluye los de texto a imagen: escribe un prompt, obtén la imagen y compártela o guárdala."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 시험 실행이 이미지 생성 모델을 지원합니다. 프롬프트를 입력하면 바로 이미지가 만들어지고, 공유하거나 저장할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O teste de modelos agora inclui os de texto para imagem: escreva um prompt, receba a imagem e compartilhe ou salve."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O teste de modelos inclui agora os de texto para imagem: escreva um prompt, receba a imagem e partilhe ou guarde."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Modell-Testlauf unterstützt jetzt Text-zu-Bild-Modelle: Prompt eingeben, Bild erhalten, teilen oder sichern."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’essai de modèles prend désormais en charge le texte-vers-image : saisissez une consigne, obtenez l’image, partagez-la ou enregistrez-la."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صار تشغيل النماذج التجريبي يدعم نماذج تحويل النص إلى صورة: اكتب الوصف لتحصل على صورة، ثم شاركها أو احفظها."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model deneme çalıştırması artık metinden görsele modellerini de destekliyor: bir istem yazın, görseli alın, paylaşın veya kaydedin."
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,33 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "1.9.0", items: [
+            WhatsNewItem(
+                icon:   "magnifyingglass",
+                title:  String(localized: "一处搜遍所有资源", table: "WhatsNew"),
+                detail: String(localized: "概览页顶栏的放大镜可一次搜索域名、Worker、R2 存储桶、D1 数据库、KV 命名空间与隧道，点一下直达；任意资源都能星标固定到概览页。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "bell.badge",
+                title:  String(localized: "告警中心", table: "WhatsNew"),
+                detail: String(localized: "概览页新增告警卡片，汇总需要注意的资源——未启用的域名、状态异常的隧道等，点一下直达。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "text.magnifyingglass",
+                title:  String(localized: "实时日志更好用", table: "WhatsNew"),
+                detail: String(localized: "Worker 实时日志支持关键词搜索与级别筛选；长按复制整行，轻点展开完整详情并选取片段。「暂停」现在只冻结画面、日志照常接收，恢复后能看到完整记录。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "clock.arrow.circlepath",
+                title:  String(localized: "SQL 历史与收藏", table: "WhatsNew"),
+                detail: String(localized: "D1 查询自动记录最近 12 条，常用语句可收藏（按数据库分别保存）；查询结果一键导出 CSV，表详情还能查看索引。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "photo.artframe",
+                title:  String(localized: "Workers AI 文生图", table: "WhatsNew"),
+                detail: String(localized: "模型试运行新增文生图：输入提示词直接出图，可分享保存。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "1.8.7", items: [
             WhatsNewItem(
                 icon:   "globe",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -126082,82 +126082,6 @@
         }
       }
     },
-    "试运行文本生成模型需要 Workers AI 写权限（ai.write）。点上方按钮一键补齐授权，无需退出登录。": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تتطلب تجربة نماذج توليد النصوص صلاحية كتابة Workers AI (ai.write). اضغط الزر أعلاه لمنحها بخطوة واحدة دون تسجيل الخروج."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das Testen von Textgenerierungsmodellen erfordert Workers-AI-Schreibzugriff (ai.write). Tippe oben auf die Schaltfläche, um ihn in einem Schritt zu erteilen – ohne Abmeldung."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trying out text-generation models requires Workers AI write access (ai.write). Tap the button above to grant it in one step — no need to sign out."
-          }
-        },
-        "es-MX": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Probar modelos de generación de texto requiere acceso de escritura de Workers AI (ai.write). Toca el botón de arriba para concederlo en un paso, sin cerrar sesión."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tester les modèles de génération de texte nécessite l’accès en écriture Workers AI (ai.write). Touchez le bouton ci-dessus pour l’accorder en une étape, sans vous déconnecter."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テキスト生成モデルの試用には Workers AI の書き込み権限（ai.write）が必要です。上のボタンでワンタップで付与できます。ログアウトは不要です。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "텍스트 생성 모델 시험 실행에는 Workers AI 쓰기 권한(ai.write)이 필요합니다. 위 버튼을 눌러 한 번에 권한을 추가하세요. 로그아웃할 필요가 없습니다."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testar modelos de geração de texto requer acesso de escrita do Workers AI (ai.write). Toque no botão acima para conceder em uma etapa, sem sair da conta."
-          }
-        },
-        "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testar modelos de geração de texto requer acesso de escrita do Workers AI (ai.write). Toque no botão acima para conceder num passo, sem terminar sessão."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Metin üretme modellerini denemek için Workers AI yazma erişimi (ai.write) gerekir. Tek adımda vermek için yukarıdaki düğmeye dokunun; oturumu kapatmaya gerek yok."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "試執行文字生成模型需要 Workers AI 寫入權限（ai.write）。點上方按鈕一鍵補齊授權，無需登出。"
-          }
-        },
-        "zh-HK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "試執行文字生成模型需要 Workers AI 寫入權限（ai.write）。點上方按鈕一鍵補齊授權，無需登出。"
-          }
-        }
-      }
-    },
     "该 Worker 未配置 Cron 触发器。": {
       "localizations": {
         "ar": {
@@ -147456,6 +147380,4416 @@
           "stringUnit": {
             "state": "translated",
             "value": "可綁定既有 D1 資料庫 / KV 命名空間 / R2 儲存桶；佇列、Durable Object 等其它資源仍為唯讀，請用 Wrangler 或 Dashboard。"
+          }
+        }
+      }
+    },
+    "%@ · 未找到该资源": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · لم يتم العثور على المورد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Ressource nicht gefunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Resource not found"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Recurso no encontrado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Ressource introuvable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · リソースが見つかりません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · 리소스를 찾을 수 없음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Recurso não encontrado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Recurso não encontrado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Kaynak bulunamadı"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · 找不到此資源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · 找不到此資源"
+          }
+        }
+      }
+    },
+    "下拉刷新概览页后，这里会列出当前账号的资源": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسحب صفحة النظرة العامة للتحديث وستظهر هنا موارد هذا الحساب"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziehe die Übersicht zum Aktualisieren – dann erscheinen hier die Ressourcen dieses Kontos"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull to refresh the overview and this account’s resources will appear here"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desliza para actualizar el resumen y los recursos de esta cuenta aparecerán aquí"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tirez pour actualiser l’aperçu : les ressources de ce compte s’afficheront ici"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要ページを下に引いて更新すると、現在のアカウントのリソースがここに表示されます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면을 당겨서 새로고침하면 현재 계정의 리소스가 여기에 표시됩니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puxe para atualizar a visão geral e os recursos desta conta aparecerão aqui"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puxe para atualizar a vista geral e os recursos desta conta aparecerão aqui"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakışı yenilemek için çekin; bu hesabın kaynakları burada listelenir"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下拉重新整理概覽頁後，這裡會列出目前帳戶的資源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下拉重新整理概覽頁後，這裡會列出目前帳號的資源"
+          }
+        }
+      }
+    },
+    "主键": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفتاح الأساسي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primärschlüssel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary key"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clave primaria"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé primaire"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主キー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 키"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chave primária"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chave primária"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Birincil anahtar"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主鍵"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主鍵"
+          }
+        }
+      }
+    },
+    "事件": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حدث"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignis"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Événement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이벤트"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evento"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olay"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件"
+          }
+        }
+      }
+    },
+    "全部级别": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كل المستويات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Stufen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All levels"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos los niveles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous les niveaux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのレベル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 수준"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os níveis"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os níveis"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm düzeyler"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有級別"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有層級"
+          }
+        }
+      }
+    },
+    "分享 / 存储": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مشاركة / حفظ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilen / Sichern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share / Save"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir / Guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partager / Enregistrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有 / 保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공유 / 저장"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartilhar / Salvar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partilhar / Guardar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paylaş / Kaydet"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享 / 儲存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享 / 儲存"
+          }
+        }
+      }
+    },
+    "取消收藏此 SQL": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة هذا الاستعلام SQL من المفضلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses SQL aus Favoriten entfernen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove this SQL from favorites"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar este SQL de favoritos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer ce SQL des favoris"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この SQL をお気に入りから削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 SQL을 즐겨찾기에서 제거"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover este SQL dos favoritos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover este SQL dos favoritos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu SQL’i favorilerden çıkar"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將此 SQL 移出收藏"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將此 SQL 移出收藏"
+          }
+        }
+      }
+    },
+    "告警": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التنبيهات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alerts"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alertas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alertes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アラート"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alertas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alertas"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyarılar"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警示"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警示"
+          }
+        }
+      }
+    },
+    "唯一约束": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قيد التفرّد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eindeutigkeitsbedingung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unique constraint"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restricción única"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrainte d’unicité"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一意制約"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고유 제약"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restrição de unicidade"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restrição de unicidade"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benzersizlik kısıtı"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "唯一約束"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "唯一性限制"
+          }
+        }
+      }
+    },
+    "图片数据无法解码": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر فك ترميز بيانات الصورة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Bilddaten konnten nicht dekodiert werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The image data couldn’t be decoded"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron decodificar los datos de la imagen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de décoder les données de l’image"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像データをデコードできませんでした"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지 데이터를 디코딩할 수 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível decodificar os dados da imagem"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível descodificar os dados da imagem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Görsel verisi çözümlenemedi"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片數據無法解碼"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片資料無法解碼"
+          }
+        }
+      }
+    },
+    "在 App 内试运行模型需要 Workers AI 写权限（ai.write）。点上方按钮一键补齐授权，无需退出登录。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتطلب تجربة النماذج داخل التطبيق صلاحية كتابة Workers AI (ai.write). اضغط الزر أعلاه لمنحها بخطوة واحدة دون تسجيل الخروج."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Testen von Modellen in der App erfordert Workers-AI-Schreibzugriff (ai.write). Tippe oben auf die Schaltfläche, um ihn in einem Schritt zu erteilen – ohne Abmeldung."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trying out models in the app requires Workers AI write access (ai.write). Tap the button above to grant it in one step — no need to sign out."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probar modelos en la app requiere acceso de escritura de Workers AI (ai.write). Toca el botón de arriba para concederlo en un paso, sin cerrar sesión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tester des modèles dans l’app nécessite l’accès en écriture Workers AI (ai.write). Touchez le bouton ci-dessus pour l’accorder en une étape, sans vous déconnecter."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App 内でモデルを試すには Workers AI の書き込み権限（ai.write）が必要です。上のボタンでワンタップで付与できます。ログアウトは不要です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱에서 모델을 시험 실행하려면 Workers AI 쓰기 권한(ai.write)이 필요합니다. 위 버튼을 눌러 한 번에 권한을 추가하세요. 로그아웃할 필요가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testar modelos no app requer acesso de escrita do Workers AI (ai.write). Toque no botão acima para conceder em uma etapa, sem sair da conta."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testar modelos na app requer acesso de escrita do Workers AI (ai.write). Toque no botão acima para conceder num passo, sem terminar sessão."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelleri uygulama içinde denemek için Workers AI yazma erişimi (ai.write) gerekir. Tek adımda vermek için yukarıdaki düğmeye dokunun; oturumu kapatmaya gerek yok."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App 內試執行模型需要 Workers AI 寫入權限（ai.write）。點上方按鈕一鍵補齊授權，無需登出。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App 內試執行模型需要 Workers AI 寫入權限（ai.write）。點上方按鈕一鍵補齊授權，無需登出。"
+          }
+        }
+      }
+    },
+    "域名待激活，检查域名服务器是否已指向 Cloudflare": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النطاق في انتظار التفعيل — تحقّق من أن خوادم الأسماء تشير إلى Cloudflare"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain wartet auf Aktivierung – prüfe, ob die Nameserver auf Cloudflare zeigen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain pending activation — check that its name servers point to Cloudflare"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dominio pendiente de activación: verifica que sus servidores de nombres apunten a Cloudflare"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domaine en attente d’activation : vérifiez que ses serveurs de noms pointent vers Cloudflare"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメインは有効化待ちです。ネームサーバーが Cloudflare を指しているか確認してください"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인이 활성화 대기 중입니다. 네임서버가 Cloudflare를 가리키는지 확인하세요"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domínio aguardando ativação — verifique se os servidores de nomes apontam para a Cloudflare"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domínio a aguardar ativação — verifique se os servidores de nomes apontam para a Cloudflare"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı etkinleştirilmeyi bekliyor — ad sunucularının Cloudflare’i gösterdiğini doğrulayın"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名待啟用，請檢查名稱伺服器是否已指向 Cloudflare"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域待啟用，請檢查名稱伺服器是否已指向 Cloudflare"
+          }
+        }
+      }
+    },
+    "域名未处于启用状态（%@）": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النطاق ليس في حالة نشطة (%@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain ist nicht aktiv (%@)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain is not active (%@)"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El dominio no está activo (%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le domaine n’est pas actif (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメインが有効な状態ではありません（%@）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인이 활성 상태가 아닙니다(%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O domínio não está ativo (%@)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O domínio não está ativo (%@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı etkin durumda değil (%@)"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名未處於啟用狀態（%@）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域未處於啟用狀態（%@）"
+          }
+        }
+      }
+    },
+    "复制全部": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ الكل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles kopieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy All"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout copier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 복사"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar tudo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar tudo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tümünü kopyala"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部複製"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部複製"
+          }
+        }
+      }
+    },
+    "复制此行": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ هذا السطر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Zeile kopieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy this line"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar esta línea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier cette ligne"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この行をコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 줄 복사"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar esta linha"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar esta linha"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu satırı kopyala"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製此行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製此行"
+          }
+        }
+      }
+    },
+    "完整内容": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المحتوى الكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vollständiger Inhalt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Content"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contenido completo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contenu complet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全文"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 내용"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conteúdo completo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conteúdo completo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tam içerik"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整內容"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整內容"
+          }
+        }
+      }
+    },
+    "定时表达式": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعبير cron"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cron-Ausdruck"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cron Expression"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expresión cron"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expression cron"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cron 式"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cron 표현식"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expressão cron"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expressão cron"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cron ifadesi"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排程表達式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排程運算式"
+          }
+        }
+      }
+    },
+    "导出 CSV": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدير CSV"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV exportieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export CSV"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar CSV"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter en CSV"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV を書き出す"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV 내보내기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar CSV"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar CSV"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV dışa aktar"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出 CSV"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出 CSV"
+          }
+        }
+      }
+    },
+    "导出为当前已加载的 %lld 行，需要更多请加 LIMIT / OFFSET 分批查询": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يصدّر الصفوف المحمَّلة حاليًا وعددها %lld. للمزيد، استعلم على دفعات باستخدام LIMIT / OFFSET"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportiert die aktuell geladenen %lld Zeilen. Für mehr Zeilen in Schritten mit LIMIT / OFFSET abfragen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exports the %lld rows currently loaded. For more, query in batches with LIMIT / OFFSET"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporta las %lld filas cargadas actualmente. Si necesitas más, consulta por lotes con LIMIT / OFFSET"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporte les %lld lignes actuellement chargées. Pour en obtenir davantage, interrogez par lots avec LIMIT / OFFSET"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在読み込まれている %lld 行を書き出します。さらに必要な場合は LIMIT / OFFSET で分割して取得してください"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 불러온 %lld개 행을 내보냅니다. 더 필요하면 LIMIT / OFFSET으로 나눠 조회하세요"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporta as %lld linhas carregadas no momento. Para mais, consulte em lotes com LIMIT / OFFSET"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporta as %lld linhas atualmente carregadas. Para mais, consulte por lotes com LIMIT / OFFSET"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şu anda yüklü olan %lld satırı dışa aktarır. Daha fazlası için LIMIT / OFFSET ile parça parça sorgulayın"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出目前已載入的 %lld 行，需要更多請加 LIMIT / OFFSET 分批查詢"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出目前已載入的 %lld 列，需要更多請加 LIMIT / OFFSET 分批查詢"
+          }
+        }
+      }
+    },
+    "已固定": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المثبَّتة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angeheftet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinned"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fijados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épinglés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留め済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고정됨"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sabitlenenler"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已固定"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已固定"
+          }
+        }
+      }
+    },
+    "已暂停 · 新增 %lld 条": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paused · %lld new"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止中 · 新着 %lld 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일시정지됨 · 새 항목 %lld개"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已暫停 · 新增 %lld 筆"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已暫停 · 新增 %lld 條"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En pausa · %lld nuevos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausado · %lld novos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em pausa · %lld novos"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausiert · %lld neue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En pause · %lld nouveaux"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موقوف مؤقتًا · %lld جديدة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duraklatıldı · %lld yeni"
+          }
+        }
+      }
+    },
+    "异常": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استثناء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausnahme"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exception"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excepción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exception"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例外"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예외"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exceção"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exceção"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İstisna"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "異常"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例外狀況"
+          }
+        }
+      }
+    },
+    "当前账号下没有 Workers 脚本": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد برامج Workers في هذا الحساب"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Konto enthält keine Workers-Skripte"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This account has no Worker scripts"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta cuenta no tiene scripts de Workers"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce compte ne contient aucun script Workers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアカウントには Workers スクリプトがありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 계정에는 Workers 스크립트가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta conta não tem scripts do Workers"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta conta não tem scripts do Workers"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu hesapta Workers betiği yok"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前帳戶下沒有 Workers 腳本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前帳號下沒有 Workers 指令碼"
+          }
+        }
+      }
+    },
+    "恢复实时滚动": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume live scrolling"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リアルタイムスクロールを再開"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간 스크롤 재개"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復即時捲動"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復實時滾動"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar desplazamiento en vivo"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar rolagem ao vivo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar deslocamento em direto"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live-Scrollen fortsetzen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre le défilement en direct"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استئناف التمرير المباشر"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canlı kaydırmayı sürdür"
+          }
+        }
+      }
+    },
+    "手动创建": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أُنشئ يدويًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuell erstellt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manually created"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creado manualmente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créé manuellement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動作成"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수동 생성"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criado manualmente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criado manualmente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elle oluşturuldu"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動建立"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動建立"
+          }
+        }
+      }
+    },
+    "按提示词生成一张图片。会消耗账号的 Workers AI 用量（每天 1 万 Neuron 免费额度）。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ينشئ صورة واحدة من موجّهك. يستهلك حصة Workers AI لحسابك (10٬000 Neuron مجانًا يوميًا)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erzeugt ein Bild aus deinem Prompt. Verbraucht das Workers-AI-Kontingent deines Kontos (10.000 Neuronen pro Tag kostenlos)."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generates one image from your prompt. Uses your account’s Workers AI quota (10,000 Neurons free per day)."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genera una imagen a partir de tu prompt. Consume la cuota de Workers AI de tu cuenta (10 000 Neuronas gratis al día)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Génère une image à partir de votre prompt. Consomme le quota Workers AI de votre compte (10 000 neurones gratuits par jour)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロンプトから画像を 1 枚生成します。アカウントの Workers AI 使用量（毎日 1 万 Neuron まで無料）を消費します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프롬프트로 이미지 한 장을 생성합니다. 계정의 Workers AI 사용량(하루 1만 Neuron 무료)을 사용합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gera uma imagem a partir do seu prompt. Consome a cota de Workers AI da sua conta (10.000 Neurônios grátis por dia)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gera uma imagem a partir do seu prompt. Consome a quota de Workers AI da sua conta (10 000 Neurónios grátis por dia)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komutunuzdan bir görsel oluşturur. Hesabınızın Workers AI kotasını kullanır (günde 10.000 Neuron ücretsiz)."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按提示詞生成一張圖片。會消耗帳戶的 Workers AI 用量（每天 1 萬 Neuron 免費額度）。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依提示詞產生一張圖片。會消耗帳號的 Workers AI 用量（每天 1 萬 Neuron 免費額度）。"
+          }
+        }
+      }
+    },
+    "按级别筛选": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التصفية حسب المستوى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Stufe filtern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter by level"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar por nivel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer par niveau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レベルで絞り込む"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수준별 필터"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar por nível"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar por nível"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Düzeye göre filtrele"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按級別篩選"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依層級篩選"
+          }
+        }
+      }
+    },
+    "换个关键词或级别再看看，已接收的日志不会丢失": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جرّب كلمة مفتاحية أو مستوى آخر — السجلات المستلمة لن تُفقد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versuche einen anderen Suchbegriff oder eine andere Stufe – bereits empfangene Protokolle gehen nicht verloren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try another keyword or level — logs already received are not lost"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba con otra palabra clave o nivel; los registros ya recibidos no se pierden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essayez un autre mot-clé ou niveau : les journaux déjà reçus ne sont pas perdus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のキーワードやレベルで試してください。受信済みのログは失われません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 검색어나 수준으로 확인해 보세요. 이미 수신한 로그는 사라지지 않습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tente outra palavra-chave ou nível — os logs já recebidos não são perdidos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimente outra palavra-chave ou nível — os registos já recebidos não se perdem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başka bir anahtar sözcük ya da düzey deneyin — alınan günlükler kaybolmaz"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換個關鍵字或級別再看看，已接收的日誌不會遺失"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換個關鍵字或層級再看看，已接收的記錄不會遺失"
+          }
+        }
+      }
+    },
+    "换个关键词试试": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جرّب كلمة مفتاحية أخرى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versuche es mit einem anderen Suchbegriff"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try a different keyword"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba con otra palabra clave"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essayez un autre mot-clé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のキーワードで試してください"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 검색어로 시도해 보세요"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tente outra palavra-chave"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimente outra palavra-chave"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farklı bir anahtar sözcük deneyin"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換個關鍵字試試"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換個關鍵字試試"
+          }
+        }
+      }
+    },
+    "描述你想生成的画面": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صِف الصورة التي تريد إنشاءها"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschreibe das gewünschte Bild"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Describe the image you want"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Describe la imagen que quieres generar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Décrivez l’image que vous souhaitez générer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成したい画像を説明してください"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생성할 이미지를 설명하세요"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descreva a imagem que você quer gerar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descreva a imagem que pretende gerar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oluşturmak istediğiniz görseli anlatın"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "描述你想生成的畫面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "描述你想生成的畫面"
+          }
+        }
+      }
+    },
+    "提示": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معلومة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Información"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Information"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정보"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilgi"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示"
+          }
+        }
+      }
+    },
+    "搜索": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بحث"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ara"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋"
+          }
+        }
+      }
+    },
+    "搜索域名、Workers、存储桶…": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث في النطاقات وWorkers والحاويات…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domains, Workers, Buckets suchen …"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search domains, Workers, buckets…"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar dominios, Workers, buckets…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher domaines, Workers, buckets…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン、Workers、バケットを検索…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인, Workers, 버킷 검색…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar domínios, Workers, buckets…"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar domínios, Workers, buckets…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı, Workers, bucket ara…"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋域名、Workers、儲存桶…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋網域、Workers、儲存桶…"
+          }
+        }
+      }
+    },
+    "搜索日志": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث في السجلات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolle durchsuchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search logs"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar registros"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher dans les journaux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログを検索"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 검색"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar logs"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar registos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Günlüklerde ara"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋日誌"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋記錄"
+          }
+        }
+      }
+    },
+    "搜索资源": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث في الموارد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ressourcen suchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search resources"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar recursos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des ressources"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リソースを検索"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "리소스 검색"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar recursos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar recursos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak ara"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋資源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋資源"
+          }
+        }
+      }
+    },
+    "收藏": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفضلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favoriten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favorites"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favoritos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favoris"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お気に入り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "즐겨찾기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favoritos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favoritos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favoriler"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收藏"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收藏"
+          }
+        }
+      }
+    },
+    "收藏此 SQL": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة هذا الاستعلام SQL إلى المفضلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses SQL zu Favoriten hinzufügen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add this SQL to favorites"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar este SQL a favoritos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter ce SQL aux favoris"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この SQL をお気に入りに追加"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 SQL을 즐겨찾기에 추가"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar este SQL aos favoritos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar este SQL aos favoritos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu SQL’i favorilere ekle"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將此 SQL 加入收藏"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將此 SQL 加入收藏"
+          }
+        }
+      }
+    },
+    "日志详情": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفاصيل السجل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolldetails"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log Details"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles del registro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails du journal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログの詳細"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 상세"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes do log"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes do registo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Günlük ayrıntıları"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日誌詳細資料"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記錄詳細資訊"
+          }
+        }
+      }
+    },
+    "暂无可搜索的资源": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد موارد قابلة للبحث بعد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine durchsuchbaren Ressourcen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No resources to search yet"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay recursos para buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune ressource à rechercher pour l’instant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索できるリソースがまだありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 검색할 리소스가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há recursos para buscar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há recursos para pesquisar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henüz aranabilir kaynak yok"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚無可搜尋的資源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚無可搜尋的資源"
+          }
+        }
+      }
+    },
+    "暂无告警，一切正常": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد تنبيهات، كل شيء على ما يرام"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Warnungen – alles in Ordnung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No alerts — everything looks good"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin alertas: todo está en orden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune alerte, tout va bien"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アラートはありません。すべて正常です"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림이 없습니다. 모두 정상입니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem alertas — está tudo certo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem alertas — está tudo bem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyarı yok, her şey yolunda"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前沒有警示，一切正常"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前沒有警示，一切正常"
+          }
+        }
+      }
+    },
+    "最近": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأخيرة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recent"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recientes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최근"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recentes"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recentes"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Son kullanılanlar"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        }
+      }
+    },
+    "查询结果 CSV": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV لنتائج الاستعلام"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV der Abfrageergebnisse"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Query results CSV"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV de resultados de la consulta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV des résultats de la requête"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クエリ結果 CSV"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쿼리 결과 CSV"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV dos resultados da consulta"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CSV dos resultados da consulta"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorgu sonuçları CSV"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查詢結果 CSV"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查詢結果 CSV"
+          }
+        }
+      }
+    },
+    "没有匹配的日志": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد سجلات مطابقة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Protokolle"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching logs"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay registros coincidentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun journal correspondant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するログがありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치하는 로그가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum log correspondente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum registo correspondente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eşleşen günlük yok"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有符合的日誌"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有符合的記錄"
+          }
+        }
+      }
+    },
+    "没有匹配的资源": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد موارد مطابقة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Ressourcen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching resources"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay recursos coincidentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune ressource correspondante"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するリソースがありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치하는 리소스가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum recurso correspondente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum recurso correspondente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eşleşen kaynak yok"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有符合的資源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有符合的資源"
+          }
+        }
+      }
+    },
+    "清除搜索": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح البحث"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suche löschen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear search"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar búsqueda"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer la recherche"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索をクリア"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 지우기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar busca"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar pesquisa"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aramayı temizle"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除搜尋"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除搜尋"
+          }
+        }
+      }
+    },
+    "清除筛选": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح التصفية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter zurücksetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear filters"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar filtros"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer les filtres"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィルタをクリア"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "필터 지우기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar filtros"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar filtros"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtreleri temizle"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除篩選"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除篩選"
+          }
+        }
+      }
+    },
+    "生成图片": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء صورة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bild generieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate image"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generar imagen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Générer l’image"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像を生成"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지 생성"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerar imagem"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerar imagem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Görsel oluştur"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成圖片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "產生圖片"
+          }
+        }
+      }
+    },
+    "生成的图片": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصورة المُنشأة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generiertes Bild"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generated image"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imagen generada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image générée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成された画像"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생성된 이미지"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imagem gerada"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imagem gerada"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oluşturulan görsel"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成的圖片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "產生的圖片"
+          }
+        }
+      }
+    },
+    "生成的图片过大，无法在 App 内预览": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصورة المُنشأة أكبر من أن تُعرَض داخل التطبيق"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das generierte Bild ist zu groß für die Vorschau in der App"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The generated image is too large to preview in the app"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La imagen generada es demasiado grande para previsualizarla en la app"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’image générée est trop volumineuse pour être prévisualisée dans l’app"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成された画像が大きすぎるため、App 内でプレビューできません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생성된 이미지가 너무 커서 앱에서 미리 볼 수 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A imagem gerada é grande demais para ser visualizada no app"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A imagem gerada é demasiado grande para pré-visualizar na app"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oluşturulan görsel uygulamada önizlenemeyecek kadar büyük"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成的圖片過大，無法在 App 內預覽"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "產生的圖片過大，無法在 App 內預覽"
+          }
+        }
+      }
+    },
+    "索引": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفهارس"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indizes"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indexes"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Índices"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Index"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インデックス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인덱스"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Índices"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Índices"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dizinler"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "索引"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "索引"
+          }
+        }
+      }
+    },
+    "级别": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المستوى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stufe"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Level"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nivel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niveau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レベル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수준"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nível"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nível"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Düzey"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "級別"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "層級"
+          }
+        }
+      }
+    },
+    "警告": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحذير"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경고"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyarı"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
+    },
+    "该模型返回的不是图片数据，暂不支持在 App 内试运行": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يعيد هذا النموذج بيانات صور، لذا لا يمكن تجربته داخل التطبيق حاليًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Modell liefert keine Bilddaten und kann daher noch nicht in der App getestet werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This model doesn’t return image data, so it can’t be tested in the app yet"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este modelo no devuelve datos de imagen, por lo que aún no se puede probar en la app"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce modèle ne renvoie pas de données d’image ; il ne peut pas encore être testé dans l’app"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このモデルは画像データを返さないため、App 内での試し実行にはまだ対応していません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 모델은 이미지 데이터를 반환하지 않아 아직 앱에서 시험 실행할 수 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este modelo não retorna dados de imagem, então ainda não é possível testá-lo no app"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este modelo não devolve dados de imagem, pelo que ainda não é possível testá-lo na app"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu model görsel verisi döndürmediğinden uygulama içinde henüz denenemiyor"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此模型返回的不是圖片數據，暫不支援在 App 內試執行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此模型回傳的不是圖片資料，暫不支援在 App 內試執行"
+          }
+        }
+      }
+    },
+    "请求地址": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عنوان الطلب"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anforderungs-URL"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request URL"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de la solicitud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de la requête"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエスト URL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청 URL"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL da requisição"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL do pedido"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İstek URL’si"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求網址"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求網址"
+          }
+        }
+      }
+    },
+    "轻点查看详情，长按复制整行": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انقر لعرض التفاصيل، واضغط مطولاً لنسخ السطر بالكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippen für Details, gedrückt halten, um die ganze Zeile zu kopieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap for details, touch and hold to copy the whole line"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca para ver detalles; mantén pulsado para copiar toda la línea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez pour les détails, maintenez pour copier toute la ligne"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップで詳細を表示、長押しで行全体をコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭하면 상세 정보, 길게 누르면 줄 전체 복사"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para ver detalhes; toque e segure para copiar a linha inteira"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para ver detalhes; toque sem soltar para copiar a linha inteira"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayrıntılar için dokunun, satırın tamamını kopyalamak için basılı tutun"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輕點查看詳細資料，長按複製整行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輕點查看詳細資訊，長按複製整行"
+          }
+        }
+      }
+    },
+    "还没有部署 Worker": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم نشر أي Worker بعد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Worker bereitgestellt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Workers deployed yet"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay Workers desplegados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun Worker déployé pour l’instant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker がまだデプロイされていません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 배포된 Worker가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum Worker implantado ainda"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há Workers implementados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henüz dağıtılmış Worker yok"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未部署 Worker"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未部署 Worker"
+          }
+        }
+      }
+    },
+    "长按可选中其中的片段单独复制": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط مطولاً لتحديد جزء من النص ونسخه"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Halte gedrückt, um einen Ausschnitt auszuwählen und zu kopieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touch and hold to select part of the text and copy it"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén pulsado para seleccionar un fragmento y copiarlo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez et maintenez pour sélectionner un extrait et le copier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "長押しすると一部だけを選択してコピーできます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "길게 눌러 일부만 선택해 복사할 수 있습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque e segure para selecionar um trecho e copiá-lo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque sem soltar para selecionar um excerto e copiá-lo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir bölümü seçip kopyalamak için basılı tutun"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "長按可選取其中片段單獨複製"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "長按可選取其中片段單獨複製"
+          }
+        }
+      }
+    },
+    "隧道状态：%@": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالة النفق: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tunnelstatus: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tunnel status: %@"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado del túnel: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État du tunnel : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トンネルの状態：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터널 상태: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status do túnel: %@"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado do túnel: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tünel durumu: %@"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隧道狀態：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通道狀態：%@"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/DeveloperPlatformModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/DeveloperPlatformModels.swift
@@ -218,6 +218,11 @@ nonisolated struct AIModel: Codable, Identifiable, Sendable {
     /// 模型短名（去掉 @cf/ 前缀的最后一段）
     var shortName: String { (name ?? id).split(separator: "/").last.map(String.init) ?? (name ?? id) }
     var taskName:  String { task?.name ?? "" }
+
+    /// 文本生成类模型（chat / instruct）
+    var isTextGen:  Bool { taskName == "Text Generation" }
+    /// 文生图类模型（Cloudflare 目录里 task name 为 `Text-to-Image`）
+    var isImageGen: Bool { taskName == "Text-to-Image" }
 }
 
 nonisolated struct AITask: Codable, Sendable {
@@ -230,6 +235,16 @@ nonisolated struct AITask: Codable, Sendable {
 nonisolated struct AIChatMessage: Codable, Sendable {
     let role:    String
     let content: String
+}
+
+/// 文生图请求体（各模型通用的最小集：只发 prompt，其余走模型默认值）
+nonisolated struct AIImageGenRequest: Codable, Sendable {
+    let prompt: String
+}
+
+/// 部分文生图模型不返回二进制，而是返回 CF 标准信封 + base64 图片（如 flux 系列）
+nonisolated struct AIImageGenResult: Codable, Sendable {
+    let image: String?
 }
 
 /// 单轮对话请求体（instruct / chat 类模型通用）

--- a/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
@@ -27,6 +27,9 @@ struct Orange_CloudApp: App {
         // 最先安装崩溃捕获，让启动期任意一步崩溃都能被记录、随下次反馈带出。
         CrashReporter.install()
         CrashReporter.recordBreadcrumb("AppStart begin")
+        // BGTask 处理器必须在 didFinishLaunching 返回前登记，且不依赖任何业务对象——
+        // 越早越好，AuthManager 稍后用 setAuthManager 回填。
+        BackgroundRefresh.register()
         #if DEBUG
         MockCloudflare.activateIfRequested()   // 诊断 mock：仅 ORANGE_MOCK=1 时生效
         #endif
@@ -36,7 +39,7 @@ struct Orange_CloudApp: App {
         // 串行预热缓存库实体解析（iOS 17.x 冷启动首次并发 fetch 竞态，Sentry APPLE-IOS-Y）
         CacheContainer.warmUp()
         WhatsNewGate.wasLoggedInAtLaunch = manager.isLoggedIn
-        BackgroundRefresh.register(authManager: manager)
+        BackgroundRefresh.setAuthManager(manager)
         // iOS 26 连续后台任务（R2 大对象 copy/move 续传），须在启动时注册处理器
         if #available(iOS 26.0, *) {
             ContinuedTaskRunner.register()

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WorkersAIService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WorkersAIService.swift
@@ -2,7 +2,7 @@
 //  WorkersAIService.swift
 //  Orange Cloud
 //
-//  Workers AI（account 级）。模型目录浏览 ai.read；文本生成试运行需 ai.read + ai.write。
+//  Workers AI（account 级）。模型目录浏览 ai.read；试运行（文本生成 / 文生图）需 ai.read + ai.write。
 //
 
 import Foundation
@@ -31,5 +31,44 @@ struct WorkersAIService {
         )
         guard response.success, let result = response.result else { throw response.toAPIError() }
         return result.response ?? ""
+    }
+
+    /// 文生图试运行（POST /accounts/{id}/ai/run/{model}）。model 路径同上，无需额外编码。
+    /// 返回体有两种形态：多数模型直接回图片二进制（PNG/JPEG），少数回 CF 信封 + base64 `image`。
+    /// 两种都不匹配时抛出明确错误，不静默返回空图。
+    func runTextToImage(accountId: String, model: String, prompt: String) async throws -> Data {
+        let raw = try await client.postRaw(
+            "accounts/\(accountId)/ai/run/\(model)", body: AIImageGenRequest(prompt: prompt)
+        )
+
+        if Self.looksLikeImage(raw) { return raw }
+
+        // 信封 + base64 形态
+        if let envelope = try? JSONDecoder().decode(CFAPIResponse<AIImageGenResult>.self, from: raw) {
+            guard envelope.success else { throw envelope.toAPIError() }
+            if let base64 = envelope.result?.image,
+               let decoded = Data(base64Encoded: base64, options: [.ignoreUnknownCharacters]),
+               Self.looksLikeImage(decoded) {
+                return decoded
+            }
+        }
+
+        AppLog.network.error("ai/run text-to-image: unexpected payload (\(raw.count) bytes)")
+        throw APIError.cloudflareError(
+            code: 0,
+            message: String(localized: "该模型返回的不是图片数据，暂不支持在 App 内试运行")
+        )
+    }
+
+    /// 按魔数判断是否图片（PNG / JPEG / GIF / WEBP）
+    private static func looksLikeImage(_ data: Data) -> Bool {
+        guard data.count > 12 else { return false }
+        let head = [UInt8](data.prefix(12))
+        if head[0] == 0x89, head[1] == 0x50, head[2] == 0x4E, head[3] == 0x47 { return true }   // PNG
+        if head[0] == 0xFF, head[1] == 0xD8, head[2] == 0xFF { return true }                    // JPEG
+        if head[0] == 0x47, head[1] == 0x49, head[2] == 0x46 { return true }                    // GIF
+        if head[0] == 0x52, head[1] == 0x49, head[2] == 0x46, head[3] == 0x46,
+           head[8] == 0x57, head[9] == 0x45, head[10] == 0x42, head[11] == 0x50 { return true } // WEBP
+        return false
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/AIImagePlaygroundViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/AIImagePlaygroundViewModel.swift
@@ -1,0 +1,80 @@
+//
+//  AIImagePlaygroundViewModel.swift
+//  Orange Cloud
+//
+//  Workers AI 文生图试运行（POST /accounts/{id}/ai/run/{model}，需 ai.read + ai.write）。
+//  返回的是图片二进制：只保留一张结果，重新运行即释放上一张，避免多张大图叠在内存里。
+//
+
+import Foundation
+import Observation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@Observable
+@MainActor
+final class AIImagePlaygroundViewModel {
+
+    var prompt = ""
+    var isRunning = false
+    var error: String?
+
+    private(set) var imageData: Data?
+    #if canImport(UIKit)
+    /// 解码后的图片（只在拿到新数据时解一次，body 里不重复解码）
+    private(set) var image: UIImage?
+    #endif
+
+    /// 结果大小上限：超过就不解码，给明确提示而不是让内存尖峰
+    static let maxImageBytes = 24 * 1024 * 1024
+
+    private let service: WorkersAIService
+    let accountId: String?
+    let model: AIModel
+
+    init(service: WorkersAIService, accountId: String?, model: AIModel) {
+        self.service = service
+        self.accountId = accountId
+        self.model = model
+    }
+
+    var trimmedPrompt: String { prompt.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var canRun: Bool { !trimmedPrompt.isEmpty && !isRunning && accountId != nil }
+
+    func run() async {
+        guard let accountId, canRun else { return }
+        isRunning = true
+        error = nil
+        clearImage()
+        defer { isRunning = false }
+        do {
+            let data = try await service.runTextToImage(
+                accountId: accountId,
+                model: model.name ?? model.id,
+                prompt: trimmedPrompt
+            )
+            guard data.count <= Self.maxImageBytes else {
+                error = String(localized: "生成的图片过大，无法在 App 内预览")
+                return
+            }
+            #if canImport(UIKit)
+            guard let decoded = UIImage(data: data) else {
+                error = String(localized: "图片数据无法解码")
+                return
+            }
+            image = decoded
+            #endif
+            imageData = data
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    private func clearImage() {
+        imageData = nil
+        #if canImport(UIKit)
+        image = nil
+        #endif
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/D1IndexListViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/D1IndexListViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  D1IndexListViewModel.swift
+//  Orange Cloud
+//
+//  D1 表结构补充：PRAGMA index_list(<table>) 读索引清单（只读，d1.read 即可）。
+//  表名走标识符转义（双引号包裹 + 内部双引号加倍），不接受任意拼接。
+//
+
+import Foundation
+import Observation
+
+/// PRAGMA index_list 的一行
+nonisolated struct D1IndexInfo: Identifiable, Sendable {
+    let name:     String
+    let isUnique: Bool
+    /// c = CREATE INDEX 建的；u = UNIQUE 约束隐式建的；pk = 主键隐式建的
+    let origin:   String
+
+    var id: String { name }
+
+    var originLabel: String {
+        switch origin {
+        case "pk": String(localized: "主键")
+        case "u":  String(localized: "唯一约束")
+        case "c":  String(localized: "手动创建")
+        default:   origin
+        }
+    }
+}
+
+@Observable
+@MainActor
+final class D1IndexListViewModel {
+
+    private(set) var indexes: [D1IndexInfo] = []
+    private(set) var loaded = false
+    var error: String?
+
+    private let service: D1Service
+    private let accountId: String
+    private let databaseId: String
+    private let tableName: String
+
+    init(service: D1Service, accountId: String, databaseId: String, tableName: String) {
+        self.service = service
+        self.accountId = accountId
+        self.databaseId = databaseId
+        self.tableName = tableName
+    }
+
+    /// 标识符加引号并转义内部双引号，防注入（对齐 D1TableViewModel.quoted）
+    private var quotedTable: String {
+        "\"" + tableName.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
+
+    func load() async {
+        guard !loaded else { return }
+        do {
+            let results = try await service.query(
+                accountId: accountId, databaseId: databaseId,
+                sql: "PRAGMA index_list(\(quotedTable))"
+            )
+            indexes = (results.first?.results ?? []).compactMap { row in
+                guard case .string(let name) = row["name"] else { return nil }
+                let unique = (row["unique"]?.displayText ?? "0") != "0"
+                let origin = row["origin"]?.displayText ?? ""
+                return D1IndexInfo(name: name, isUnique: unique, origin: origin)
+            }
+            loaded = true
+        } catch {
+            // 索引卡是补充信息，失败不打断表浏览，只在卡里提示
+            self.error = error.localizedDescription
+            loaded = true
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
@@ -33,6 +33,17 @@ final class DashboardViewModel {
     /// 账户级数据集未授权（免费账号常态）：UI 显示「无账户级数据权限」而非重试，且停发后续账户级查询
     private(set) var accountAnalyticsUnavailable = false
 
+    // MARK: - 资源清单（命令搜索 / 跨类型置顶 / 告警中心共用）
+    // 域名与 Workers 直接读 SwiftData 缓存，这里只补拉「概览页原本不持有」的四类；
+    // 每类按 scope 门控惰性补拉，缺权限就留空数组（不报错、搜索里直接没有该类）。
+    private(set) var r2Buckets:    [R2Bucket] = []
+    private(set) var d1Databases:  [D1Database] = []
+    private(set) var kvNamespaces: [KVNamespace] = []
+    private(set) var tunnels:      [Tunnel] = []
+
+    private var inventoryLoadedForAccount: String?
+    private var inventoryTask: Task<Void, Never>?
+
     private var loadedZoneIds: Set<String> = []
     private var assetsLoadedForAccount: String?
     private var usageLoadedForAccount: String?
@@ -52,6 +63,8 @@ final class DashboardViewModel {
     private let zoneService: ZoneService
     private let workerService: WorkerService
     private let dnsService: DNSService
+    private let kvService: KVService
+    private let tunnelService: TunnelService
 
     init(
         analyticsService: AnalyticsService,
@@ -60,7 +73,9 @@ final class DashboardViewModel {
         d1Service: D1Service,
         zoneService: ZoneService,
         workerService: WorkerService,
-        dnsService: DNSService
+        dnsService: DNSService,
+        kvService: KVService,
+        tunnelService: TunnelService
     ) {
         self.analyticsService = analyticsService
         self.accountService = accountService
@@ -69,6 +84,62 @@ final class DashboardViewModel {
         self.zoneService = zoneService
         self.workerService = workerService
         self.dnsService = dnsService
+        self.kvService = kvService
+        self.tunnelService = tunnelService
+    }
+
+    /// 资源清单补拉（R2 / D1 / KV / Tunnel）。同一账号只拉一次，下拉刷新强制重拉；
+    /// 每类各自 scope 门控，失败或无权限保持空数组（搜索/告警里自然缺席，不弹错）。
+    /// 加载跑在 VM 持有的独立 Task：与 loadAssets 同理，手势取消不能波及它。
+    func loadInventory(
+        accountId: String,
+        canReadR2: Bool,
+        canReadD1: Bool,
+        canReadKV: Bool,
+        canReadTunnel: Bool,
+        force: Bool = false
+    ) async {
+        guard !accountId.isEmpty else { return }
+        guard force || inventoryLoadedForAccount != accountId else { return }
+        if let inventoryTask {
+            await inventoryTask.value
+            return
+        }
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.performLoadInventory(
+                accountId: accountId,
+                canReadR2: canReadR2, canReadD1: canReadD1,
+                canReadKV: canReadKV, canReadTunnel: canReadTunnel
+            )
+        }
+        inventoryTask = task
+        defer { inventoryTask = nil }
+        await task.value
+    }
+
+    private func performLoadInventory(
+        accountId: String,
+        canReadR2: Bool,
+        canReadD1: Bool,
+        canReadKV: Bool,
+        canReadTunnel: Bool
+    ) async {
+        if canReadR2, let buckets = try? await r2Service.listBuckets(accountId: accountId) {
+            r2Buckets = buckets
+            r2BucketCount = buckets.count
+        }
+        if canReadD1, let databases = try? await d1Service.listDatabases(accountId: accountId) {
+            d1Databases = databases
+            d1DatabaseCount = databases.count
+        }
+        if canReadKV, let namespaces = try? await kvService.listNamespaces(accountId: accountId) {
+            kvNamespaces = namespaces
+        }
+        if canReadTunnel, let list = try? await tunnelService.listTunnels(accountId: accountId) {
+            tunnels = list
+        }
+        inventoryLoadedForAccount = accountId
     }
 
     /// 首屏资产统计：拉 Zone / Worker 列表同步进缓存（指标格直接从 @Query 读到数量），

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerTailViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerTailViewModel.swift
@@ -28,9 +28,78 @@ final class WorkerTailViewModel {
         let text: String
     }
 
+    /// 级别筛选（只影响展示，不丢原始日志）。
+    /// log/debug/info/warn 是 Workers runtime 的原样 token，不翻译；
+    /// error 归并 runtime 抛出的 exception 行。
+    nonisolated enum LevelFilter: String, CaseIterable, Identifiable, Sendable {
+        case all, event, log, debug, info, warn, error
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .all:   String(localized: "全部级别")
+            case .event: String(localized: "事件")
+            case .log:   "log"
+            case .debug: "debug"
+            case .info:  "info"
+            case .warn:  "warn"
+            case .error: "error"
+            }
+        }
+
+        func matches(_ level: String) -> Bool {
+            switch self {
+            case .all:   true
+            case .event: level == "event"
+            case .log:   level == "log"
+            case .debug: level == "debug"
+            case .info:  level == "info"
+            case .warn:  level == "warn"
+            case .error: level == "error" || level == "exception"
+            }
+        }
+    }
+
     private(set) var lines: [LogLine] = []
     private(set) var state: ConnectionState = .idle
-    var isPaused = false       // 暂停 = 丢弃新事件，连接保持
+
+    /// 暂停 = 冻结视图（停止自动滚到底），事件照常入 buffer，恢复后能看到这段日志
+    private(set) var isPaused = false
+    /// 暂停期间累积的新行数，用于提示「暂停期间新增 N 条」
+    private(set) var pausedNewCount = 0
+
+    /// 切换暂停；恢复时清零计数（视图会随之自动滚到底）
+    func togglePause() {
+        isPaused.toggle()
+        if !isPaused { pausedNewCount = 0 }
+    }
+
+    // MARK: - 展示过滤（原始 lines 始终保留全量，改条件不丢历史）
+
+    var searchText = ""
+    var levelFilter: LevelFilter = .all
+
+    /// 是否处于筛选态（决定空态文案）
+    var isFiltering: Bool {
+        levelFilter != .all || !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// 实际渲染的日志行：关键词（不区分大小写，匹配正文）+ 级别双重过滤
+    var visibleLines: [LogLine] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard levelFilter != .all || !query.isEmpty else { return lines }
+        return lines.filter { line in
+            guard levelFilter.matches(line.level) else { return false }
+            guard !query.isEmpty else { return true }
+            return line.text.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    func clearFilters() {
+        searchText = ""
+        levelFilter = .all
+    }
 
     private let service: WorkerTailService
     private let accountId: String
@@ -77,6 +146,7 @@ final class WorkerTailViewModel {
 
     func clear() {
         lines.removeAll()
+        pausedNewCount = 0
     }
 
     private func connect() async {
@@ -158,8 +228,6 @@ final class WorkerTailViewModel {
     // MARK: - 事件 → 日志行
 
     private func handle(_ item: TailTraceItem) {
-        guard !isPaused else { return }
-
         var newLines: [LogLine] = []
         let eventDate = item.eventTimestamp.map { Date(timeIntervalSince1970: TimeInterval($0) / 1000) } ?? Date()
 
@@ -193,6 +261,7 @@ final class WorkerTailViewModel {
         if lines.count > Self.maxLines {
             lines.removeFirst(lines.count - Self.maxLines)
         }
+        if isPaused { pausedNewCount += newLines.count }
 
         eventCount += 1
         updateActivity()

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/AlertCenterCard.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/AlertCenterCard.swift
@@ -1,0 +1,170 @@
+//
+//  AlertCenterCard.swift
+//  Orange Cloud
+//
+//  概览页「告警中心」：最多 5 条，严重度用不同配色圆点；全部正常时显示「暂无告警」。
+//  规则在 Core/Dashboard/DashboardAlerts.swift（纯函数、不发请求），本文件只负责呈现。
+//
+
+import SwiftUI
+
+struct AlertCenterCard: View {
+
+    let alerts: [DashboardAlert]
+    /// 点击一条告警：由概览页栈根的 navdest 承接（值式路由，勿改 eager NavigationLink）
+    let onSelect: (DashboardResourceRoute) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack {
+            Text("告警")
+                .font(.title3.bold())
+            Spacer()
+            if !alerts.isEmpty {
+                Text("\(alerts.count)")
+                    .font(.caption.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if alerts.isEmpty {
+            emptyIsland
+        } else {
+            VStack(spacing: 0) {
+                ForEach(alerts) { alert in
+                    row(alert)
+                    if alert.id != alerts.last?.id {
+                        Divider().padding(.leading, 30)
+                    }
+                }
+            }
+            .glassIsland()
+        }
+    }
+
+    private var emptyIsland: some View {
+        HStack(spacing: 10) {
+            SeverityDot(severity: .ok)
+            Text("暂无告警，一切正常")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, OCLayout.islandPadding)
+        .padding(.vertical, 14)
+        .glassIsland(cornerRadius: OCLayout.chipRadius)
+    }
+
+    @ViewBuilder
+    private func row(_ alert: DashboardAlert) -> some View {
+        if let route = alert.route {
+            Button {
+                onSelect(route)
+            } label: {
+                AlertRow(alert: alert, showsChevron: true)
+            }
+            .buttonStyle(.plain)
+        } else {
+            AlertRow(alert: alert, showsChevron: false)
+        }
+    }
+}
+
+/// 单条告警行（圆点 + 标题 + 说明）
+private struct AlertRow: View {
+
+    let alert: DashboardAlert
+    let showsChevron: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            SeverityDot(severity: alert.severity)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(alert.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(alert.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, OCLayout.islandPadding)
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+}
+
+/// 严重度圆点：critical 红 / warn 橙 / info 蓝 / ok 绿；
+/// 开启「不用颜色区分」时换成带形状的符号，不只靠颜色传达。
+private struct SeverityDot: View {
+
+    let severity: DashboardAlert.Severity
+
+    @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
+
+    private var color: Color {
+        switch severity {
+        case .critical: .red
+        case .warn:     .ocOrange
+        case .info:     .blue
+        case .ok:       .green
+        }
+    }
+
+    private var glyph: String {
+        switch severity {
+        case .critical: "exclamationmark.circle.fill"
+        case .warn:     "exclamationmark.triangle.fill"
+        case .info:     "info.circle.fill"
+        case .ok:       "checkmark.circle.fill"
+        }
+    }
+
+    private var label: String {
+        switch severity {
+        case .critical: String(localized: "严重")
+        case .warn:     String(localized: "警告")
+        case .info:     String(localized: "提示")
+        case .ok:       String(localized: "正常")
+        }
+    }
+
+    var body: some View {
+        Group {
+            if differentiateWithoutColor {
+                Image(systemName: glyph)
+                    .font(.system(size: 12))
+                    .foregroundStyle(color)
+            } else {
+                Circle()
+                    .fill(color)
+                    .frame(width: 8, height: 8)
+                    .background(
+                        Circle()
+                            .fill(color.opacity(0.13))
+                            .frame(width: 14, height: 14)
+                    )
+            }
+        }
+        .frame(width: 16)
+        .accessibilityLabel(label)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -28,8 +28,14 @@ import WidgetKit
 struct DashboardView: View {
 
     @Environment(AuthManager.self) private var auth
+    @Environment(EntitlementStore.self) private var entitlements
 
     private let session: SessionStore
+
+    /// 命令搜索 / 告警中心选中的资源目的地：栈根用 `.navigationDestination(item:)` 承接。
+    /// 用 item 版而非 NavigationPath：本工程没有一处 `NavigationStack(path:)`，
+    /// 而 item 版同样能程序化 push（TunnelCreateView 已在用），改动面与风险都最小。
+    @State private var resourceRoute: DashboardResourceRoute?
 
     init(session: SessionStore) {
         self.session = session
@@ -41,7 +47,7 @@ struct DashboardView: View {
 
     var body: some View {
         NavigationStack {
-            DashboardHomeView(session: session)
+            DashboardHomeView(session: session, resourceRoute: $resourceRoute)
                 .navigationDestination(for: CachedZone.self) { zone in
                     ZoneDetailView(zone: zone, session: session)
                 }
@@ -70,10 +76,55 @@ struct DashboardView: View {
                         canWriteDNS: auth.hasScope("dns.write")
                     )
                 }
+                // 命令搜索 / 告警中心 / 跨类型置顶的跳转（Worker 详情、R2 对象、D1 控制台、
+                // KV 键列表内部都还要继续 push）同样只挂栈根，值式
+                .navigationDestination(item: $resourceRoute) { route in
+                    resourceDestination(route)
+                }
                 // 域名详情子树（规则 hub / 负载均衡 / Snippets / Bulk Redirects）从本栈
                 // push 的域名卡进入，其路由也要挂在本栈根
                 .zoneRouteDestinations(session: session)
                 .id(session.selectedAccount?.id)
+        }
+        // 账号切换后旧账号的资源目的地不应留在栈上
+        .onChange(of: session.selectedAccount?.id) {
+            resourceRoute = nil
+        }
+    }
+
+    /// 免费层的 Pro 资源正常做法是在**派发前**就弹付费墙（DashboardHomeView.openResource），
+    /// 根本走不到这里；这层只是兜底，防止将来新加的入口漏挂闸门直接把详情页放进来。
+    @ViewBuilder
+    private func resourceDestination(_ route: DashboardResourceRoute) -> some View {
+        if let feature = route.proFeature, !entitlements.isPro {
+            ProLockedView(feature: feature)
+                .navigationBarTitleDisplayMode(.inline)
+        } else {
+            unlockedResourceDestination(route)
+        }
+    }
+
+    @ViewBuilder
+    private func unlockedResourceDestination(_ route: DashboardResourceRoute) -> some View {
+        switch route {
+        case .zone(let zone):
+            ZoneDetailView(zone: zone, session: session)
+        case .worker(let script):
+            WorkerDetailView(script: script, session: session)
+        case .bucket(let bucket):
+            R2ObjectListView(bucket: bucket, session: session)
+        case .database(let database):
+            D1QueryView(database: database, session: session)
+        case .namespace(let namespace):
+            KVKeyListView(namespace: namespace, session: session)
+        case .tunnel(let tunnel):
+            TunnelDetailView(
+                tunnel: tunnel,
+                accountId: currentAccountId,
+                session: session,
+                canWrite: auth.hasScope("argotunnel.write"),
+                canWriteDNS: auth.hasScope("dns.write")
+            )
         }
     }
 }
@@ -84,6 +135,7 @@ private struct DashboardHomeView: View {
 
     @Environment(SessionStore.self) private var session
     @Environment(AuthManager.self) private var auth
+    @Environment(EntitlementStore.self) private var entitlements
     @Environment(\.modelContext) private var modelContext
     // 域名 / Workers 缓存只取当前账号（父视图 .id(selectedAccount) 切换账号时重建以刷新谓词）；
     // DNS 记录缓存无 accountId 字段，按当前账号下的缓存域名在内存里过滤计数。
@@ -93,8 +145,17 @@ private struct DashboardHomeView: View {
 
     @State private var viewModel: DashboardViewModel
 
+    /// 命令搜索选中的目的地：先关 sheet、再在 onDismiss 里赋给栈根的 item navdest
+    @Binding private var resourceRoute: DashboardResourceRoute?
+    @State private var showSearch = false
+    @State private var pendingRoute: DashboardResourceRoute?
+    /// 免费层点 Pro 资源（R2 / D1 / KV / Tunnel）时弹的付费墙场景
+    @State private var paywallFeature: ProFeature?
+
     // 套餐预设与账单日按账户存储（AccountPrefsStore，开启 iCloud 同步后跨设备）
     private let prefsStore = AccountPrefsStore.shared
+    // 跨类型置顶（域名 / Workers / R2 / D1 / KV / Tunnel），按账号隔离
+    private let pinnedStore = PinnedResourceStore.shared
 
     private var currentAccountId: String {
         session.selectedAccount?.id ?? ""
@@ -134,7 +195,8 @@ private struct DashboardHomeView: View {
     @AppStorage(DayBoundary.storageKey, store: UserDefaults(suiteName: WidgetSnapshot.appGroupID))
     private var dayBoundaryRaw = DayBoundary.utc.rawValue
 
-    init(session: SessionStore) {
+    init(session: SessionStore, resourceRoute: Binding<DashboardResourceRoute?>) {
+        _resourceRoute = resourceRoute
         let accountId = session.selectedAccount?.id ?? ""
         _cachedZones = Query(
             filter: #Predicate<CachedZone> { $0.accountId == accountId },
@@ -150,7 +212,9 @@ private struct DashboardHomeView: View {
             d1Service: session.d1Service,
             zoneService: session.zoneService,
             workerService: session.workerService,
-            dnsService: session.dnsService
+            dnsService: session.dnsService,
+            kvService: session.kvService,
+            tunnelService: session.tunnelService
         ))
     }
 
@@ -174,10 +238,50 @@ private struct DashboardHomeView: View {
         return cachedRecords.filter { zoneIds.contains($0.zoneId) }.count
     }
 
-    /// 首页展示的域名：用户 pin 过的优先；一个没 pin 时兜底展示前 3 个
+    // MARK: - 跨类型置顶 / 搜索 / 告警的数据
+
+    private var zonesById: [String: CachedZone] {
+        Dictionary(cachedZones.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    /// 当前账号固定的域名 id（统一置顶 store 为准；旧的 CachedZone.pinned 已一次性迁移进来）
+    private var pinnedZoneIds: [String] {
+        pinnedStore.pins(for: currentAccountId, type: .zone).map(\.resourceId)
+    }
+
+    /// 首页展示的域名：用户 pin 过的优先（按固定顺序）；一个没 pin 时兜底展示前 3 个
     private var displayZones: [CachedZone] {
-        let pinned = cachedZones.filter(\.pinned)
+        let byId = zonesById
+        let pinned = pinnedZoneIds.compactMap { byId[$0] }
         return pinned.isEmpty ? Array(cachedZones.prefix(3)) : pinned
+    }
+
+    /// 全账号可搜索资源（域名 / Workers 走 SwiftData 缓存，其余四类来自 VM 惰性补拉的清单）
+    private var resourceItems: [DashboardResourceItem] {
+        DashboardResourceCatalog.items(
+            zones: cachedZones,
+            workers: cachedWorkers,
+            buckets: viewModel.r2Buckets,
+            databases: viewModel.d1Databases,
+            namespaces: viewModel.kvNamespaces,
+            tunnels: viewModel.tunnels
+        )
+    }
+
+    /// 域名以外的固定项（域名仍在「域名」段展示，避免同一张卡出现两次）
+    private var pinnedNonZoneResources: [PinnedResource] {
+        pinnedStore.pins(for: currentAccountId).filter { $0.type != .zone }
+    }
+
+    private var alerts: [DashboardAlert] {
+        DashboardAlerts.build(
+            zones: cachedZones,
+            tunnels: viewModel.tunnels,
+            // 资产仍在加载时不下「一个 Worker 都没有」的结论（缓存此刻本来就是空的）
+            workerCount: (auth.hasScope("workers-scripts.read") && !viewModel.isLoadingAssets && !cachedZones.isEmpty)
+                ? cachedWorkers.count
+                : nil
+        )
     }
 
     var body: some View {
@@ -200,14 +304,23 @@ private struct DashboardHomeView: View {
                     }
                 }
                 .islandReveal(1)
-                usageSection
+                // 首屏还没有任何缓存、资产仍在加载时先不出告警卡（免得空数据被当成「一切正常」）
+                if !(cachedZones.isEmpty && viewModel.isLoadingAssets) {
+                    AlertCenterCard(alerts: alerts) { route in
+                        openResource(route)
+                    }
                     .islandReveal(2)
-                zonesSection
+                }
+                usageSection
                     .islandReveal(3)
-                networkSection
+                zonesSection
                     .islandReveal(4)
+                // 无固定项时整段不出现（islandReveal 挂在段内，避免空段占掉 VStack 间距）
+                pinnedResourcesSection
+                networkSection
+                    .islandReveal(6)
                 bulkRedirectsSection
-                    .islandReveal(5)
+                    .islandReveal(7)
             }
             .padding(OCLayout.pagePadding)
         }
@@ -217,9 +330,25 @@ private struct DashboardHomeView: View {
         // DashboardView 的栈根，不能挂回这里：iOS 17.0 上 navdest 注册在栈内容的嵌套
         // 子视图会在 push 时触发 AttributeGraph 无限循环整 App 冻结（见外壳注释）。
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("搜索资源", systemImage: "magnifyingglass") {
+                    showSearch = true
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 accountMenu
             }
+        }
+        // 搜索面板里选中资源后：先关 sheet，关闭完成再派发给栈根 navdest（不在 sheet 内 push）
+        .sheet(isPresented: $showSearch, onDismiss: dispatchPendingRoute) {
+            ResourceSearchView(
+                items: resourceItems,
+                accountId: currentAccountId,
+                onSelect: { route in
+                    pendingRoute = route
+                    showSearch = false
+                }
+            )
         }
         .task(id: session.accounts.count) {
             AccountSwitchTip.hasMultipleAccounts = session.accounts.count > 1 || auth.sessions.count > 1
@@ -236,6 +365,17 @@ private struct DashboardHomeView: View {
         }
         .task {
             await loadUsage()
+        }
+        .task {
+            await loadInventory()
+        }
+        // 旧的 CachedZone.pinned → 统一置顶 store 的一次性迁移：域名缓存到位后才迁（store 内按账号只做一次）
+        .task(id: cachedZones.count) {
+            pinnedStore.migrateZonePinsIfNeeded(
+                accountId: currentAccountId,
+                pinnedZoneIds: cachedZones.filter(\.pinned).map(\.id),
+                hasZoneData: !cachedZones.isEmpty
+            )
         }
         .onChange(of: accountPrefs.billingCycleDay) {
             Task { await loadUsage(force: true) }
@@ -255,6 +395,10 @@ private struct DashboardHomeView: View {
         .sheet(item: $usageDetail) { service in
             usageDetailSheet(service)
         }
+        // 免费层点 Pro 资源（搜索结果 / 告警 / 已固定）的付费墙
+        .sheet(item: $paywallFeature) { feature in
+            PaywallView(feature: feature)
+        }
     }
 
     /// 「需重新授权」引导：说明 + 一键重授权（同身份原地换令牌），成功摘标后自动重拉
@@ -272,12 +416,49 @@ private struct DashboardHomeView: View {
         .glassIsland(cornerRadius: OCLayout.chipRadius)
     }
 
-    /// 下拉刷新 / 顶部失败提示重试：强制重拉账号、资产、流量、用量
+    /// 下拉刷新 / 顶部失败提示重试：强制重拉账号、资产、流量、用量、资源清单
     private func refreshAll() async {
         await session.ensureAccounts()
         await loadAssets(force: true)
         await loadTraffic(force: true)
         await loadUsage(force: true)
+        await loadInventory(force: true)
+    }
+
+    /// sheet 关闭后再 push，避免「关面板」与「入栈」同帧打架
+    private func dispatchPendingRoute() {
+        guard let route = pendingRoute else { return }
+        pendingRoute = nil
+        openResource(route)
+    }
+
+    /// 打开一个资源（命令搜索 / 告警中心 / 已固定区共用的唯一出口）。
+    ///
+    /// 与 Android `OrangeCloudRoot.openResource` 同口径：**能搜到，点进去撞付费墙**——
+    /// 免费层点 R2 / D1 / KV / Tunnel 不入栈，改弹 PaywallView（复用 ProFeature 的场景文案，
+    /// 与存储 Tab 整页闸门、Tunnel 入口闸门是同一套）。域名 / Workers 免费，照常 push。
+    ///
+    /// 闸门只在「赋值 route 之前」判断，不动栈根的值式 navdest 结构（导航铁律）。
+    private func openResource(_ route: DashboardResourceRoute) {
+        if let feature = route.proFeature, !entitlements.isPro {
+            paywallFeature = feature
+        } else {
+            resourceRoute = route
+        }
+    }
+
+    /// 资源清单（R2 / D1 / KV / Tunnel）惰性补拉：**免费层也拉**，让搜索结果与告警覆盖全部资源
+    /// （点进去才撞付费墙，见 openResource）；各类仍按 scope 分别门控，缺权限就跳过该类。
+    private func loadInventory(force: Bool = false) async {
+        guard let accountId = session.selectedAccount?.id else { return }
+        await viewModel.loadInventory(
+            accountId: accountId,
+            canReadR2: auth.hasScope("workers-r2.read"),
+            canReadD1: auth.hasScope("d1.read"),
+            canReadKV: auth.hasScope("workers-kv-storage.read"),
+            canReadTunnel: auth.hasScope("argotunnel.read"),
+            force: force
+        )
     }
 
     /// 首屏资产统计：域名 / Workers / DNS 数量不等用户进入对应页面，进 Dashboard 就拉
@@ -1082,13 +1263,92 @@ private struct DashboardHomeView: View {
                 }
                 .glassIsland()
 
-                if cachedZones.first(where: \.pinned) == nil {
+                if pinnedZoneIds.isEmpty {
                     Label("在域名详情页点图钉，可固定想在首页看到的域名", systemImage: "pin")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .padding(.horizontal, 4)
                 }
             }
+        }
+    }
+
+    // MARK: - 已固定（域名以外：Workers / R2 / D1 / KV / Tunnel）
+
+    @ViewBuilder
+    private var pinnedResourcesSection: some View {
+        let pins = pinnedNonZoneResources
+        if !pins.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("已固定")
+                        .font(.title3.bold())
+                    Spacer()
+                    Button("搜索") { showSearch = true }
+                        .font(.subheadline)
+                        .foregroundStyle(Color.ocOrangeText)
+                }
+                pinnedIsland(pins)
+            }
+            .islandReveal(5)
+        }
+    }
+
+    private func pinnedIsland(_ pins: [PinnedResource]) -> some View {
+        // 标题 / 副标题一律现查（持久化里只有 type + id），资源改名后固定依然有效
+        let itemsById = Dictionary(resourceItems.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return VStack(spacing: 0) {
+            ForEach(pins) { pin in
+                pinnedRow(pin, item: itemsById[pin.id])
+                if pin.id != pins.last?.id {
+                    Divider().padding(.leading, 56)
+                }
+            }
+        }
+        .glassIsland()
+    }
+
+    @ViewBuilder
+    private func pinnedRow(_ pin: PinnedResource, item: DashboardResourceItem?) -> some View {
+        if let item {
+            Button {
+                openResource(item.route)
+            } label: {
+                PinnedResourceRow(
+                    type: item.type,
+                    title: item.title,
+                    subtitle: "\(item.type.label) · \(item.subtitle)",
+                    resolved: true
+                )
+            }
+            .buttonStyle(.plain)
+            .contextMenu {
+                Button("取消固定", systemImage: "star.slash", role: .destructive) {
+                    pinnedStore.unpin(pin, accountId: currentAccountId)
+                }
+            }
+        } else {
+            // 资源查不到（已删除 / 该类清单未加载 / 缺权限）：显示标识本身，并给取消固定的出口
+            HStack(spacing: 0) {
+                PinnedResourceRow(
+                    type: pin.type,
+                    title: pin.resourceId,
+                    subtitle: String(localized: "\(pin.type.label) · 未找到该资源"),
+                    resolved: false
+                )
+                Button {
+                    pinnedStore.unpin(pin, accountId: currentAccountId)
+                } label: {
+                    Image(systemName: "star.slash")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 40, height: 40)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("取消固定")
+            }
+            .padding(.trailing, 4)
         }
     }
 
@@ -1367,6 +1627,42 @@ private struct DashboardZoneCard: View {
             }
             StatusDot(status: zone.status, size: 7)
                 .accessibilityHidden(true)   // 状态已在副标题文字中
+        }
+        .padding(.horizontal, OCLayout.islandPadding)
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - 已固定资源行（跨类型：Workers / R2 / D1 / KV / Tunnel）
+
+private struct PinnedResourceRow: View {
+
+    let type: PinnedResourceType
+    let title: String
+    let subtitle: String
+    /// 能否在当前数据源里解析到该资源（否则弱化显示，不给跳转）
+    let resolved: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            TintIcon(systemImage: type.symbolName, color: type.tint, size: 32)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(resolved ? Color.primary : Color.secondary)
+                    .lineLimit(1)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            if resolved {
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
         }
         .padding(.horizontal, OCLayout.islandPadding)
         .padding(.vertical, 10)

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/ResourceSearchView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/ResourceSearchView.swift
@@ -1,0 +1,195 @@
+//
+//  ResourceSearchView.swift
+//  Orange Cloud
+//
+//  命令搜索：概览页工具栏放大镜弹出的 sheet，跨类型实时过滤当前账号的资源
+//  （域名 / Workers / R2 / D1 / KV / Tunnel），点行跳转、点星标切换固定到首页。
+//
+//  **刻意不用 `.searchable`**：本工程已知 `.refreshable` + `.searchable` 组合下拉必报
+//  「网络错误：已取消」（Zone/DNS/Worker/KV 四页修过），概览页是 refreshable 的，
+//  因此搜索走 sheet + 普通 TextField。
+//
+//  **跳转不在 sheet 内 push**：选中只回调给概览页，由它先关 sheet、再由**栈根**的
+//  `.navigationDestination(item:)` 承接（值式路由）。sheet 内 eager NavigationLink
+//  指向「内部还要再导航」的目的页在 iOS 17 会卡死（见 DashboardView 注释）。
+//
+
+import SwiftUI
+
+struct ResourceSearchView: View {
+
+    /// 当前账号的全部可搜索资源（由概览页从缓存 + VM 清单拼好传入）
+    let items: [DashboardResourceItem]
+    let accountId: String
+    /// 选中一条：概览页负责关闭 sheet 并在关闭后派发路由
+    let onSelect: (DashboardResourceRoute) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var queryFocused: Bool
+    @State private var query = ""
+
+    private let pinnedStore = PinnedResourceStore.shared
+
+    /// 空查询显示前 30 条（已固定的排在最前），有查询最多 50 条
+    private var results: [DashboardResourceItem] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            let pins = pinnedStore.pins(for: accountId)
+            let pinnedIds = Set(pins.map(\.id))
+            let pinnedFirst = items.filter { pinnedIds.contains($0.id) }
+                + items.filter { !pinnedIds.contains($0.id) }
+            return Array(pinnedFirst.prefix(30))
+        }
+        return Array(items.filter { $0.matches(trimmed) }.prefix(50))
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                searchField
+                resultList
+            }
+            .padding(.top, 8)
+            .background { SkyBackground() }
+            .navigationTitle("搜索资源")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("完成") { dismiss() }
+                }
+            }
+            .task {
+                // sheet 完成呈现后再抢焦点，避免 iOS 17 上键盘与转场抢时序
+                queryFocused = true
+            }
+        }
+    }
+
+    // MARK: - 输入框（普通 TextField，见文件头注释）
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("搜索域名、Workers、存储桶…", text: $query)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .focused($queryFocused)
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("清空")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .glassIsland(cornerRadius: OCLayout.chipRadius)
+        .padding(.horizontal, OCLayout.pagePadding)
+    }
+
+    // MARK: - 结果
+
+    @ViewBuilder
+    private var resultList: some View {
+        if items.isEmpty {
+            emptyState(
+                icon: "square.stack.3d.up.slash",
+                title: String(localized: "暂无可搜索的资源"),
+                detail: String(localized: "下拉刷新概览页后，这里会列出当前账号的资源")
+            )
+        } else if results.isEmpty {
+            emptyState(
+                icon: "magnifyingglass",
+                title: String(localized: "没有匹配的资源"),
+                detail: String(localized: "换个关键词试试")
+            )
+        } else {
+            List(results) { item in
+                row(item)
+                    .glassRow()
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .scrollDismissesKeyboard(.immediately)
+        }
+    }
+
+    private func emptyState(icon: String, title: String, detail: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.subheadline.weight(.medium))
+            Text(detail)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func row(_ item: DashboardResourceItem) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                onSelect(item.route)
+            } label: {
+                HStack(spacing: 10) {
+                    TintIcon(systemImage: item.type.symbolName, color: item.type.tint, size: 30)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(item.title)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                        Text("\(item.type.label) · \(item.subtitle)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 8)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            starButton(item)
+        }
+    }
+
+    private func starButton(_ item: DashboardResourceItem) -> some View {
+        let pinned = pinnedStore.isPinned(item.pin, accountId: accountId)
+        return Button {
+            pinnedStore.toggle(item.pin, accountId: accountId)
+        } label: {
+            Image(systemName: pinned ? "star.fill" : "star")
+                .font(.subheadline)
+                .foregroundStyle(pinned ? Color.ocOrangeText : Color.secondary)
+                .frame(width: 32, height: 32)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(pinned ? String(localized: "取消固定") : String(localized: "固定到首页"))
+    }
+
+}
+
+extension PinnedResourceType {
+    /// 行内图标底色（与存储页 StorageRow 的配色口径一致；品牌橙只给域名 / R2）
+    var tint: Color {
+        switch self {
+        case .zone:   .ocOrange
+        case .worker: .purple
+        case .r2:     .ocOrange
+        case .d1:     .blue
+        case .kv:     .green
+        case .tunnel: .teal
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/DeveloperPlatform/WorkersAIView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/DeveloperPlatform/WorkersAIView.swift
@@ -3,10 +3,14 @@
 //  Orange Cloud
 //
 //  Workers AI 模型目录（按任务类型分组，可搜索）。account 级，ai.read。
-//  点模型查看详情；文本生成（Text Generation）类模型可试运行（Playground），需 ai.read + ai.write。
+//  点模型查看详情；文本生成（Text Generation）与文生图（Text-to-Image）模型可试运行（Playground），
+//  需 ai.read + ai.write。文生图返回图片二进制，走 CFAPIClient.postRaw。
 //
 
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct WorkersAIView: View {
 
@@ -100,7 +104,7 @@ struct WorkersAIView: View {
     }
 }
 
-// MARK: - 模型详情 + 文本生成 Playground
+// MARK: - 模型详情 + 试运行 Playground（文本生成 / 文生图）
 
 private struct AIModelDetailSheet: View {
 
@@ -110,6 +114,7 @@ private struct AIModelDetailSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AuthManager.self) private var auth
     @State private var playVM: AIPlaygroundViewModel
+    @State private var imageVM: AIImagePlaygroundViewModel
 
     init(session: SessionStore, model: AIModel) {
         self.session = session
@@ -119,13 +124,18 @@ private struct AIModelDetailSheet: View {
             accountId: session.selectedAccount?.id,
             model: model
         ))
+        _imageVM = State(initialValue: AIImagePlaygroundViewModel(
+            service: session.workersAIService,
+            accountId: session.selectedAccount?.id,
+            model: model
+        ))
     }
 
-    private var isTextGen: Bool { model.taskName == "Text Generation" }
     private var hasAIWrite: Bool { auth.hasScope("ai.write") }
 
     var body: some View {
         @Bindable var playVM = playVM
+        @Bindable var imageVM = imageVM
         NavigationStack {
             List {
                 Section {
@@ -141,20 +151,17 @@ private struct AIModelDetailSheet: View {
                 }
                 .glassRow()
 
-                if isTextGen {
+                if model.isTextGen {
                     if hasAIWrite {
                         playground(text: $playVM.prompt, vm: playVM)
                     } else {
-                        Section {
-                            if let sessionId = auth.currentSessionId {
-                                ReauthorizeButton(sessionId: sessionId, scopes: ["ai.write"])
-                            }
-                        } header: {
-                            Text("试运行")
-                        } footer: {
-                            Text("试运行文本生成模型需要 Workers AI 写权限（ai.write）。点上方按钮一键补齐授权，无需退出登录。")
-                        }
-                        .glassRow()
+                        reauthorizeSection
+                    }
+                } else if model.isImageGen {
+                    if hasAIWrite {
+                        imagePlayground(text: $imageVM.prompt, vm: imageVM)
+                    } else {
+                        reauthorizeSection
                     }
                 } else {
                     Section {} footer: {
@@ -170,6 +177,88 @@ private struct AIModelDetailSheet: View {
                 ToolbarItem(placement: .confirmationAction) { Button("完成") { dismiss() } }
             }
         }
+    }
+
+    @ViewBuilder
+    private var reauthorizeSection: some View {
+        Section {
+            if let sessionId = auth.currentSessionId {
+                ReauthorizeButton(sessionId: sessionId, scopes: ["ai.write"])
+            }
+        } header: {
+            Text("试运行")
+        } footer: {
+            Text("在 App 内试运行模型需要 Workers AI 写权限（ai.write）。点上方按钮一键补齐授权，无需退出登录。")
+        }
+        .glassRow()
+    }
+
+    // MARK: - 文生图 Playground
+
+    @ViewBuilder
+    private func imagePlayground(text: Binding<String>, vm: AIImagePlaygroundViewModel) -> some View {
+        Section {
+            TextField("描述你想生成的画面", text: text, axis: .vertical)
+                .lineLimit(3...8)
+            Button {
+                Task { await vm.run() }
+            } label: {
+                HStack {
+                    Spacer()
+                    if vm.isRunning {
+                        ProgressView()
+                    } else {
+                        Label("生成图片", systemImage: "photo").fontWeight(.semibold)
+                    }
+                    Spacer()
+                }
+            }
+            .disabled(!vm.canRun)
+        } header: {
+            Text("试运行")
+        } footer: {
+            Text("按提示词生成一张图片。会消耗账号的 Workers AI 用量（每天 1 万 Neuron 免费额度）。")
+        }
+        .glassRow()
+
+        if vm.isRunning || vm.error != nil || vm.imageData != nil {
+            Section {
+                if let error = vm.error {
+                    Text(error).font(.footnote).foregroundStyle(.red)
+                } else if vm.isRunning {
+                    HStack { Spacer(); ProgressView(); Spacer() }
+                } else {
+                    generatedImage(vm)
+                }
+            } header: {
+                Text("输出")
+            }
+            .glassRow()
+        }
+    }
+
+    @ViewBuilder
+    private func generatedImage(_ vm: AIImagePlaygroundViewModel) -> some View {
+        #if canImport(UIKit)
+        if let uiImage = vm.image {
+            let image = Image(uiImage: uiImage)
+            VStack(spacing: 10) {
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                ShareLink(
+                    item: image,
+                    preview: SharePreview("生成的图片", image: image)
+                ) {
+                    Label("分享 / 存储", systemImage: "square.and.arrow.up")
+                        .font(.callout)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        #endif
     }
 
     @ViewBuilder

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1QueryView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1QueryView.swift
@@ -2,11 +2,15 @@
 //  D1QueryView.swift
 //  Orange Cloud
 //
-//  D1 SQL 查询控制台：表入口（→ D1TableView 浏览/编辑）+ SQL 编辑器 + 结果卡片。
+//  D1 SQL 查询控制台：表入口（→ D1TableView 浏览/编辑）+ 最近/收藏 SQL + SQL 编辑器 + 结果卡片。
 //  入口：StorageView 的 D1 段。
+//
+//  最近执行与收藏按 databaseId 分键落盘（D1QueryHistoryStore），不同库互不串。
 //
 
 import SwiftUI
+import CoreTransferable
+import UniformTypeIdentifiers
 
 /// 待删除表的 sheet 载荷（String 非 Identifiable，包一层用于 .sheet(item:)）
 private struct DropTarget: Identifiable {
@@ -23,6 +27,7 @@ struct D1QueryView: View {
 
     @Environment(AuthManager.self) private var auth
     @State private var viewModel: D1QueryViewModel
+    private let store = D1QueryHistoryStore.shared
     @State private var showLimitReminder = false
     @State private var tableToDrop: DropTarget?
     @FocusState private var sqlFocused: Bool
@@ -44,6 +49,10 @@ struct D1QueryView: View {
             VStack(alignment: .leading, spacing: 16) {
                 tablesIsland
 
+                favoriteChips
+
+                historyChips
+
                 sqlEditor
 
                 if let error = viewModel.error {
@@ -60,7 +69,8 @@ struct D1QueryView: View {
                         total: viewModel.results.count,
                         originalRowCount: viewModel.originalRowCounts.indices.contains(index)
                             ? viewModel.originalRowCounts[index]
-                            : (result.results?.count ?? 0)
+                            : (result.results?.count ?? 0),
+                        runToken: viewModel.didRun
                     )
                 }
             }
@@ -78,7 +88,7 @@ struct D1QueryView: View {
                     if viewModel.needsLimitReminder {
                         showLimitReminder = true
                     } else {
-                        Task { await viewModel.run() }
+                        Task { await runSQL() }
                     }
                 } label: {
                     if viewModel.isRunning {
@@ -93,7 +103,7 @@ struct D1QueryView: View {
         .sensoryFeedback(.success, trigger: viewModel.didRun)
         .confirmationDialog("查询未带 LIMIT", isPresented: $showLimitReminder, titleVisibility: .visible) {
             Button("仍要执行") {
-                Task { await viewModel.run() }
+                Task { await runSQL() }
             }
             Button("取消", role: .cancel) {}
         } message: {
@@ -162,11 +172,102 @@ struct D1QueryView: View {
         }
     }
 
-    private var sqlEditor: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label("SQL", systemImage: "terminal")
+    // MARK: - 最近 / 收藏
+
+    private var databaseId: String { database.uuid }
+
+    /// 执行成功才入历史（失败语句不值得回填）
+    private func runSQL() async {
+        let statement = viewModel.sql
+        await viewModel.run()
+        if viewModel.error == nil {
+            store.record(statement, in: databaseId)
+        }
+    }
+
+    @ViewBuilder
+    private var favoriteChips: some View {
+        let items = store.favorites(for: databaseId)
+        if !items.isEmpty {
+            chipStrip(title: String(localized: "收藏"), icon: "star.fill", items: items)
+        }
+    }
+
+    @ViewBuilder
+    private var historyChips: some View {
+        let items = store.history(for: databaseId)
+        if !items.isEmpty {
+            chipStrip(title: String(localized: "最近"), icon: "clock.arrow.circlepath", items: items)
+        }
+    }
+
+    /// 一行横滑 chip：点按回填输入框
+    private func chipStrip(title: String, icon: String, items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: icon)
                 .font(.footnote.bold())
                 .foregroundStyle(.secondary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(items, id: \.self) { item in
+                        Button {
+                            viewModel.sql = item
+                        } label: {
+                            Text(Self.chipLabel(item))
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 7)
+                                .glassIsland(cornerRadius: 10)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(Text(verbatim: Self.chipLabel(item)))
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            // SQL 始终 LTR，避免在 RTL 语言下镜像
+            .environment(\.layoutDirection, .leftToRight)
+        }
+    }
+
+    /// chip 上的单行摘要：折掉换行与连续空白，超长截断
+    private static func chipLabel(_ sql: String) -> String {
+        let flattened = sql
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
+        return flattened.count > 42 ? String(flattened.prefix(42)) + "…" : flattened
+    }
+
+    private var isCurrentFavorite: Bool {
+        store.isFavorite(viewModel.sql, in: databaseId)
+    }
+
+    private var favoriteButton: some View {
+        Button {
+            store.toggleFavorite(viewModel.sql, in: databaseId)
+        } label: {
+            Image(systemName: isCurrentFavorite ? "star.fill" : "star")
+                .font(.footnote)
+                .foregroundStyle(isCurrentFavorite ? Color.ocOrange : Color.secondary)
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .accessibilityLabel(Text(
+            isCurrentFavorite ? String(localized: "取消收藏此 SQL") : String(localized: "收藏此 SQL")
+        ))
+    }
+
+    private var sqlEditor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Label("SQL", systemImage: "terminal")
+                    .font(.footnote.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                favoriteButton
+            }
             TextEditor(text: Binding(
                 get: { viewModel.sql },
                 set: { viewModel.sql = $0 }
@@ -200,10 +301,14 @@ private struct D1ResultCard: View {
     let total: Int
     /// 截断前的原始行数（ViewModel 只保留前 maxStoredRows 行驻留内存）
     let originalRowCount: Int
+    /// 每次成功执行翻转一次，作为 CSV 重新生成的信号（同一视图身份复用时区分新旧结果）
+    let runToken: Bool
 
     private static let maxRows = 100
     /// 单元格展示截断：完整大字段进 Text 会把 CoreText 排版拖上主线程
     private static let cellLimit = 256
+
+    @State private var csvDoc: D1CSVDocument?
 
     private var rows: [[String: JSONValue]] { result.results ?? [] }
 
@@ -214,10 +319,16 @@ private struct D1ResultCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if total > 1 {
-                Text("语句 \(index + 1)")
-                    .font(.footnote.bold())
-                    .foregroundStyle(.secondary)
+            if total > 1 || !rows.isEmpty {
+                HStack(spacing: 8) {
+                    if total > 1 {
+                        Text("语句 \(index + 1)")
+                            .font(.footnote.bold())
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if !rows.isEmpty { exportButton }
+                }
             }
 
             if rows.isEmpty {
@@ -254,6 +365,11 @@ private struct D1ResultCard: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
+                if originalRowCount > rows.count {
+                    Text("导出为当前已加载的 \(rows.count) 行，需要更多请加 LIMIT / OFFSET 分批查询")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
             }
 
             if let meta = result.meta {
@@ -275,11 +391,84 @@ private struct D1ResultCard: View {
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
         .glassIsland()
+        .task(id: resultSignature) {
+            guard !rows.isEmpty else {
+                csvDoc = nil
+                return
+            }
+            csvDoc = D1CSVDocument(
+                filename: "d1-result-\(index + 1).csv",
+                text: D1CSV.text(columns: columns, rows: rows)
+            )
+        }
+    }
+
+    /// 导出当前结果集为 CSV（只导已驻留的行，不为导出再发一次无上限查询）。
+    /// CSV 文本在 .task 里生成一次并缓存，避免每次 body 求值都重新拼几百行字符串。
+    @ViewBuilder
+    private var exportButton: some View {
+        if let csvDoc {
+            ShareLink(item: csvDoc, preview: SharePreview("查询结果 CSV")) {
+                Label("导出 CSV", systemImage: "square.and.arrow.up")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.ocOrangeText)
+        }
+    }
+
+    /// 结果内容变化的近似签名：驱动 CSV 重新生成
+    private var resultSignature: String {
+        "\(index)|\(rows.count)|\(originalRowCount)|\(result.meta?.duration ?? -1)|\(runToken)"
     }
 
     private func cellDisplay(_ value: JSONValue?) -> String {
         guard let value else { return "NULL" }
         let text = value.displayText
         return text.count > Self.cellLimit ? String(text.prefix(Self.cellLimit)) + "…" : text
+    }
+}
+
+// MARK: - CSV 导出
+
+/// 结果集 → CSV 文本（RFC 4180）。含逗号 / 双引号 / 换行的字段用双引号包裹，
+/// 内部双引号写成两个。NULL 导出为空字段。数值/字节等一律出原值，不做本地化格式化。
+private nonisolated enum D1CSV {
+
+    static func text(columns: [String], rows: [[String: JSONValue]]) -> String {
+        var lines: [String] = [columns.map(field).joined(separator: ",")]
+        lines.reserveCapacity(rows.count + 1)
+        for row in rows {
+            lines.append(columns.map { field(rawText(row[$0])) }.joined(separator: ","))
+        }
+        return lines.joined(separator: "\r\n")
+    }
+
+    static func rawText(_ value: JSONValue?) -> String {
+        guard let value else { return "" }
+        if case .null = value { return "" }
+        return value.displayText
+    }
+
+    static func field(_ text: String) -> String {
+        let needsQuoting = text.contains(",") || text.contains("\"")
+            || text.contains("\n") || text.contains("\r")
+        guard needsQuoting else { return text }
+        return "\"" + text.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
+}
+
+/// ShareLink 载荷：导出为 .csv 文件
+private nonisolated struct D1CSVDocument: Transferable {
+
+    let filename: String
+    let text: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .commaSeparatedText) { document in
+            // BOM：Excel 打开非 BOM 的 UTF-8 CSV 会把中文识别成乱码
+            Data([0xEF, 0xBB, 0xBF]) + Data(document.text.utf8)
+        }
+        .suggestedFileName { $0.filename }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1TableView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/D1TableView.swift
@@ -15,6 +15,7 @@ struct D1TableView: View {
 
     @Environment(AuthManager.self) private var auth
     @State private var viewModel: D1TableViewModel
+    @State private var indexVM: D1IndexListViewModel
     @State private var editingRow: [String: JSONValue]?
     @State private var showDenied = false
 
@@ -22,6 +23,12 @@ struct D1TableView: View {
         self.database = database
         self.tableName = tableName
         _viewModel = State(initialValue: D1TableViewModel(
+            service: session.d1Service,
+            accountId: session.selectedAccount?.id ?? "",
+            databaseId: database.uuid,
+            tableName: tableName
+        ))
+        _indexVM = State(initialValue: D1IndexListViewModel(
             service: session.d1Service,
             accountId: session.selectedAccount?.id ?? "",
             databaseId: database.uuid,
@@ -54,6 +61,8 @@ struct D1TableView: View {
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .padding(.horizontal, 4)
+
+                    indexCard
                 }
                 .padding()
             }
@@ -62,6 +71,7 @@ struct D1TableView: View {
         .navigationTitle(tableName)
         .navigationBarTitleDisplayMode(.inline)
         .task { await viewModel.load() }
+        .task { await indexVM.load() }
         .refreshable { await viewModel.load() }
         .sheet(item: .init(
             get: { editingRow.map { EditingRowBox(row: $0) } },
@@ -83,6 +93,48 @@ struct D1TableView: View {
             Text(viewModel.error ?? "")
         }
         .sensoryFeedback(.success, trigger: viewModel.didSave)
+    }
+
+    // MARK: - 索引卡（PRAGMA index_list，只读补充信息）
+
+    @ViewBuilder
+    private var indexCard: some View {
+        if indexVM.loaded && !indexVM.indexes.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("索引", systemImage: "list.bullet.indent")
+                    .font(.footnote.bold())
+                    .foregroundStyle(.secondary)
+                VStack(spacing: 6) {
+                    ForEach(indexVM.indexes) { index in
+                        indexRow(index)
+                        if index.id != indexVM.indexes.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+                .padding(OCLayout.islandPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .glassIsland(cornerRadius: OCLayout.chipRadius)
+            }
+        }
+    }
+
+    private func indexRow(_ index: D1IndexInfo) -> some View {
+        HStack(spacing: 8) {
+            Text(index.name)
+                .font(.caption.monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            if index.isUnique {
+                Text(verbatim: "UNIQUE")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Color.ocOrangeText)
+            }
+            Text(index.originLabel)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
     }
 
     // MARK: - 网格骨架（表头 + 数据行的占位条）

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerTailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerTailView.swift
@@ -7,11 +7,17 @@
 
 import SwiftUI
 import TipKit
+import UIKit
 
 struct WorkerTailView: View {
 
     @State private var viewModel: WorkerTailViewModel
+    /// 复制成功的触觉反馈触发器
+    @State private var copyTick = 0
+    /// 点击行后展示的详情（sheet 而非 push：日志流页面 push 会打断实时滚动）
+    @State private var detailLine: WorkerTailViewModel.LogLine?
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.colorScheme) private var colorScheme
 
     init(accountId: String, scriptName: String, session: SessionStore) {
         _viewModel = State(initialValue: WorkerTailViewModel(
@@ -23,9 +29,13 @@ struct WorkerTailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            statusBar
+            header
             Divider()
             logConsole
+        }
+        .sensoryFeedback(.success, trigger: copyTick)
+        .sheet(item: $detailLine) { line in
+            LogLineDetailSheet(line: line) { copy(line) }
         }
         .navigationTitle("实时日志")
         .navigationBarTitleDisplayMode(.inline)
@@ -35,7 +45,7 @@ struct WorkerTailView: View {
                     viewModel.isPaused ? String(localized: "继续") : String(localized: "暂停"),
                     systemImage: viewModel.isPaused ? "play.fill" : "pause.fill"
                 ) {
-                    viewModel.isPaused.toggle()
+                    viewModel.togglePause()
                 }
                 .safePopoverTip(TailPauseTip())
                 Button("清屏", systemImage: "xmark.bin") {
@@ -60,7 +70,18 @@ struct WorkerTailView: View {
         }
     }
 
-    // MARK: - 连接状态条
+    // MARK: - 顶部：连接状态 + 筛选
+
+    /// 状态条与筛选条共用一层材质背景（静态、不随列表滚动，不产生逐行模糊节点）
+    private var header: some View {
+        VStack(spacing: 8) {
+            statusBar
+            filterBar
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.regularMaterial)
+    }
 
     private var statusBar: some View {
         HStack(spacing: 8) {
@@ -81,14 +102,75 @@ struct WorkerTailView: View {
                 .tint(Color.ocOrange)
             }
             if viewModel.isPaused {
-                Label("已暂停", systemImage: "pause.fill")
+                // 暂停只冻结视图，事件仍在入 buffer；点一下即恢复并滚到底
+                Button {
+                    viewModel.togglePause()
+                } label: {
+                    Label(
+                        viewModel.pausedNewCount > 0
+                            ? String(localized: "已暂停 · 新增 \(viewModel.pausedNewCount) 条")
+                            : String(localized: "已暂停"),
+                        systemImage: "pause.fill"
+                    )
                     .font(.caption)
                     .foregroundStyle(Color.ocOrangeText)
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("恢复实时滚动")
             }
         }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-        .background(.regularMaterial)
+    }
+
+    // MARK: - 筛选条（普通 TextField，不用 .searchable）
+
+    private var filterBar: some View {
+        HStack(spacing: 8) {
+            searchField
+            levelMenu
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            TextField("搜索日志", text: $viewModel.searchText)
+                .font(.footnote)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.done)
+            if !viewModel.searchText.isEmpty {
+                Button {
+                    viewModel.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("清除搜索")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(OCGlass.fill(for: colorScheme), in: .rect(cornerRadius: 9))
+    }
+
+    private var levelMenu: some View {
+        Menu {
+            Picker("级别", selection: $viewModel.levelFilter) {
+                ForEach(WorkerTailViewModel.LevelFilter.allCases) { level in
+                    Text(level.title).tag(level)
+                }
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Label(viewModel.levelFilter.title, systemImage: "line.3.horizontal.decrease.circle")
+                .font(.footnote)
+                .foregroundStyle(viewModel.levelFilter == .all ? Color.secondary : Color.ocOrangeText)
+        }
+        .accessibilityLabel("按级别筛选")
     }
 
     private var statusColor: Color {
@@ -114,28 +196,56 @@ struct WorkerTailView: View {
     private var logConsole: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                if viewModel.lines.isEmpty {
-                    emptyHint
-                } else {
-                    LazyVStack(alignment: .leading, spacing: 4) {
-                        ForEach(viewModel.lines) { line in
-                            LogLineRow(line: line)
-                                .id(line.id)
-                        }
-                    }
-                    .padding(12)
-                    // 日志正文（时间戳 + 请求路径/JSON）始终 LTR，避免在阿拉伯语等 RTL 下被镜像
-                    .environment(\.layoutDirection, .leftToRight)
-                }
+                logContent
             }
             .background { SkyBackground() }
             .onChange(of: viewModel.lines.count) {
-                guard !viewModel.isPaused, let last = viewModel.lines.last else { return }
-                withAnimation(.easeOut(duration: 0.15)) {
-                    proxy.scrollTo(last.id, anchor: .bottom)
-                }
+                scrollToBottom(proxy)
+            }
+            // 恢复时补一次滚动：暂停期间新行已入 buffer，但 count 不再变化时不会触发上面那条
+            .onChange(of: viewModel.isPaused) {
+                scrollToBottom(proxy)
             }
         }
+    }
+
+    @ViewBuilder
+    private var logContent: some View {
+        if viewModel.lines.isEmpty {
+            emptyHint
+        } else if viewModel.visibleLines.isEmpty {
+            noMatchHint
+        } else {
+            logList
+        }
+    }
+
+    private var logList: some View {
+        LazyVStack(alignment: .leading, spacing: 4) {
+            ForEach(viewModel.visibleLines) { line in
+                LogLineRow(
+                    line: line,
+                    onCopy: { copy(line) },
+                    onOpen: { detailLine = line }
+                )
+                .id(line.id)
+            }
+        }
+        .padding(12)
+        // 日志正文（时间戳 + 请求路径/JSON）始终 LTR，避免在阿拉伯语等 RTL 下被镜像
+        .environment(\.layoutDirection, .leftToRight)
+    }
+
+    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+        guard !viewModel.isPaused, let last = viewModel.visibleLines.last else { return }
+        withAnimation(.easeOut(duration: 0.15)) {
+            proxy.scrollTo(last.id, anchor: .bottom)
+        }
+    }
+
+    private func copy(_ line: WorkerTailViewModel.LogLine) {
+        UIPasteboard.general.string = line.text
+        copyTick += 1
     }
 
     private var emptyHint: some View {
@@ -146,14 +256,47 @@ struct WorkerTailView: View {
         }
         .padding(.top, 60)
     }
+
+    /// 筛选后无结果：明确告知原始日志仍在，避免用户误以为丢了历史
+    private var noMatchHint: some View {
+        ContentUnavailableView {
+            Label("没有匹配的日志", systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text("换个关键词或级别再看看，已接收的日志不会丢失")
+        } actions: {
+            Button("清除筛选") {
+                viewModel.clearFilters()
+            }
+            .buttonStyle(.bordered)
+            .tint(Color.ocOrange)
+        }
+        .padding(.top, 60)
+    }
 }
 
 // MARK: - 单条日志行
 
 private struct LogLineRow: View {
     let line: WorkerTailViewModel.LogLine
+    /// 长按复制整行（不用行尾按钮：日志控制台每行挂按钮会淹没正文）
+    let onCopy: () -> Void
+    /// 点击展开详情（详情里才允许框选行内片段）
+    let onOpen: () -> Void
 
     var body: some View {
+        // 用 Button 承载点击、contextMenu 挂在 Button 上：
+        // 系统按钮自带长按/点击的手势仲裁，两者可稳定共存（自绘 onTapGesture + contextMenu 会互相吞手势）
+        Button(action: onOpen) {
+            rowContent
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("复制此行", systemImage: "doc.on.doc", action: onCopy)
+        }
+        .accessibilityHint(Text("轻点查看详情，长按复制整行"))
+    }
+
+    private var rowContent: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(line.timestamp, format: .dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits).second(.twoDigits))
                 .font(.caption2.monospaced())
@@ -161,19 +304,191 @@ private struct LogLineRow: View {
 
             Text(line.text)
                 .font(.caption.monospaced())
-                .foregroundStyle(levelColor)
-                .textSelection(.enabled)
+                .foregroundStyle(LogLevelStyle.color(for: line.level))
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 1)
+        .contentShape(Rectangle())
     }
+}
 
-    private var levelColor: Color {
-        switch line.level {
+// MARK: - 级别配色
+
+private enum LogLevelStyle {
+    static func color(for level: String) -> Color {
+        switch level {
         case "error", "exception": .red
         case "warn":               .orange
         case "event":              .secondary
         default:                   .primary
         }
+    }
+}
+
+// MARK: - 日志详情（可框选）
+
+/// 把一行日志按已有字段拆成分区；不改 VM 数据结构，仅在展示层解析 event / exception 的既定拼接格式。
+private nonisolated struct LogLineDetail {
+    let timestamp: Date
+    let level: String
+    let text: String
+    /// 请求方法（event 行）
+    var method: String?
+    var url: String?
+    var outcome: String?
+    var cron: String?
+    /// 异常名（exception 行）
+    var exceptionName: String?
+
+    init(_ line: WorkerTailViewModel.LogLine) {
+        timestamp = line.timestamp
+        level = line.level
+        text = line.text
+
+        if line.level == "event" {
+            // 生成端格式："METHOD URL → outcome" 或 "cron EXPR → outcome"
+            let parts = line.text.components(separatedBy: " → ")
+            let head = parts.first ?? line.text
+            if parts.count > 1 { outcome = parts.dropFirst().joined(separator: " → ") }
+            if head.hasPrefix("cron ") {
+                cron = String(head.dropFirst("cron ".count))
+            } else {
+                let tokens = head.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+                if tokens.count == 2 {
+                    method = String(tokens[0])
+                    url = String(tokens[1])
+                }
+            }
+        } else if line.level == "exception" {
+            let parts = line.text.components(separatedBy: ": ")
+            if parts.count > 1 { exceptionName = parts[0] }
+        }
+    }
+}
+
+private struct LogLineDetailSheet: View {
+    let line: WorkerTailViewModel.LogLine
+    let onCopy: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var detail: LogLineDetail { LogLineDetail(line) }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    metaSection
+                    structuredSection
+                    bodySection
+                }
+                .padding(16)
+            }
+            .background { SkyBackground() }
+            .navigationTitle("日志详情")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("完成") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("复制全部", systemImage: "doc.on.doc", action: onCopy)
+                        .tint(Color.ocOrange)
+                }
+            }
+        }
+    }
+
+    // MARK: 分区
+
+    @ViewBuilder
+    private var metaSection: some View {
+        island {
+            fieldRow(title: Text("级别"), value: detail.level, monospaced: true, tint: LogLevelStyle.color(for: detail.level))
+            Divider().opacity(0.4)
+            fieldRow(
+                title: Text("时间"),
+                value: detail.timestamp.formatted(date: .abbreviated, time: .standard),
+                monospaced: true,
+                tint: .secondary
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var structuredSection: some View {
+        if detail.method != nil || detail.cron != nil || detail.exceptionName != nil {
+            island {
+                if let method = detail.method {
+                    fieldRow(title: Text("请求方法"), value: method, monospaced: true, tint: .primary)
+                }
+                if let url = detail.url {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("请求地址"), value: url, monospaced: true, tint: .primary)
+                }
+                if let cron = detail.cron {
+                    fieldRow(title: Text("定时表达式"), value: cron, monospaced: true, tint: .primary)
+                }
+                if let outcome = detail.outcome {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("结果"), value: outcome, monospaced: true, tint: .secondary)
+                }
+                if let name = detail.exceptionName {
+                    fieldRow(title: Text("异常"), value: name, monospaced: true, tint: .red)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var bodySection: some View {
+        island {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("完整内容")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(detail.text)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(LogLevelStyle.color(for: detail.level))
+                    .textSelection(.enabled)   // 详情态才开框选：列表行开了会吞掉长按手势
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    // 日志正文（URL / JSON）恒定 LTR，避免 RTL 语言下被镜像
+                    .environment(\.layoutDirection, .leftToRight)
+                Text("长按可选中其中的片段单独复制")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    // MARK: 组件
+
+    @ViewBuilder
+    private func fieldRow(title: Text, value: String, monospaced: Bool, tint: Color) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            title
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+            Text(value)
+                .font(monospaced ? .footnote.monospaced() : .footnote)
+                .foregroundStyle(tint)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .environment(\.layoutDirection, .leftToRight)
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// 玻璃岛：用 OCGlass 纯色近似，不使用真材质（backdrop blur 会掉帧）
+    @ViewBuilder
+    private func island<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(OCGlass.fill(for: colorScheme), in: .rect(cornerRadius: 16))
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
@@ -44,6 +44,13 @@ struct ZoneDetailView: View {
         ))
     }
 
+    /// 跨资源类型的置顶存储（域名的固定状态以它为准，CachedZone.pinned 仅作镜像）
+    private let pinnedStore = PinnedResourceStore.shared
+
+    private var isPinned: Bool {
+        pinnedStore.isPinned(PinnedResource(type: .zone, resourceId: zone.id), accountId: zone.accountId)
+    }
+
     private var canReadSettings: Bool { auth.hasScope("zone-settings.read") }
     private var canEditSettings: Bool { auth.hasScope("zone-settings.write") }
     private var canPurge: Bool { auth.hasScope("cache.purge") }
@@ -289,10 +296,16 @@ struct ZoneDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(zone.pinned ? String(localized: "取消固定") : String(localized: "固定到首页"),
-                       systemImage: zone.pinned ? "pin.fill" : "pin") {
+                // 置顶以 PinnedResourceStore 为准（跨资源类型统一）；同时把旧的
+                // CachedZone.pinned 字段镜像写回，老数据/其它入口读它时不至于分裂。
+                Button(isPinned ? String(localized: "取消固定") : String(localized: "固定到首页"),
+                       systemImage: isPinned ? "pin.fill" : "pin") {
+                    let nowPinned = pinnedStore.toggle(
+                        PinnedResource(type: .zone, resourceId: zone.id),
+                        accountId: zone.accountId
+                    )
                     withAnimation(.smooth) {
-                        zone.pinned.toggle()
+                        zone.pinned = nowPinned
                     }
                     SafeCache.perform("pin 状态保存") { try modelContext.save() }
                 }


### PR DESCRIPTION
本版新增五项功能，另修一处实时日志的既有缺陷。版本号 **1.9.0 build 35**（`MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` 各 12 处已同步）。

### 新功能
- **概览页命令搜索与跨资源置顶**：一处搜遍域名 / Worker / R2 / D1 / KV / 隧道，点击直达；任意资源可星标固定。置顶只持久化 `type+id`（资源改名不失效），按 `accountId` 分键隔离多账号。免费层同样可搜，点 Pro 资源时走付费墙。
- **告警中心**：汇总未启用域名、异常隧道等需要注意的资源，点击直达。
- **Worker 实时日志**：关键词搜索 + 级别筛选 + 长按复制整行 + 点击查看行详情（详情态可框选复制片段）。全量 buffer 不因筛选丢历史。
- **D1**：查询历史（12 条）与 SQL 收藏（20 条）按数据库分别落盘、结果导出 CSV（RFC 4180 转义 + UTF-8 BOM）、表详情新增索引查看（`PRAGMA index_list`）。
- **Workers AI**：模型试运行支持文生图，兼容二进制与 base64 信封两种返回形态。

### 修复
- 实时日志的「暂停」原会**丢弃**暂停期间的事件，现改为只冻结画面、日志照常入 buffer，并提示暂停期间新增条数。

### 非功能改动
- `BackgroundRefresh` 注册改为幂等 + 记录注册成败 + weak 持有 `AuthManager`，便于排查「后台刷新为何不跑」。
- `AIModel` 的类型判定与文生图请求/响应模型从 Service 归位到模型层，Service 回归纯服务。

### 验证状态
- ✅ `xcodebuild -scheme "Orange Cloud"` 通过，无 error、无版本不匹配 warning
- ✅ `Localizable.xcstrings` 新增 58 key × 13 语，占位符本次零新增不一致
- ⚠️ **尚未真机验证**。最高危：命令搜索的 sheet → 栈根路由派发（已按值式路由 + `.navigationDestination` 只挂栈根实现，但需 iOS 17.0 真机确认）；其次为文生图对非 flux 模型的返回形态。