### PR TITLE
feat(ios): 暂停 / 恢复 Cloudflare 代理，发 1.9.3 (38)

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheModels.swift
@@ -25,6 +25,9 @@ final class CachedZone {
     // DNS 记录总数（Dashboard 轻量 total_count 回写 / 详情页兜底拉取），nil = 尚未统计。
     // 可选新增字段走轻量迁移；detail 页首屏优先读它，避免默认显示 0 条。
     var dnsRecordCount: Int?
+    // 是否暂停 Cloudflare 代理。API 里与 status 正交（暂停时 status 仍是 active），
+    // 展示状态一律读 displayStatus，别直接读 status。默认值走轻量迁移。
+    var paused: Bool = false
 
     init(from zone: Zone, accountId: String) {
         self.id          = zone.id
@@ -34,6 +37,7 @@ final class CachedZone {
         self.nameServers = zone.nameServers ?? []
         self.accountId   = accountId
         self.updatedAt   = Date()
+        self.paused      = zone.paused ?? false
     }
 
     func update(from zone: Zone) {
@@ -41,8 +45,12 @@ final class CachedZone {
         status      = zone.status
         planName    = zone.plan?.name ?? "—"
         nameServers = zone.nameServers ?? []
+        paused      = zone.paused ?? false
         updatedAt   = Date()
     }
+
+    /// 对外展示用状态：暂停优先于 status（Cloudflare 暂停时 status 仍报 active）
+    var displayStatus: String { paused ? "paused" : status }
 }
 
 @Model

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardAlerts.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardAlerts.swift
@@ -38,16 +38,22 @@ enum DashboardAlerts {
     ) -> [DashboardAlert] {
         var alerts: [DashboardAlert] = []
 
-        // ① 未激活 / 已暂停的域名
-        for zone in zones where zone.status != "active" {
+        // ① 未激活 / 已暂停的域名（暂停是用户主动操作，单独给一条可读的说明）
+        for zone in zones where zone.displayStatus != "active" {
             let pendingLike = zone.status == "pending" || zone.status == "initializing"
+            let detail: String
+            if zone.paused {
+                detail = String(localized: "已暂停 Cloudflare，流量当前不经过代理")
+            } else if pendingLike {
+                detail = String(localized: "域名待激活，检查域名服务器是否已指向 Cloudflare")
+            } else {
+                detail = String(localized: "域名未处于启用状态（\(zone.status)）")
+            }
             alerts.append(DashboardAlert(
                 id: "zone|\(zone.id)",
                 severity: pendingLike ? .warn : .critical,
                 title: zone.name,
-                detail: pendingLike
-                    ? String(localized: "域名待激活，检查域名服务器是否已指向 Cloudflare")
-                    : String(localized: "域名未处于启用状态（\(zone.status)）"),
+                detail: detail,
                 route: .zone(zone)
             ))
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardResource.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Dashboard/DashboardResource.swift
@@ -86,7 +86,7 @@ enum DashboardResourceCatalog {
             items.append(DashboardResourceItem(
                 pin: PinnedResource(type: .zone, resourceId: zone.id),
                 title: zone.name,
-                subtitle: "\(planShort(zone.planName)) · \(zoneStatusText(zone.status))",
+                subtitle: "\(planShort(zone.planName)) · \(zoneStatusText(zone.displayStatus))",
                 route: .zone(zone)
             ))
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/AppNotifications.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/AppNotifications.swift
@@ -61,9 +61,14 @@ enum AppNotifications {
             guard let zones = try? await zoneService.listZones(accountId: accountId) else { continue }
             let byId = Dictionary(uniqueKeysWithValues: zones.map { ($0.id, $0) })
             for entry in cached where entry.accountId == accountId {
-                if let fresh = byId[entry.id], fresh.status != entry.status {
-                    changes.append((entry.name, entry.status, fresh.status))
-                    entry.update(from: fresh)
+                // 比对展示态：暂停与 status 正交（暂停时 status 仍是 active），
+                // 在别处暂停/恢复了域名也要能推送到
+                if let fresh = byId[entry.id] {
+                    let freshStatus = (fresh.paused ?? false) ? "paused" : fresh.status
+                    if freshStatus != entry.displayStatus {
+                        changes.append((entry.name, entry.displayStatus, freshStatus))
+                        entry.update(from: fresh)
+                    }
                 }
             }
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -2205,6 +2205,82 @@
         }
       }
     },
+    "一键暂停 Cloudflare": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause Cloudflare in one tap"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一鍵暫停 Cloudflare"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一鍵暫停 Cloudflare"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワンタップで Cloudflare を一時停止"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa Cloudflare con un toque"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 번의 탭으로 Cloudflare 일시 중지"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause o Cloudflare com um toque"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause o Cloudflare com um toque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare mit einem Tipp pausieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre Cloudflare en pause en un geste"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف Cloudflare مؤقتًا بنقرة واحدة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tek dokunuşla Cloudflare’i duraklatın"
+          }
+        }
+      }
+    },
     "不再只是查看——新建隧道、获取连接令牌与命令、配置公共主机名路由。": {
       "localizations": {
         "en": {
@@ -2277,6 +2353,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Artık yalnızca görüntülemek değil — tüneller oluşturun, bağlantı belirteçleri ve komutları alın ve genel ana makine adı yönlendirmesini yapılandırın."
+          }
+        }
+      }
+    },
+    "从概览页打开 Pro 功能的订阅说明时，整页不再跟着重算，弹出与收起都不会顿挫。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opening the subscription details for a Pro feature from Overview no longer re-renders the whole page, so it appears and dismisses without stutter."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從總覽頁打開 Pro 功能的訂閱說明時，整頁不再跟著重算，彈出與收起都不會頓挫。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從概覽頁打開 Pro 功能的訂閱說明時，整頁不再跟著重算，彈出與收起都不會頓挫。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要画面から Pro 機能のサブスクリプション説明を開いても画面全体が再描画されなくなり、表示も閉じる動作も引っかかりません。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir los detalles de suscripción de una función Pro desde el resumen ya no vuelve a dibujar toda la pantalla, así que aparece y se cierra sin tirones."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면에서 Pro 기능의 구독 안내를 열어도 화면 전체가 다시 그려지지 않아, 나타나고 닫힐 때 끊김이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir os detalhes de assinatura de um recurso Pro pela visão geral não recalcula mais a tela inteira, então ele aparece e fecha sem travadas."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir os detalhes de subscrição de uma funcionalidade Pro a partir da vista geral já não recalcula o ecrã inteiro, pelo que surge e fecha sem solavancos."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aus der Übersicht die Abo-Info einer Pro-Funktion geöffnet, wird nicht mehr die ganze Seite neu berechnet – Ein- und Ausblenden laufen ruckelfrei."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’ouverture des informations d’abonnement d’une fonction Pro depuis l’aperçu ne recalcule plus toute la page : l’affichage et la fermeture se font sans à-coups."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يعد فتح تفاصيل الاشتراك لميزة Pro من صفحة النظرة العامة يعيد رسم الصفحة بأكملها، فيظهر ويُغلق بسلاسة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakıştan bir Pro özelliğinin abonelik bilgisi açıldığında artık tüm sayfa yeniden hesaplanmıyor; açılış ve kapanış takılmadan gerçekleşiyor."
           }
         }
       }
