### PR TITLE
feat(android): 1.7.1（versionCode 21）默认账号 + 账号菜单滚动修复

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         // 实况通知促升(API36) 均 if-guard 渐进增强，Android 8–11 落固定品牌调色板与常驻通知回退。
         minSdk = 26
         targetSdk = 36
-        versionCode = 20
-        versionName = "1.7.0"
+        versionCode = 21
+        versionName = "1.7.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/system/AppPrefs.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/system/AppPrefs.kt
@@ -73,6 +73,22 @@ class AppPrefs @Inject constructor(
         dataStore.edit { it[KEY_NOTIF_WORKER] = enabled }
     }
 
+    /**
+     * 某个登录身份下默认进入的 Cloudflare 账号（按身份分键）。
+     * 用户切一次账号就记住它，下次冷启动直接进这个账号而不是列表第一个（issue #71）。
+     */
+    suspend fun defaultAccountId(sessionId: String): String? {
+        if (sessionId.isEmpty()) return null
+        return dataStore.data.first()[defaultAccountKey(sessionId)]?.takeIf { it.isNotEmpty() }
+    }
+
+    suspend fun setDefaultAccountId(sessionId: String, accountId: String) {
+        if (sessionId.isEmpty() || accountId.isEmpty()) return
+        dataStore.edit { it[defaultAccountKey(sessionId)] = accountId }
+    }
+
+    private fun defaultAccountKey(sessionId: String) = stringPreferencesKey("pref_default_account_$sessionId")
+
     /** 某个资源列表的排序偏好（key 如 "workers" / "pages"）。 */
     fun listSort(key: String): Flow<ResourceSort> =
         dataStore.data.map { ResourceSort.from(it[intPreferencesKey("pref_sort_$key")] ?: 0) }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/core/whatsnew/WhatsNewReleases.generated.kt
