### PR TITLE
chore(changelog): iOS 1.9.1 发布说明

### DIFF
--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,7 +1,7 @@
 [
   {
-    "version": "1.9.0",
-    "date": "2026.07.20",
+    "version": "1.9.1",
+    "date": "2026.07.22",
     "channel": "App Store",
     "inApp": true,
     "items": [


### PR DESCRIPTION
## 内容 / What

单一数据源 changelog：将从未上架的 `1.9.0` 条目并入 **1.9.1**（日期 2026.07.22）。线上仍是 1.8.7，1.9.0 的 5 项功能才是 1.8.7 用户实际获得的内容。

Folds the never-shipped `1.9.0` entry into **1.9.1** in the single-source changelog. The live store is still 1.8.7, so 1.9.0's five features are what 1.8.7 users actually receive.

- 全局搜索 / Search everything
- 告警中心 / Alert center
- 实时日志增强 / Better live logs
- SQL 历史与收藏 / SQL history & favorites
- Workers AI 文生图 / Workers AI text-to-image

## 说明 / Notes

- **先合此 PR**（infra），iOS 版本分支 `release/ios-1.9.1` 随后。路径互斥，仅动 `packages/changelog/ios.json`。
- Merge this **infra PR first**; `release/ios-1.9.1` follows. Path-exclusive — only `packages/changelog/ios.json` changes.
- 生成物同步已跑 `pnpm changelog:gen && changelog:check`（App 端生成物在 iOS 分支）。
- 评分邀请为内部机制，不进发布说明。
- 官网更新历史据此展示；送审后 ASC webhook 翻牌。