@@ -4329,6 +4481,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alan adı ayrıntılarına birleşik \"Kurallar\" girişi eklendi: tekil yönlendirme, kaynak, yapılandırma, sıkıştırma ve özel hata kuralları görüntüleme, açma/kapatma, oluşturma, düzenleme ve silmeyi destekler; Page Rules ve URL normalleştirme görüntüleme ile açma/kapatmayı destekler."
+          }
+        }
+      }
+    },
+    "域名详情的「操作」里新增「暂停 Cloudflare」开关。暂停后流量不再经过 Cloudflare——WAF、缓存加速与源站 IP 隐藏都会失效，DNS 仍由 Cloudflare 解析；恢复同样一键完成，两者约 5 分钟生效。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actions in the zone details now has a “Pause Cloudflare” switch. While paused, traffic no longer passes through Cloudflare — WAF, caching and origin IP masking stop working, while DNS is still resolved by Cloudflare. Resuming is one tap too, and either change takes about 5 minutes."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域詳情的「操作」中新增「暫停 Cloudflare」開關。暫停後流量不再經過 Cloudflare——WAF、快取加速與來源伺服器 IP 隱藏都會失效，DNS 仍由 Cloudflare 解析；恢復同樣一鍵完成，兩者約 5 分鐘生效。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名詳情的「操作」中新增「暫停 Cloudflare」開關。暫停後流量不再經過 Cloudflare——WAF、緩存加速與源站 IP 隱藏都會失效，DNS 仍由 Cloudflare 解析；恢復同樣一鍵完成，兩者約 5 分鐘生效。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン詳細の「操作」に「Cloudflare を一時停止」スイッチを追加しました。一時停止中はトラフィックが Cloudflare を経由しなくなり、WAF・キャッシュ・オリジン IP の秘匿が無効になります（DNS の解決は Cloudflare が継続）。再開もワンタップで、どちらも反映まで約 5 分です。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sección Acciones de los detalles del dominio ahora incluye el interruptor «Pausar Cloudflare». En pausa, el tráfico deja de pasar por Cloudflare: el WAF, la caché y el ocultamiento de la IP de origen dejan de funcionar, aunque el DNS lo sigue resolviendo Cloudflare. Reanudar es igual de simple y ambos cambios tardan unos 5 minutos."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 상세의 ‘작업’에 'Cloudflare 일시 중지' 스위치가 생겼습니다. 일시 중지하면 트래픽이 Cloudflare를 거치지 않아 WAF, 캐시 가속, 원본 IP 숨김이 중단되며 DNS는 계속 Cloudflare가 확인합니다. 다시 시작도 한 번의 탭이고, 두 경우 모두 약 5분 뒤 적용됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A seção Ações nos detalhes do domínio agora tem a chave “Pausar o Cloudflare”. Em pausa, o tráfego deixa de passar pelo Cloudflare: WAF, cache e ocultação do IP de origem param de funcionar, e o DNS continua sendo resolvido pelo Cloudflare. Retomar é igualmente simples e ambos levam cerca de 5 minutos."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A secção Ações nos detalhes do domínio passa a ter o interruptor “Pausar o Cloudflare”. Em pausa, o tráfego deixa de passar pelo Cloudflare: WAF, cache e ocultação do IP de origem deixam de funcionar e o DNS continua a ser resolvido pelo Cloudflare. Retomar é igualmente simples e ambos demoram cerca de 5 minutos."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In den Domain-Details unter „Aktionen“ gibt es jetzt den Schalter „Cloudflare pausieren“. Pausiert läuft der Traffic nicht mehr über Cloudflare – WAF, Caching und die Verschleierung der Origin-IP entfallen, DNS wird weiterhin von Cloudflare aufgelöst. Fortsetzen geht genauso schnell, und beides greift nach etwa 5 Minuten."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La section Actions des détails du domaine propose désormais l’interrupteur « Mettre Cloudflare en pause ». En pause, le trafic ne passe plus par Cloudflare : WAF, mise en cache et masquage de l’IP d’origine cessent de fonctionner, tandis que le DNS reste résolu par Cloudflare. La réactivation est tout aussi simple, et comptez environ 5 minutes dans les deux cas."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا مفتاح «إيقاف Cloudflare مؤقتًا» ضمن «الإجراءات» في تفاصيل النطاق. أثناء الإيقاف المؤقت لا تمر حركة المرور عبر Cloudflare، فيتوقف جدار حماية تطبيقات الويب والتخزين المؤقت وإخفاء عنوان IP للخادم الأصلي، بينما يستمر Cloudflare في تحليل DNS. والاستئناف بنقرة واحدة أيضًا، ويستغرق كلاهما نحو 5 دقائق."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı ayrıntılarındaki İşlemler bölümüne “Cloudflare’i duraklat” anahtarı eklendi. Duraklatıldığında trafik Cloudflare üzerinden geçmez; WAF, önbellek hızlandırma ve kaynak IP gizleme devre dışı kalır, DNS çözümlemesi Cloudflare’de sürer. Sürdürmek de tek dokunuş ve her ikisi de yaklaşık 5 dakikada etkili olur."
           }
         }
       }
