### PR TITLE
fix(deps): 修掉 brace-expansion 与 body-parser 两个 DoS 漏洞（部分，见后续 PR）

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,8 @@ overrides:
   ws@>=8.0.0 <8.21.0: 8.21.0
   postcss@<8.5.10: 8.5.10
   esbuild@>=0.27.3 <0.28.1: 0.28.1
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  body-parser@>=2.0.0 <2.3.0: 2.3.0
 
 importers:
 
@@ -2161,8 +2163,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   bowser@2.14.1:
@@ -2174,8 +2176,8 @@ packages:
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -6276,10 +6278,10 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
@@ -6301,7 +6303,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6905,7 +6907,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -7498,7 +7500,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ overrides:
   'ws@>=8.0.0 <8.21.0': '8.21.0'
   'postcss@<8.5.10': '8.5.10'
   'esbuild@>=0.27.3 <0.28.1': '0.28.1'
+  'brace-expansion@>=3.0.0 <5.0.7': '5.0.7'
+  'body-parser@>=2.0.0 <2.3.0': '2.3.0'
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true


### PR DESCRIPTION
> ⚠️ **本 PR 覆盖不全，已由后续 PR 补齐。** 当时误判 default branch 上只有 2 条开放告警（查询开放告警时被 `head` 截断了分页输出，又只信了 `git push` 的「新引入」提示），实际有 **25 条**。此外本 PR 对 `brace-expansion` 的处理有两处错误，也在后续 PR 中修正。

实际合入内容，均为 `pnpm-lock.yaml` 里的间接依赖：

| 包 | 严重度 | 变更 | 告警 |
|---|---|---|---|
| `body-parser` | low | 2.2.2 → 2.3.0 | [GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6) — 非法 `limit` 值静默关闭体积限制 |
| `brace-expansion` | high | 5.0.6 → 5.0.7 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)（仅 5.x 线，**且 5.0.7 仍不够**） |

override 写在 `pnpm-workspace.yaml`（pnpm 11 不读 `package.json` 的 `pnpm.overrides`）。

## 本 PR 的两处判断错误

1. **漏了 1.x / 2.x**：`GHSA-3jxr-9vmj-r5cp` 对不同大版本有**独立**的漏洞范围（`<1.1.16`、`>=2.0.0 <2.1.2`），锁文件里的 `brace-expansion@1.1.15` 与 `2.1.1` 都受影响。我当时判断它们「不在漏洞范围内」，是把 5.x 那一条范围当成了全部。
2. **5.0.7 本身仍受影响**：另有公告 [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) 覆盖 `<= 5.0.7`，唯一修复版是 5.0.8。

验证当时通过：`pnpm test` 96 项、`pnpm build` 均正常——只是覆盖面不足，不是引入了问题。

---

**English** — ⚠️ **Incomplete; superseded by a follow-up PR.** This PR was written believing only 2 alerts were open on the default branch (the alert query had been truncated by `head`, and the `git push` summary reports only newly introduced ones); there were actually 25. It also got `brace-expansion` wrong twice: `GHSA-3jxr-9vmj-r5cp` carries separate ranges per major (`<1.1.16`, `>=2.0.0 <2.1.2`) so the 1.1.15 and 2.1.1 copies were affected too, and a second advisory `GHSA-mh99-v99m-4gvg` covers `<=5.0.7`, making 5.0.7 itself insufficient. What did land: `body-parser` 2.2.2 → 2.3.0 and `brace-expansion` 5.0.6 → 5.0.7.
