### PR TITLE
feat(ios): 1.9.1（build 36）评分邀请 + 版本号

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/ContentView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ContentView.swift
@@ -56,6 +56,7 @@ private struct SessionRootView: View {
             .environment(session)
             .whatsNewSheet()
             .telemetryConsentPrompt()
+            .ratingPrompt()
     }
 }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Rating/RatingPrompt.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Rating/RatingPrompt.swift
@@ -1,0 +1,37 @@
+//
+//  RatingPrompt.swift
+//  Orange Cloud
+//
+//  应用内评分邀请的参与度门控与节流（系统 SKStoreReviewController 自身另有年度限频，
+//  可能静默不弹）。策略：只把「已登录启动」计为参与度信号；达到阈值后，每个版本最多
+//  主动邀请一次。设置「关于」页仍保留用户可手动触发的评分入口，二者互不影响。
+//
+
+import Foundation
+
+nonisolated enum RatingPrompt {
+
+    private static let engagedLaunchesKey   = "ratingEngagedLaunches"
+    private static let lastPromptVersionKey = "ratingLastPromptVersion"
+
+    /// 触发主动邀请所需的最小「已登录启动」次数
+    private static let minEngagedLaunches = 3
+
+    /// App 启动且此次为已登录态时 +1（在 App.init 调用）。
+    static func registerEngagedLaunch() {
+        let d = UserDefaults.standard
+        d.set(d.integer(forKey: engagedLaunchesKey) + 1, forKey: engagedLaunchesKey)
+    }
+
+    /// 是否满足主动邀请评分：达到最小启动次数，且当前版本尚未邀请过。
+    static var shouldRequest: Bool {
+        let d = UserDefaults.standard
+        guard d.integer(forKey: engagedLaunchesKey) >= minEngagedLaunches else { return false }
+        return d.string(forKey: lastPromptVersionKey) != WhatsNewStore.currentVersion
+    }
+
+    /// 记录已在当前版本邀请过（每个版本最多主动邀请一次）。
+    static func markRequested() {
+        UserDefaults.standard.set(WhatsNewStore.currentVersion, forKey: lastPromptVersionKey)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,7 +10,7 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
-        WhatsNewRelease(version: "1.9.0", items: [
+        WhatsNewRelease(version: "1.9.1", items: [
             WhatsNewItem(
                 icon:   "magnifyingglass",
                 title:  String(localized: "一处搜遍所有资源", table: "WhatsNew"),

--- a/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
@@ -39,6 +39,8 @@ struct Orange_CloudApp: App {
         // 串行预热缓存库实体解析（iOS 17.x 冷启动首次并发 fetch 竞态，Sentry APPLE-IOS-Y）
         CacheContainer.warmUp()
         WhatsNewGate.wasLoggedInAtLaunch = manager.isLoggedIn
+        // 参与度信号：只把「已登录启动」计入，用于稍后主动邀请评分（每版本至多一次）
+        if manager.isLoggedIn { RatingPrompt.registerEngagedLaunch() }
         BackgroundRefresh.setAuthManager(manager)
         // iOS 26 连续后台任务（R2 大对象 copy/move 续传），须在启动时注册处理器
         if #available(iOS 26.0, *) {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Rating/RatingPromptModifier.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Rating/RatingPromptModifier.swift
@@ -1,0 +1,32 @@
+//
+//  RatingPromptModifier.swift
+//  Orange Cloud
+//
+//  登录后的会话根视图挂载：满足参与度与版本门控时，主动拉起系统评分邀请。
+//  与 What's New / 体验者计划错峰（同一启动只出一个打扰），排在最后、优先级最低。
+//
+
+import SwiftUI
+import StoreKit
+
+struct RatingPromptModifier: ViewModifier {
+
+    @Environment(\.requestReview) private var requestReview
+
+    func body(content: Content) -> some View {
+        content.task {
+            guard RatingPrompt.shouldRequest else { return }
+            // 让 What's New / 体验者计划先完成评估/呈现；主界面稳定后再邀请
+            try? await Task.sleep(for: .seconds(4))
+            guard !WhatsNewGate.presentedThisLaunch else { return }
+            WhatsNewGate.presentedThisLaunch = true   // 占住本次启动的唯一打扰位
+            RatingPrompt.markRequested()
+            requestReview()
+        }
+    }
+}
+
+extension View {
+    /// 应用内评分邀请门控（挂在登录后的会话根视图，排在其它一次性弹窗之后）
+    func ratingPrompt() -> some View { modifier(RatingPromptModifier()) }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/WhatsNew/WhatsNewView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/WhatsNew/WhatsNewView.swift
@@ -144,6 +144,7 @@ struct TelemetryConsentModifier: ViewModifier {
                 try? await Task.sleep(for: .seconds(2))
                 guard !WhatsNewGate.presentedThisLaunch,
                       telemetry.consent == .unasked else { return }
+                WhatsNewGate.presentedThisLaunch = true   // 占位：评分邀请等打扰本次让路
                 showAsk = true
             }
             .alert("加入体验者计划？", isPresented: $showAsk) {


### PR DESCRIPTION
## 内容 / What

- **应用内评分邀请**：满 3 次「已登录启动」后主动拉起系统评分面板，每版本至多一次；与「新功能」/体验者计划错峰（同一启动只出一个打扰），排在最后、优先级最低。设置「关于」页原有手动评分入口保留。
  In-app rating invitation: after 3 signed-in launches it triggers the system review sheet, at most once per version; yields to What's New / the tester program (one interruption per launch) and runs last. The manual entry in Settings › About stays.
- **版本号 / Version**：`MARKETING_VERSION` 1.9.0→1.9.1、`CURRENT_PROJECT_VERSION` 35→36（各 12 处）。
- 同步 WhatsNew 生成物（1.9.0 并入 1.9.1，源在 changelog 包 / #67）。

## 新增文件 / New files
- `Core/Rating/RatingPrompt.swift` — 参与度门控 store
- `Views/Rating/RatingPromptModifier.swift` — `.ratingPrompt()` 修饰器（挂会话根视图）

## 验证 / Verified
- `xcodebuild -scheme "Orange Cloud" build`（Xcode-beta）✅ 无 error、无版本不匹配 warning。
- 系统评分面板 OS 提供，无新增本地化文案。
- ASC 元数据（1.9.1 · 12 语 release notes）已由 `fastlane deliver` 推送并回读核对。

## 依赖 / Depends on
- 合入顺序：先合 #67（infra）再合本 PR。Merge #67 first, then this.
- 二进制构建 / 上传 / 送审由 Xcode Cloud 处理（本地不 archive、不 submit）。Binary build/upload/submit handled by Xcode Cloud.