@@ -7293,6 +7521,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Genel bakış artık dikkat gerektirenleri tek kartta topluyor: etkinleştirilmemiş alan adları, durumu bozuk tüneller ve daha fazlası. Dokununca doğrudan açılır."
+          }
+        }
+      }
+    },
+    "概览页更跟手": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smoother Overview"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總覽頁更順手"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概覽頁更順手"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要画面がなめらかに"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumen más fluido"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면이 더 부드럽게"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visão geral mais fluida"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista geral mais fluida"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flüssigere Übersicht"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu plus fluide"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صفحة النظرة العامة أكثر سلاسة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakış daha akıcı"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,18 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "1.9.3", items: [
+            WhatsNewItem(
+                icon:   "pause.circle",
+                title:  String(localized: "一键暂停 Cloudflare", table: "WhatsNew"),
+                detail: String(localized: "域名详情的「操作」里新增「暂停 Cloudflare」开关。暂停后流量不再经过 Cloudflare——WAF、缓存加速与源站 IP 隐藏都会失效，DNS 仍由 Cloudflare 解析；恢复同样一键完成，两者约 5 分钟生效。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "speedometer",
+                title:  String(localized: "概览页更跟手", table: "WhatsNew"),
+                detail: String(localized: "从概览页打开 Pro 功能的订阅说明时，整页不再跟着重算，弹出与收起都不会顿挫。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "1.9.2", items: [
             WhatsNewItem(
                 icon:   "person.crop.circle.badge.checkmark",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -7790,6 +7790,7 @@
         }
       }
     },
+    "BINDING_NAME": {},
     "Bot 分数": {
       "localizations": {
         "ar": {
@@ -34353,6 +34354,7 @@
       }
     },
     "其它绑定（只读）": {
+      "extractionState": "stale",
       "localizations": {
         "ar": {
           "stringUnit": {
@@ -47583,6 +47585,7 @@
       }
     },
     "向左滑动查看实时日志 · 点按查看详情": {
+      "extractionState": "stale",
       "localizations": {
         "ar": {
           "stringUnit": {
@@ -71317,6 +71320,82 @@
         }
       }
     },
+    "恢复 Cloudflare？": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استئناف Cloudflare؟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare fortsetzen?"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Cloudflare?"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Reanudar Cloudflare?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réactiver Cloudflare ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare を再開しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare를 다시 시작할까요?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar o Cloudflare?"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar o Cloudflare?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare sürdürülsün mü?"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復 Cloudflare？"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復 Cloudflare？"
+          }
+        }
+      }
+    },
     "恢复 NULL": {
       "localizations": {
         "ar": {
@@ -71389,6 +71468,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "恢復 NULL"
+          }
+        }
+      }
+    },
+    "恢复后，%@ 的流量重新经由 Cloudflare 代理，缓存与安全防护随之生效。生效约需 5 分钟。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بعد الاستئناف، تعود حركة المرور إلى %@ عبر وكيل Cloudflare، ويعود التخزين المؤقت والحماية الأمنية إلى العمل. يستغرق السريان نحو 5 دقائق."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach dem Fortsetzen läuft der Traffic von %@ wieder über Cloudflare, Caching und Sicherheitsschutz greifen erneut. Die Änderung greift nach etwa 5 Minuten."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Once resumed, traffic to %@ is proxied through Cloudflare again, and caching and security protection take effect with it. Takes about 5 minutes to take effect."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al reanudar, el tráfico de %@ vuelve a pasar por el proxy de Cloudflare y se restablecen la caché y la protección de seguridad. Tarda unos 5 minutos en aplicarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une fois réactivé, le trafic de %@ repasse par le proxy Cloudflare : la mise en cache et la protection de sécurité redeviennent actives. Effectif au bout d’environ 5 minutes."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再開すると、%@ のトラフィックは再び Cloudflare を経由し、キャッシュとセキュリティ保護が有効になります。反映まで約 5 分かかります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시작하면 %@의 트래픽이 다시 Cloudflare를 통해 프록시되고 캐시와 보안 보호가 함께 적용됩니다. 적용까지 약 5분이 걸립니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ao retomar, o tráfego de %@ volta a passar pelo proxy do Cloudflare, e o cache e a proteção de segurança voltam a valer. Leva cerca de 5 minutos para entrar em vigor."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ao retomar, o tráfego de %@ volta a passar pelo proxy do Cloudflare, repondo a cache e a proteção de segurança. Demora cerca de 5 minutos a fazer efeito."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sürdürdüğünüzde %@ trafiği yeniden Cloudflare proxy’si üzerinden geçer; önbellek ve güvenlik koruması yeniden devreye girer. Etkili olması yaklaşık 5 dakika sürer."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復後，%@ 的流量重新經由 Cloudflare 代理，快取與安全防護隨之生效。約需 5 分鐘生效。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復後，%@ 的流量重新經由 Cloudflare 代理，緩存與安全防護隨之生效。約需 5 分鐘生效。"
           }
         }
       }