@@ -5,6 +5,13 @@ import jiamin.chen.orangecloud.R
 // ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。
 internal val whatsNewReleases: List<WhatsNewRelease> = listOf(
     WhatsNewRelease(
+        version = "1.7.1",
+        items = listOf(
+            WhatsNewItem(R.string.whatsnew_1_7_1_0_title, R.string.whatsnew_1_7_1_0_detail),
+            WhatsNewItem(R.string.whatsnew_1_7_1_1_title, R.string.whatsnew_1_7_1_1_detail),
+        ),
+    ),
+    WhatsNewRelease(
         version = "1.7.0",
         items = listOf(
             WhatsNewItem(R.string.whatsnew_1_7_0_0_title, R.string.whatsnew_1_7_0_0_detail),

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/AccountStore.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/data/repository/AccountStore.kt
@@ -2,6 +2,7 @@ package jiamin.chen.orangecloud.data.repository
 
 import jiamin.chen.orangecloud.core.auth.AuthRepository
 import jiamin.chen.orangecloud.core.di.ApplicationScope
+import jiamin.chen.orangecloud.core.system.AppPrefs
 import jiamin.chen.orangecloud.data.model.Account
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,8 +26,9 @@ import javax.inject.Singleton
 @Singleton
 class AccountStore @Inject constructor(
     private val accountRepository: AccountRepository,
-    authRepository: AuthRepository,
-    @ApplicationScope externalScope: CoroutineScope,
+    private val authRepository: AuthRepository,
+    private val appPrefs: AppPrefs,
+    @ApplicationScope private val externalScope: CoroutineScope,
 ) {
     private val _accounts = MutableStateFlow<List<Account>>(emptyList())
     val accounts: StateFlow<List<Account>> = _accounts.asStateFlow()
@@ -82,14 +84,22 @@ class AccountStore @Inject constructor(
     fun select(accountId: String) {
         if (_accounts.value.any { it.id == accountId }) {
             _selectedAccountId.value = accountId
+            // 记住这个身份的默认账号，下次冷启动直接进它（issue #71）
+            val sessionId = authRepository.state.value.currentSessionId
+            if (sessionId != null) {
+                externalScope.launch { appPrefs.setDefaultAccountId(sessionId, accountId) }
+            }
         }
     }
 
-    private fun applyAccounts(list: List<Account>) {
+    private suspend fun applyAccounts(list: List<Account>) {
         _accounts.value = list
         val current = _selectedAccountId.value
         if (current == null || list.none { it.id == current }) {
-            _selectedAccountId.value = list.firstOrNull()?.id
+            // 优先用用户上次选定的默认账号，落空（首次登录 / 账号已被移除）才回退列表第一个
+            val sessionId = authRepository.state.value.currentSessionId
+            val preferred = sessionId?.let { id -> appPrefs.defaultAccountId(id) }
+            _selectedAccountId.value = list.firstOrNull { it.id == preferred }?.id ?: list.firstOrNull()?.id
         }
         loaded = list.isNotEmpty()
     }

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/dashboard/DashboardScreen.kt
@@ -304,47 +304,56 @@ private fun AccountMenu(
             shadowElevation = 6.dp,
             modifier = Modifier
                 .align(Alignment.TopEnd)
-                .padding(top = 96.dp, end = 12.dp)
-                .width(264.dp),
+                // bottom padding 把菜单高度封在屏幕内——否则账号一多就被底部裁掉（issue #71）
+                .padding(top = 96.dp, end = 12.dp, bottom = 24.dp)
+                .width(276.dp),
         ) {
             Column(Modifier.padding(8.dp)) {
-                if (sessions.size > 1) {
+                // 身份 + 账号列表内滚动（高度已被上面的 padding 封顶），
+                // 「添加账号」留在滚动区外固定在底部，账号再多也点得到
+                Column(
+                    Modifier
+                        .weight(1f, fill = false)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    if (sessions.size > 1) {
+                        Text(
+                            stringResource(R.string.dash_switch_identity),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = cs.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 12.dp, top = 8.dp, bottom = 6.dp),
+                        )
+                        sessions.forEach { session ->
+                            Row(
+                                Modifier.fillMaxWidth().clickable { onPickSession(session.id) }.padding(10.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                ZoneAvatar(session.label, size = 38.dp)
+                                Spacer(Modifier.width(12.dp))
+                                Text(session.label, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = cs.onSurface, maxLines = 2, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                                if (session.id == currentSessionId) Icon(Icons.Outlined.Check, contentDescription = null, tint = cs.primary, modifier = Modifier.size(18.dp))
+                            }
+                        }
+                        Box(Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp).height(1.dp).background(cs.outlineVariant))
+                    }
                     Text(
-                        stringResource(R.string.dash_switch_identity),
+                        stringResource(R.string.dash_switch_account),
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Medium,
                         color = cs.onSurfaceVariant,
                         modifier = Modifier.padding(start = 12.dp, top = 8.dp, bottom = 6.dp),
                     )
-                    sessions.forEach { session ->
+                    accounts.forEach { account ->
                         Row(
-                            Modifier.fillMaxWidth().clickable { onPickSession(session.id) }.padding(10.dp),
+                            Modifier.fillMaxWidth().clickable { onPick(account.id) }.padding(10.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            ZoneAvatar(session.label, size = 38.dp)
+                            ZoneAvatar(account.name, size = 38.dp)
                             Spacer(Modifier.width(12.dp))
-                            Text(session.label, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = cs.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
-                            if (session.id == currentSessionId) Icon(Icons.Outlined.Check, contentDescription = null, tint = cs.primary, modifier = Modifier.size(18.dp))
+                            Text(account.name, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = cs.onSurface, maxLines = 2, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                            if (account.id == currentId) Icon(Icons.Outlined.Check, contentDescription = null, tint = cs.primary, modifier = Modifier.size(18.dp))
                         }
-                    }
-                    Box(Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp).height(1.dp).background(cs.outlineVariant))
-                }
-                Text(
-                    stringResource(R.string.dash_switch_account),
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = cs.onSurfaceVariant,
-                    modifier = Modifier.padding(start = 12.dp, top = 8.dp, bottom = 6.dp),
-                )
-                accounts.forEach { account ->
-                    Row(
-                        Modifier.fillMaxWidth().clickable { onPick(account.id) }.padding(10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        ZoneAvatar(account.name, size = 38.dp)
-                        Spacer(Modifier.width(12.dp))
-                        Text(account.name, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = cs.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
-                        if (account.id == currentId) Icon(Icons.Outlined.Check, contentDescription = null, tint = cs.primary, modifier = Modifier.size(18.dp))
                     }
                 }
                 Box(Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp).height(1.dp).background(cs.outlineVariant))

--- a/apps/android/app/src/main/res/values-ar/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ar/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">يتذكّر حسابك الافتراضي</string>
+    <string name="whatsnew_1_7_1_0_detail">عند وجود أكثر من حساب Cloudflare، يتذكّر التطبيق الحساب الذي اخترته آخر مرة ويفتح عليه مباشرة بدلاً من العودة دائمًا إلى أول حساب في القائمة.</string>
+    <string name="whatsnew_1_7_1_1_title">إصلاحات قائمة تبديل الحسابات</string>
+    <string name="whatsnew_1_7_1_1_detail">عند وجود حسابات كثيرة، يمكن الآن تمرير القائمة لأعلى وأسفل لعرض جميع الحسابات، ولم يعد زر «إضافة حساب» يُدفع خارج الشاشة.</string>
     <string name="whatsnew_1_7_0_0_title">ابحث في كل شيء من مكان واحد</string>
     <string name="whatsnew_1_7_0_0_detail">تبحث العدسة في صفحة النظرة العامة دفعة واحدة في النطاقات وWorkers وحاويات R2 وقواعد بيانات D1 ومساحات أسماء KV والأنفاق، وانقر على النتيجة للانتقال مباشرة. ويمكن الآن تثبيت أي مورد في الصفحة بنجمة.</string>
     <string name="whatsnew_1_7_0_1_title">مركز التنبيهات</string>

--- a/apps/android/app/src/main/res/values-de/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-de/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Merkt sich dein Standardkonto</string>
+    <string name="whatsnew_1_7_1_0_detail">Bei mehreren Cloudflare-Konten merkt sich die App das zuletzt gewählte Konto und startet direkt damit – statt immer auf das erste Konto der Liste zurückzufallen.</string>
+    <string name="whatsnew_1_7_1_1_title">Korrekturen am Kontowechsel-Menü</string>
+    <string name="whatsnew_1_7_1_1_detail">Bei vielen Konten lässt sich das Menü jetzt scrollen und zeigt alle Konten; „Konto hinzufügen“ wird nicht mehr aus dem Bild geschoben.</string>
     <string name="whatsnew_1_7_0_0_title">Alles an einer Stelle suchen</string>
     <string name="whatsnew_1_7_0_0_detail">Über die Lupe in der Übersicht durchsuchst du Domains, Workers, R2-Buckets, D1-Datenbanken, KV-Namespaces und Tunnel auf einmal – ein Tippen führt direkt hin. Und jede Ressource lässt sich per Stern an die Übersicht heften.</string>
     <string name="whatsnew_1_7_0_1_title">Warnungszentrale</string>

--- a/apps/android/app/src/main/res/values-en/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-en/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Remembers your default account</string>
+    <string name="whatsnew_1_7_1_0_detail">With more than one Cloudflare account, the app now remembers the one you picked last and opens straight into it, instead of always falling back to the first in the list.</string>
+    <string name="whatsnew_1_7_1_1_title">Account switcher fixes</string>
+    <string name="whatsnew_1_7_1_1_detail">With a long list of accounts, the switcher now scrolls and shows every account, and “Add account” stays pinned at the bottom instead of being pushed off screen.</string>
     <string name="whatsnew_1_7_0_0_title">Search everything from one place</string>
     <string name="whatsnew_1_7_0_0_detail">The magnifier on the overview searches domains, Workers, R2 buckets, D1 databases, KV namespaces and tunnels at once — tap a result to go straight there. And any resource can now be starred to the overview.</string>
     <string name="whatsnew_1_7_0_1_title">Alert center</string>

--- a/apps/android/app/src/main/res/values-es/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-es/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Recuerda tu cuenta predeterminada</string>
+    <string name="whatsnew_1_7_1_0_detail">Si tienes varias cuentas de Cloudflare, la app recuerda la última que elegiste y abre directamente en ella, en lugar de volver siempre a la primera de la lista.</string>
+    <string name="whatsnew_1_7_1_1_title">Correcciones en el menú de cuentas</string>
+    <string name="whatsnew_1_7_1_1_detail">Cuando tienes muchas cuentas, el menú ahora se desplaza y muestra todas, y «Agregar cuenta» ya no queda fuera de la pantalla.</string>
     <string name="whatsnew_1_7_0_0_title">Busca todo desde un solo lugar</string>
     <string name="whatsnew_1_7_0_0_detail">La lupa de la pantalla de resumen busca a la vez dominios, Workers, buckets R2, bases de datos D1, espacios de nombres KV y túneles; toca un resultado para ir directo. Además, ahora puedes fijar cualquier recurso al resumen con una estrella.</string>
     <string name="whatsnew_1_7_0_1_title">Centro de alertas</string>

--- a/apps/android/app/src/main/res/values-fr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-fr/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Retient votre compte par défaut</string>
+    <string name="whatsnew_1_7_1_0_detail">Avec plusieurs comptes Cloudflare, l’app retient celui que vous avez choisi en dernier et s’ouvre directement dessus, au lieu de revenir toujours au premier de la liste.</string>
+    <string name="whatsnew_1_7_1_1_title">Corrections du menu des comptes</string>
+    <string name="whatsnew_1_7_1_1_detail">Avec de nombreux comptes, le menu défile désormais et affiche tous les comptes ; « Ajouter un compte » n’est plus repoussé hors de l’écran.</string>
     <string name="whatsnew_1_7_0_0_title">Tout chercher au même endroit</string>
     <string name="whatsnew_1_7_0_0_detail">La loupe de l’aperçu recherche d’un coup les domaines, Workers, buckets R2, bases D1, espaces de noms KV et tunnels : touchez un résultat pour y aller. Et n’importe quelle ressource peut désormais être épinglée à l’aperçu.</string>
     <string name="whatsnew_1_7_0_1_title">Centre d’alertes</string>

--- a/apps/android/app/src/main/res/values-ja/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ja/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">既定のアカウントを記憶</string>
+    <string name="whatsnew_1_7_1_0_detail">Cloudflare アカウントが複数ある場合、最後に選んだアカウントを記憶し、次に開いたときはそのアカウントで始まります。常に一覧の先頭に戻ることはありません。</string>
+    <string name="whatsnew_1_7_1_1_title">アカウント切り替えメニューの修正</string>
+    <string name="whatsnew_1_7_1_1_detail">アカウントが多い場合でも、切り替えメニューを上下にスクロールしてすべてのアカウントを表示できるようになりました。「アカウントを追加」も画面外に押し出されません。</string>
     <string name="whatsnew_1_7_0_0_title">すべてのリソースをまとめて検索</string>
     <string name="whatsnew_1_7_0_0_detail">概要ページの虫めがねから、ドメイン・Worker・R2 バケット・D1 データベース・KV ネームスペース・トンネルをまとめて検索でき、タップですぐ移動できます。どのリソースもスターを付けて概要ページに固定できます。</string>
     <string name="whatsnew_1_7_0_1_title">アラートセンター</string>

--- a/apps/android/app/src/main/res/values-ko/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-ko/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">기본 계정을 기억합니다</string>
+    <string name="whatsnew_1_7_1_0_detail">Cloudflare 계정이 여러 개일 때 마지막으로 선택한 계정을 기억해, 다음에 열면 바로 그 계정으로 시작합니다. 더 이상 목록의 첫 번째 계정으로 돌아가지 않습니다.</string>
+    <string name="whatsnew_1_7_1_1_title">계정 전환 메뉴 수정</string>
+    <string name="whatsnew_1_7_1_1_detail">계정이 많아도 전환 메뉴를 위아래로 스크롤해 모든 계정을 볼 수 있고, ‘계정 추가’도 화면 밖으로 밀려나지 않습니다.</string>
     <string name="whatsnew_1_7_0_0_title">모든 리소스를 한 곳에서 검색</string>
     <string name="whatsnew_1_7_0_0_detail">개요 화면 상단의 돋보기로 도메인, Worker, R2 버킷, D1 데이터베이스, KV 네임스페이스, 터널을 한 번에 검색하고 바로 이동할 수 있습니다. 이제 어떤 리소스든 별표로 개요 화면에 고정할 수 있습니다.</string>
     <string name="whatsnew_1_7_0_1_title">알림 센터</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Lembra sua conta padrão</string>
+    <string name="whatsnew_1_7_1_0_detail">Com mais de uma conta Cloudflare, o app passa a lembrar a última que você escolheu e abre direto nela, em vez de sempre voltar para a primeira da lista.</string>
+    <string name="whatsnew_1_7_1_1_title">Correções no menu de contas</string>
+    <string name="whatsnew_1_7_1_1_detail">Com muitas contas, o menu agora rola e mostra todas elas, e “Adicionar conta” não fica mais fora da tela.</string>
     <string name="whatsnew_1_7_0_0_title">Busque tudo em um só lugar</string>
     <string name="whatsnew_1_7_0_0_detail">A lupa na tela de visão geral busca de uma vez domínios, Workers, buckets R2, bancos D1, namespaces KV e túneis — toque para ir direto. E agora dá para fixar qualquer recurso na visão geral com uma estrela.</string>
     <string name="whatsnew_1_7_0_1_title">Central de alertas</string>

--- a/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-pt-rPT/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Memoriza a sua conta predefinida</string>
+    <string name="whatsnew_1_7_1_0_detail">Com mais do que uma conta Cloudflare, a app passa a memorizar a última que escolheu e abre diretamente nela, em vez de voltar sempre à primeira da lista.</string>
+    <string name="whatsnew_1_7_1_1_title">Correções no menu de contas</string>
+    <string name="whatsnew_1_7_1_1_detail">Com muitas contas, o menu agora desloca-se e mostra todas, e “Adicionar conta” já não fica fora do ecrã.</string>
     <string name="whatsnew_1_7_0_0_title">Pesquise tudo num só lugar</string>
     <string name="whatsnew_1_7_0_0_detail">A lupa no ecrã de descrição geral pesquisa de uma vez domínios, Workers, buckets R2, bases de dados D1, namespaces KV e túneis — toque para ir direto. E agora pode fixar qualquer recurso com uma estrela.</string>
     <string name="whatsnew_1_7_0_1_title">Centro de alertas</string>

--- a/apps/android/app/src/main/res/values-tr/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-tr/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">Varsayılan hesabınızı hatırlar</string>
+    <string name="whatsnew_1_7_1_0_detail">Birden fazla Cloudflare hesabı varsa uygulama en son seçtiğiniz hesabı hatırlar ve doğrudan onunla açılır; artık her seferinde listedeki ilk hesaba dönmez.</string>
+    <string name="whatsnew_1_7_1_1_title">Hesap değiştirme menüsü düzeltmeleri</string>
+    <string name="whatsnew_1_7_1_1_detail">Çok sayıda hesap olduğunda menü artık kaydırılabiliyor ve tüm hesapları gösteriyor; “Hesap ekle” de ekranın dışına itilmiyor.</string>
     <string name="whatsnew_1_7_0_0_title">Her şeyi tek yerden arayın</string>
     <string name="whatsnew_1_7_0_0_detail">Genel bakıştaki büyüteç; alan adlarını, Worker’ları, R2 bucket’larını, D1 veritabanlarını, KV ad alanlarını ve tünelleri tek seferde arar, dokununca doğrudan açar. Artık her kaynağı yıldızlayıp genel bakışa sabitleyebilirsiniz.</string>
     <string name="whatsnew_1_7_0_1_title">Uyarı merkezi</string>

--- a/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rHK/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">記住你的預設帳戶</string>
+    <string name="whatsnew_1_7_1_0_detail">有多個 Cloudflare 帳戶時，App 會記住你上次選的那一個，下次打開直接進入它，不再固定回到列表裡的第一個。</string>
+    <string name="whatsnew_1_7_1_1_title">修正帳戶切換菜單</string>
+    <string name="whatsnew_1_7_1_1_detail">帳戶較多時，切換菜單現在可以上下滑動並完整顯示所有帳戶，「新增帳戶」也不會再被擠出畫面。</string>
     <string name="whatsnew_1_7_0_0_title">一處搜遍所有資源</string>
     <string name="whatsnew_1_7_0_0_detail">概覽頁頂部的放大鏡可一次搜尋域名、Worker、R2 儲存桶、D1 資料庫、KV 命名空間與隧道，點一下直達；任何資源都可以加星固定到概覽頁。</string>
     <string name="whatsnew_1_7_0_1_title">告警中心</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">記住你的預設帳戶</string>
+    <string name="whatsnew_1_7_1_0_detail">有多個 Cloudflare 帳戶時，App 會記住你上次選的那一個，下次打開直接進入它，不再固定回到清單裡的第一個。</string>
+    <string name="whatsnew_1_7_1_1_title">修正帳戶切換選單</string>
+    <string name="whatsnew_1_7_1_1_detail">帳戶較多時，切換選單現在可以上下滑動並完整顯示所有帳戶，「新增帳戶」也不會再被擠出畫面。</string>
     <string name="whatsnew_1_7_0_0_title">一處搜遍所有資源</string>
     <string name="whatsnew_1_7_0_0_detail">總覽頁頂端的放大鏡可一次搜尋網域、Worker、R2 儲存桶、D1 資料庫、KV 命名空間與通道，點一下直達；任何資源都能加上星號固定到總覽頁。</string>
     <string name="whatsnew_1_7_0_1_title">告警中心</string>

--- a/apps/android/app/src/main/res/values/whatsnew.xml
+++ b/apps/android/app/src/main/res/values/whatsnew.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/android.json 后运行 `pnpm changelog:gen`。 -->
 <resources>
+    <string name="whatsnew_1_7_1_0_title">记住你的默认账号</string>
+    <string name="whatsnew_1_7_1_0_detail">有多个 Cloudflare 账号时，App 会记住你上次选中的那一个，下次打开直接进入它，不再固定回到列表里的第一个。</string>
+    <string name="whatsnew_1_7_1_1_title">修复账号切换菜单</string>
+    <string name="whatsnew_1_7_1_1_detail">账号较多时，切换菜单现在可以上下滑动并完整显示所有账号，「添加账号」也不会再被挤出屏幕。</string>
     <string name="whatsnew_1_7_0_0_title">一处搜遍所有资源</string>
     <string name="whatsnew_1_7_0_0_detail">概览页顶栏的放大镜可一次搜索域名、Worker、R2 存储桶、D1 数据库、KV 命名空间与隧道，点一下直达；任意资源都能星标固定到概览页。</string>
     <string name="whatsnew_1_7_0_1_title">告警中心</string>


### PR DESCRIPTION
修 issue #71（截图机型 HUAWEI BLA-AL00，即 Android 版）。路径只含 `apps/android/`，changelog 源在 #72。

## 修复：账号切换菜单不能滑、显示不全
根因是 `AccountMenu` 的内容是一个**无滚动、无高度上限的 `Column`**（`Box` + `align(TopEnd)` + `padding(top=96dp)`），账号一多就被内容区底部裁掉，连「添加账号」一起被切。

- 菜单加 `bottom = 24.dp`，把高度封在内容区内（父 `Box` 有界，滚动才生效）
- 身份 + 账号列表移入 `weight(1f, fill = false) + verticalScroll` 的子 Column
- 「添加账号」与其分隔线留在滚动区外，固定底部
- 宽度 264 → 276dp、账号/身份名 `maxLines` 1 → 2，缓解长账号名截断

## 需求：自定义每次打开进入的账号
口径 = **记住上次选择，按登录身份分别记**（选一次即默认，菜单里的 ✓ 就是它）：

- `AppPrefs.defaultAccountId / setDefaultAccountId`（DataStore，键按 sessionId 分）
- `AccountStore.select` 写、`applyAccounts` 读；自动兜底选中**不**写盘，不会覆盖用户存的默认值
- 落空（首次登录 / 该账号已不可访问）才回退列表第一个

与 iOS（#74）、鸿蒙（早已是该行为）口径一致。

## 版本 / 校验
- `versionCode` 20 → **21**、`versionName` 1.7.0 → **1.7.1**
- 带 changelog 生成物：`WhatsNewReleases.generated.kt` + 13× `whatsnew.xml`（`pnpm changelog:check` ✅）
- `./gradlew :app:compileDirectDebugKotlin :app:processDirectDebugResources` 通过

## 遗留
- 滚动修复的真机目视验收未做（约束为父容器有界 + `weight(fill=false)`，逻辑成立，但布局改动最终看真机）
- 工作区里那笔 Play Billing 9 升级（`libs.versions.toml` / `PlayBilling.kt`）**未挟带进本分支**