@@ -84466,6 +84621,234 @@
           "stringUnit": {
             "state": "translated",
             "value": "暫停"
+          }
+        }
+      }
+    },
+    "暂停 Cloudflare": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف Cloudflare مؤقتًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare pausieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause Cloudflare"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar Cloudflare"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre Cloudflare en pause"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare を一時停止"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare 일시 중지"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar o Cloudflare"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar o Cloudflare"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare’i duraklat"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停 Cloudflare"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停 Cloudflare"
+          }
+        }
+      }
+    },
+    "暂停 Cloudflare？": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف Cloudflare مؤقتًا؟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare pausieren?"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause Cloudflare?"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Pausar Cloudflare?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre Cloudflare en pause ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare を一時停止しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare를 일시 중지할까요?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar o Cloudflare?"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar o Cloudflare?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare duraklatılsın mı?"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停 Cloudflare？"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停 Cloudflare？"
+          }
+        }
+      }
+    },
+    "暂停后，%@ 的流量不再经过 Cloudflare：WAF、缓存加速与源站 IP 隐藏都会失效，DNS 仍由 Cloudflare 解析。生效约需 5 分钟。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بعد الإيقاف المؤقت، لن تمر حركة المرور إلى %@ عبر Cloudflare: سيتوقف جدار حماية تطبيقات الويب والتخزين المؤقت وإخفاء عنوان IP للخادم الأصلي، بينما يستمر Cloudflare في تحليل DNS. يستغرق السريان نحو 5 دقائق."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach dem Pausieren läuft der Traffic von %@ nicht mehr über Cloudflare: WAF, Caching und die Verschleierung der Origin-IP entfallen, DNS wird weiterhin von Cloudflare aufgelöst. Die Änderung greift nach etwa 5 Minuten."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Once paused, traffic to %@ no longer passes through Cloudflare: WAF, caching, and origin IP masking all stop working, while DNS is still resolved by Cloudflare. Takes about 5 minutes to take effect."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al pausar, el tráfico de %@ dejará de pasar por Cloudflare: el WAF, la caché y el ocultamiento de la IP de origen dejarán de funcionar; el DNS lo seguirá resolviendo Cloudflare. Tarda unos 5 minutos en aplicarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une fois en pause, le trafic de %@ ne passe plus par Cloudflare : WAF, mise en cache et masquage de l’IP d’origine cessent de fonctionner, tandis que le DNS reste résolu par Cloudflare. Effectif au bout d’environ 5 minutes."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止すると、%@ のトラフィックは Cloudflare を経由しなくなり、WAF・キャッシュ・オリジン IP の秘匿がすべて無効になります。DNS の解決は Cloudflare が引き続き行います。反映まで約 5 分かかります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일시 중지하면 %@의 트래픽이 더 이상 Cloudflare를 거치지 않습니다. WAF, 캐시 가속, 원본 IP 숨김이 모두 중단되며 DNS는 계속 Cloudflare가 확인합니다. 적용까지 약 5분이 걸립니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ao pausar, o tráfego de %@ deixa de passar pelo Cloudflare: WAF, cache e ocultação do IP de origem param de funcionar; o DNS continua sendo resolvido pelo Cloudflare. Leva cerca de 5 minutos para entrar em vigor."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ao pausar, o tráfego de %@ deixa de passar pelo Cloudflare: WAF, cache e ocultação do IP de origem deixam de funcionar; o DNS continua a ser resolvido pelo Cloudflare. Demora cerca de 5 minutos a fazer efeito."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duraklattığınızda %@ trafiği artık Cloudflare üzerinden geçmez: WAF, önbellek hızlandırma ve kaynak IP gizleme devre dışı kalır, DNS çözümlemesi Cloudflare tarafında sürer. Etkili olması yaklaşık 5 dakika sürer."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停後，%@ 的流量不再經過 Cloudflare：WAF、快取加速與來源伺服器 IP 隱藏都會失效，DNS 仍由 Cloudflare 解析。約需 5 分鐘生效。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停後，%@ 的流量不再經過 Cloudflare：WAF、緩存加速與源站 IP 隱藏都會失效，DNS 仍由 Cloudflare 解析。約需 5 分鐘生效。"
           }
         }
       }
@@ -103112,6 +103495,82 @@
         }
       }
     },
+    "流量绕过 Cloudflare，仅保留 DNS 解析": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتجاوز حركة المرور Cloudflare، ويبقى تحليل DNS فقط"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traffic umgeht Cloudflare, nur die DNS-Auflösung bleibt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traffic bypasses Cloudflare; only DNS resolution remains"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El tráfico omite Cloudflare; solo se mantiene la resolución DNS"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le trafic contourne Cloudflare, seule la résolution DNS reste active"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トラフィックは Cloudflare を経由せず、DNS 解決のみ残ります"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트래픽이 Cloudflare를 우회하고 DNS 확인만 유지됩니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O tráfego ignora o Cloudflare; só a resolução DNS continua"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O tráfego ignora o Cloudflare; apenas a resolução DNS se mantém"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trafik Cloudflare’i atlar, yalnızca DNS çözümlemesi kalır"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流量繞過 Cloudflare，僅保留 DNS 解析"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流量繞過 Cloudflare，僅保留 DNS 解析"
+          }
+        }
+      }
+    },
     "测试推送": {
       "localizations": {
         "ar": {
@@ -114209,6 +114668,158 @@
           "stringUnit": {
             "state": "translated",
             "value": "確認開啟"
+          }
+        }
+      }
+    },
+    "确认恢复": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استئناف"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réactiver"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再開する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시작"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sürdür"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認恢復"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認恢復"
+          }
+        }
+      }
+    },
+    "确认暂停": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف مؤقت"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre en pause"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일시 중지"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duraklat"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認暫停"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認暫停"
           }
         }
       }
@@ -148977,6 +149588,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Duraklatıldı · %lld yeni"
+          }
+        }
+      }
+    },
+    "已暂停 Cloudflare，流量当前不经过代理": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أُوقف Cloudflare مؤقتًا، ولا تمر حركة المرور عبر الوكيل حاليًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare ist pausiert, der Traffic läuft derzeit nicht über den Proxy"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare is paused; traffic currently bypasses the proxy"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare está en pausa; el tráfico no pasa por el proxy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare est en pause, le trafic ne passe pas par le proxy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare は一時停止中で、トラフィックはプロキシを経由していません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare가 일시 중지되어 트래픽이 프록시를 거치지 않습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare pausado; o tráfego não passa pelo proxy"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare em pausa; o tráfego não passa pelo proxy"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare duraklatıldı, trafik şu anda proxy üzerinden geçmiyor"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已暫停 Cloudflare，流量目前不經過代理"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已暫停 Cloudflare，流量目前不經過代理"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/Zone.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/Zone.swift
@@ -8,12 +8,15 @@ import Foundation
 nonisolated struct Zone: Codable, Identifiable, Hashable, Sendable {
     let id:          String
     let name:        String
-    let status:      String          // "active" | "pending" | "paused" 等
+    let status:      String          // "active" | "pending" | "initializing" | "moved" 等
+    /// 是否暂停 Cloudflare 代理（Dashboard 的「Pause Cloudflare on Site」）。
+    /// 与 status 正交：暂停时 status 多半仍是 "active"，展示态要以本字段优先。
+    let paused:      Bool?
     let plan:        ZonePlan?
     let nameServers: [String]?
 
     enum CodingKeys: String, CodingKey {
-        case id, name, status, plan
+        case id, name, status, paused, plan
         case nameServers = "name_servers"
     }
 }
@@ -32,4 +35,9 @@ nonisolated struct CreateZoneRequest: Codable, Sendable {
     nonisolated struct AccountRef: Codable, Sendable {
         let id: String
     }
+}
+
+/// PATCH /zones/{id} 请求体：暂停 / 恢复 Cloudflare 代理
+nonisolated struct PauseZoneRequest: Codable, Sendable {
+    let paused: Bool
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/ZoneService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/ZoneService.swift
@@ -57,4 +57,18 @@ struct ZoneService {
         }
         return zone
     }
+
+    /// 暂停 / 恢复 Cloudflare 代理（Dashboard 的「Pause Cloudflare on Site」）。
+    /// 暂停后 DNS 仍由 Cloudflare 解析，但流量不再经过 Cloudflare——WAF、缓存、
+    /// 源站 IP 隐藏一并失效；生效约需 5 分钟。需要 zone.write。
+    func setPaused(zoneId: String, paused: Bool) async throws -> Zone {
+        let response: CFAPIResponse<Zone> = try await client.patch(
+            "zones/\(zoneId)",
+            body: PauseZoneRequest(paused: paused)
+        )
+        guard response.success, let zone = response.result else {
+            throw response.toAPIError()
+        }
+        return zone
+    }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZoneActionsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZoneActionsViewModel.swift
@@ -2,7 +2,11 @@
 //  ZoneActionsViewModel.swift
 //  Orange Cloud
 //
-//  Zone 详情页「操作」区：Under Attack / 开发模式开关 + 缓存清理。
+//  Zone 详情页「操作」区：Under Attack / 开发模式 / 暂停 Cloudflare 开关 + 缓存清理。
+//
+//  注意暂停态与另两个开关的数据源不同：Under Attack / 开发模式读写 zone settings
+//  （zone-settings.read/.write），暂停读写 zone 本身（zone.read / zone.write），
+//  两条链路的权限与加载态各自独立，别合并。
 //
 
 import Foundation
@@ -15,19 +19,25 @@ final class ZoneActionsViewModel {
     private(set) var underAttack = false
     private(set) var devMode = false
     private(set) var settingsLoaded = false
+    /// 是否暂停 Cloudflare 代理。初值取自本地缓存，进页后再用 API 校准。
+    private(set) var paused: Bool
 
     var isTogglingUnderAttack = false
     var isTogglingDevMode = false
+    var isTogglingPause = false
     var isPurging = false
     var didPurge = false       // sensoryFeedback / 提示触发器
     var error: String?
 
     private let service: ZoneSettingsService
+    private let zoneService: ZoneService
     private let zoneId: String
 
-    init(service: ZoneSettingsService, zoneId: String) {
+    init(service: ZoneSettingsService, zoneService: ZoneService, zoneId: String, paused: Bool = false) {
         self.service = service
+        self.zoneService = zoneService
         self.zoneId = zoneId
+        self.paused = paused
     }
 
     func loadSettings() async {
@@ -72,6 +82,33 @@ final class ZoneActionsViewModel {
             self.error = error.localizedDescription
         }
         isTogglingDevMode = false
+    }
+
+    /// 校准暂停态（只需 zone.read，与 loadSettings 的 zone-settings.read 无关）。
+    /// 返回最新值，调用方据此回写本地缓存；读失败保持缓存值不动。
+    @discardableResult
+    func refreshPaused() async -> Bool? {
+        guard let zone = try? await zoneService.getZone(zoneId: zoneId) else { return nil }
+        paused = zone.paused ?? false
+        return paused
+    }
+
+    /// 暂停 / 恢复 Cloudflare 代理。返回是否成功，供调用方回写缓存。
+    @discardableResult
+    func setPaused(_ on: Bool) async -> Bool {
+        guard !isTogglingPause else { return false }
+        isTogglingPause = true
+        error = nil
+        defer { isTogglingPause = false }
+        do {
+            let zone = try await zoneService.setPaused(zoneId: zoneId, paused: on)
+            // 少数情况下响应不带 paused，按请求值兜底
+            paused = zone.paused ?? on
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
     }
 
     func purgeCache() async {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -149,8 +149,12 @@ private struct DashboardHomeView: View {
     @Binding private var resourceRoute: DashboardResourceRoute?
     @State private var showSearch = false
     @State private var pendingRoute: DashboardResourceRoute?
-    /// 免费层点 Pro 资源（R2 / D1 / KV / Tunnel）时弹的付费墙场景
-    @State private var paywallFeature: ProFeature?
+    /// 免费层点 Pro 资源（R2 / D1 / KV / Tunnel）时弹的付费墙场景。
+    /// 状态放 @Observable 而非本视图 @State：本视图 body 极重（问候区 TimelineView、
+    /// 宫格、每个域名的迷你图、置顶清单的全量资源字典），@State 翻转会让整页在
+    /// sheet 呈现动画的起帧同帧重算，iPhone 11 级设备上是可感知的顿挫（issue #69）；
+    /// 隔离后只有 PaywallSheetHost 重算。
+    @State private var paywallPresenter = DashboardPaywallPresenter()
 
     // 套餐预设与账单日按账户存储（AccountPrefsStore，开启 iCloud 同步后跨设备）
     private let prefsStore = AccountPrefsStore.shared
@@ -395,10 +399,9 @@ private struct DashboardHomeView: View {
         .sheet(item: $usageDetail) { service in
             usageDetailSheet(service)
         }
-        // 免费层点 Pro 资源（搜索结果 / 告警 / 已固定）的付费墙
-        .sheet(item: $paywallFeature) { feature in
-            PaywallView(feature: feature)
-        }
+        // 免费层点 Pro 资源（搜索结果 / 告警 / 已固定）的付费墙：
+        // sheet 挂在透明宿主上，触发 / 收起都不重算本视图 body（见 paywallPresenter 注释）
+        .background { PaywallSheetHost(presenter: paywallPresenter) }
     }
 
     /// 「需重新授权」引导：说明 + 一键重授权（同身份原地换令牌），成功摘标后自动重拉
@@ -441,7 +444,7 @@ private struct DashboardHomeView: View {
     /// 闸门只在「赋值 route 之前」判断，不动栈根的值式 navdest 结构（导航铁律）。
     private func openResource(_ route: DashboardResourceRoute) {
         if let feature = route.proFeature, !entitlements.isPro {
-            paywallFeature = feature
+            paywallPresenter.feature = feature
         } else {
             resourceRoute = route
         }
@@ -1580,7 +1583,7 @@ private struct DashboardZoneCard: View {
     let points: [TrafficDataPoint]?
 
     private var statusText: String {
-        switch zone.status {
+        switch zone.displayStatus {
         case "active":                  String(localized: "已启用")
         case "pending", "initializing": String(localized: "待激活")
         default:                        String(localized: "已暂停")
@@ -1625,7 +1628,7 @@ private struct DashboardZoneCard: View {
                         .accessibilityLabel("24 小时请求")
                 }
             }
-            StatusDot(status: zone.status, size: 7)
+            StatusDot(status: zone.displayStatus, size: 7)
                 .accessibilityHidden(true)   // 状态已在副标题文字中
         }
         .padding(.horizontal, OCLayout.islandPadding)
@@ -1698,5 +1701,28 @@ private struct StatIsland: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(OCLayout.islandPadding)
         .glassIsland(cornerRadius: OCLayout.chipRadius)
+    }
+}
+
+// MARK: - 付费墙弹层隔离宿主（issue #69）
+
+/// 付费墙场景的独立状态载体：@Observable 按属性追踪，DashboardHomeView 只写不读，
+/// 触发 / 收起弹层都不会牵连整个概览页 body 重算（那是弹层起帧顿挫的来源）。
+@Observable
+private final class DashboardPaywallPresenter {
+    var feature: ProFeature?
+}
+
+/// 透明叶子视图，唯一读取 presenter.feature 的地方——sheet 起落只重算它自己
+private struct PaywallSheetHost: View {
+
+    @Bindable var presenter: DashboardPaywallPresenter
+
+    var body: some View {
+        Color.clear
+            .allowsHitTesting(false)
+            .sheet(item: $presenter.feature) { feature in
+                PaywallView(feature: feature)
+            }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
@@ -40,7 +40,10 @@ struct ZoneDetailView: View {
             analyticsService: session.analyticsService, zoneId: zoneId
         ))
         _actionsViewModel = State(initialValue: ZoneActionsViewModel(
-            service: session.zoneSettingsService, zoneId: zoneId
+            service: session.zoneSettingsService,
+            zoneService: session.zoneService,
+            zoneId: zoneId,
+            paused: zone.paused
         ))
     }
 
@@ -54,6 +57,8 @@ struct ZoneDetailView: View {
     private var canReadSettings: Bool { auth.hasScope("zone-settings.read") }
     private var canEditSettings: Bool { auth.hasScope("zone-settings.write") }
     private var canPurge: Bool { auth.hasScope("cache.purge") }
+    /// 暂停 / 恢复走 zone 本身，权限与 zone-settings 那条链路无关
+    private var canEditZone: Bool { auth.hasScope("zone.write") }
 
     /// DNS 记录数：本地已同步过记录用实时缓存计数；否则用 Dashboard/入页回写的
     /// total_count（CachedZone.dnsRecordCount），避免首进详情页默认显示 0 条。
@@ -61,8 +66,14 @@ struct ZoneDetailView: View {
         records.isEmpty ? (zone.dnsRecordCount ?? 0) : records.count
     }
 
+    /// hero 卡状态：暂停优先于 status（暂停时 API 的 status 仍是 active），
+    /// 且以 ViewModel 的实时值为准，切换后立刻翻牌
+    private var displayStatus: String {
+        actionsViewModel.paused ? "paused" : zone.status
+    }
+
     private var statusText: String {
-        switch zone.status {
+        switch displayStatus {
         case "active":                  String(localized: "已启用")
         case "pending", "initializing": String(localized: "待激活")
         default:                        String(localized: "已暂停")
@@ -210,6 +221,9 @@ struct ZoneDetailView: View {
                         tint: .red,
                         isOn: actionsViewModel.underAttack,
                         isBusy: actionsViewModel.isTogglingUnderAttack,
+                        canEdit: canEditSettings,
+                        isLoaded: actionsViewModel.settingsLoaded,
+                        deniedScope: canReadSettings ? "zone-settings.write" : "zone-settings.read",
                         requestToggle: { on in pendingAction = .underAttack(on) }
                     )
 
@@ -220,7 +234,25 @@ struct ZoneDetailView: View {
                         tint: .blue,
                         isOn: actionsViewModel.devMode,
                         isBusy: actionsViewModel.isTogglingDevMode,
+                        canEdit: canEditSettings,
+                        isLoaded: actionsViewModel.settingsLoaded,
+                        deniedScope: canReadSettings ? "zone-settings.write" : "zone-settings.read",
                         requestToggle: { on in pendingAction = .devMode(on) }
+                    )
+
+                    // 暂停态一直可读（zone.read 是登录基础权限），故 isLoaded 恒 true：
+                    // 无 zone.write 时行内显示当前开/关而非锁，符合「能看不能改」的一致语义。
+                    settingToggleRow(
+                        title: String(localized: "暂停 Cloudflare"),
+                        subtitle: String(localized: "流量绕过 Cloudflare，仅保留 DNS 解析"),
+                        icon: "pause.circle",
+                        tint: .gray,
+                        isOn: actionsViewModel.paused,
+                        isBusy: actionsViewModel.isTogglingPause,
+                        canEdit: canEditZone,
+                        isLoaded: true,
+                        deniedScope: "zone.write",
+                        requestToggle: { on in pendingAction = .pause(on) }
                     )
 
                     Button {
@@ -320,6 +352,11 @@ struct ZoneDetailView: View {
             }
         }
         .task {
+            // 暂停态只需 zone.read（登录必备），与上面的 settings 权限无关：
+            // 进页用 API 校准一次，纠正列表缓存里过期的暂停态
+            await syncPausedFromAPI()
+        }
+        .task {
             // 该 zone 尚未统计过记录数（前 50 个之外 / Dashboard 未加载完就进来）：
             // 入页轻量拉一次 total_count 回写缓存，首屏不显示 0 条
             if zone.dnsRecordCount == nil, records.isEmpty, auth.hasScope("dns.read"),
@@ -335,6 +372,7 @@ struct ZoneDetailView: View {
             if canReadSettings {
                 await actionsViewModel.loadSettings()
             }
+            await syncPausedFromAPI()
         }
         .confirmationDialog(
             pendingAction?.title ?? "",
@@ -350,6 +388,10 @@ struct ZoneDetailView: View {
                     switch action {
                     case .underAttack(let on): await actionsViewModel.setUnderAttack(on)
                     case .devMode(let on):     await actionsViewModel.setDevMode(on)
+                    case .pause(let on):
+                        if await actionsViewModel.setPaused(on) {
+                            writeBackPaused(actionsViewModel.paused)
+                        }
                     }
                 }
             }
@@ -402,8 +444,24 @@ struct ZoneDetailView: View {
         }
     }
 
+    // MARK: - 暂停态与缓存同步
+
+    /// 从 API 校准暂停态并回写缓存（列表/首页读的是同一份 CachedZone）
+    private func syncPausedFromAPI() async {
+        guard let paused = await actionsViewModel.refreshPaused() else { return }
+        writeBackPaused(paused)
+    }
+
+    private func writeBackPaused(_ paused: Bool) {
+        guard zone.paused != paused else { return }
+        zone.paused = paused
+        SafeCache.perform("暂停状态保存") { try modelContext.save() }
+    }
+
     // MARK: - 设置开关行
 
+    /// canEdit / isLoaded / deniedScope 由调用方给：Under Attack 与开发模式走
+    /// zone-settings.*，暂停走 zone.write，两条权限链路不共用。
     private func settingToggleRow(
         title: String,
         subtitle: String,
@@ -411,6 +469,9 @@ struct ZoneDetailView: View {
         tint: Color,
         isOn: Bool,
         isBusy: Bool,
+        canEdit: Bool,
+        isLoaded: Bool,
+        deniedScope: String,
         requestToggle: @escaping (Bool) -> Void
     ) -> some View {
         HStack(spacing: 12) {
@@ -424,7 +485,7 @@ struct ZoneDetailView: View {
             Spacer()
             if isBusy {
                 ProgressView()
-            } else if canEditSettings && actionsViewModel.settingsLoaded {
+            } else if canEdit && isLoaded {
                 Toggle("", isOn: Binding(
                     get: { isOn },
                     set: { on in requestToggle(on) }
@@ -433,10 +494,10 @@ struct ZoneDetailView: View {
                 .accessibilityLabel(title)
             } else {
                 Button {
-                    deniedScopeHint = canReadSettings ? "zone-settings.write" : "zone-settings.read"
+                    deniedScopeHint = deniedScope
                     showActionDenied = true
                 } label: {
-                    if actionsViewModel.settingsLoaded {
+                    if isLoaded {
                         // 只读授权：显示当前状态
                         Text(isOn ? String(localized: "开") : String(localized: "关"))
                             .font(.subheadline)
@@ -450,7 +511,7 @@ struct ZoneDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(title)
-                .accessibilityValue(actionsViewModel.settingsLoaded ? (isOn ? String(localized: "开") : String(localized: "关")) : "")
+                .accessibilityValue(isLoaded ? (isOn ? String(localized: "开") : String(localized: "关")) : "")
                 .accessibilityHint("需要额外授权才能修改")
             }
         }
@@ -467,11 +528,11 @@ struct ZoneDetailView: View {
                 .minimumScaleFactor(0.7)
             HStack(spacing: 8) {
                 HStack(spacing: 5) {
-                    StatusDot(status: zone.status, size: 7)
+                    StatusDot(status: displayStatus, size: 7)
                         .accessibilityHidden(true)
                     Text(statusText)
                         .font(.footnote.weight(.medium))
-                        .foregroundStyle(zone.status == "active" ? Color.green : Color.secondary)
+                        .foregroundStyle(displayStatus == "active" ? Color.green : Color.secondary)
                 }
                 .accessibilityElement(children: .combine)
                 PlanBadge(planName: zone.planName)
@@ -508,11 +569,14 @@ struct ZoneDetailView: View {
 private nonisolated enum PendingZoneAction: Identifiable {
     case underAttack(Bool)
     case devMode(Bool)
+    /// true = 暂停 Cloudflare，false = 恢复
+    case pause(Bool)
 
     var id: String {
         switch self {
         case .underAttack(let on): "underAttack-\(on)"
         case .devMode(let on):     "devMode-\(on)"
+        case .pause(let on):       "pause-\(on)"
         }
     }
 
@@ -522,6 +586,8 @@ private nonisolated enum PendingZoneAction: Identifiable {
         case .underAttack(false): String(localized: "关闭 Under Attack 模式？")
         case .devMode(true):      String(localized: "开启开发模式？")
         case .devMode(false):     String(localized: "关闭开发模式？")
+        case .pause(true):        String(localized: "暂停 Cloudflare？")
+        case .pause(false):       String(localized: "恢复 Cloudflare？")
         }
     }
 
@@ -529,6 +595,8 @@ private nonisolated enum PendingZoneAction: Identifiable {
         switch self {
         case .underAttack(true), .devMode(true):   String(localized: "确认开启")
         case .underAttack(false), .devMode(false): String(localized: "确认关闭")
+        case .pause(true):                         String(localized: "确认暂停")
+        case .pause(false):                        String(localized: "确认恢复")
         }
     }
 
@@ -542,6 +610,10 @@ private nonisolated enum PendingZoneAction: Identifiable {
             String(localized: "开启后，\(zoneName) 将临时绕过 Cloudflare 缓存，源站负载会上升；3 小时后自动关闭。")
         case .devMode(false):
             String(localized: "关闭后，\(zoneName) 立即恢复缓存加速。")
+        case .pause(true):
+            String(localized: "暂停后，\(zoneName) 的流量不再经过 Cloudflare：WAF、缓存加速与源站 IP 隐藏都会失效，DNS 仍由 Cloudflare 解析。生效约需 5 分钟。")
+        case .pause(false):
+            String(localized: "恢复后，\(zoneName) 的流量重新经由 Cloudflare 代理，缓存与安全防护随之生效。生效约需 5 分钟。")
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneListView.swift
@@ -301,7 +301,7 @@ private struct ZoneSidebarRow: View {
                 PlanBadge(planName: zone.planName)
             }
             Spacer()
-            StatusDot(status: zone.status, size: 7)
+            StatusDot(status: zone.displayStatus, size: 7)
         }
         .padding(.vertical, 2)
     }
@@ -334,7 +334,7 @@ struct ZoneCard: View {
 
             Spacer()
 
-            StatusDot(status: zone.status)
+            StatusDot(status: zone.displayStatus)
             Image(systemName: "chevron.right")
                 .font(.caption)
                 .foregroundStyle(.tertiary)


### PR DESCRIPTION
用户来信问「怎么暂停域名」——查下来 App 一直没有这个功能，只在状态展示里认得 `paused`。本 PR 补上 Cloudflare Dashboard 的 **Pause Cloudflare on Site**。

## 实现

- `ZoneService.setPaused` 走 `PATCH /zones/{id}` `{"paused": bool}`。权限 `zone.write` 已在登录时申请，**不用动 OAuth Client**。
- 域名详情「操作」区第三个开关，沿用既有二次确认弹窗：说明暂停后 WAF、缓存加速与源站 IP 隐藏都会失效、DNS 仍由 Cloudflare 解析、约 5 分钟生效。
- `settingToggleRow` 原先把权限判据写死成 `zone-settings.*`，改为参数传入——暂停这条链路只认 `zone.write`，没有 zone-settings 授权时该开关照常可用；缺 `zone.write` 时行内显示当前开/关并可一键重授权。

## 关键点：`paused` 与 `status` 正交

暂停时 API 的 `status` 仍是 `active`，只读 `status` 的展示会误报「已启用」。故：

- `Zone` / `CachedZone` 加 `paused`（SwiftData 带默认值，走轻量迁移）
- 新增 `CachedZone.displayStatus` 作为**唯一展示口径**，域名列表、概览页卡片、`DashboardResource`、告警清单统一改读它
- 后台状态变更通知也改比对展示态，在别处暂停了同样能推送
- 进详情页与下拉刷新各校准一次暂停态（只需 `zone.read`）并回写缓存

## 配套

- 新文案 9 条进 `Localizable.xcstrings` 13 语
- 1.9.3 的 What's New 生成物（源在 infra 分支 #81）
- `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` 各 12 处 → 1.9.3 / 38
- 另带一处已完成的概览页优化：付费墙状态从本视图 `@State` 挪进 `@Observable` 宿主，sheet 呈现动画起帧不再整页重算（issue #69）

## 验证

`xcodebuild -scheme "Orange Cloud" build` 通过，无版本不匹配 warning。构建后核对：新增 key 未被 Xcode 标 `stale`，即代码 key 与 catalog 完全对上。

> 合并次序：先合 #81（infra），本 PR 与 Android 那条随后、彼此无序。