### PR TITLE
chore(android): deploy lane 默认不再重传商店图

### DIFF
--- a/apps/android/fastlane/Fastfile
+++ b/apps/android/fastlane/Fastfile
@@ -52,14 +52,19 @@ platform :android do
     )
   end
 
-  desc "上传 AAB + 元数据 + 截图到指定轨道。track: internal(默认)/alpha(封闭测试)/beta/production"
+  desc "上传 AAB + 元数据到指定轨道。track: internal(默认)/alpha(封闭测试)/beta/production；images:true 才连图一起传"
   lane :deploy do |options|
     track = options[:track] || "internal"
+    # 图默认不传：5 语 × 18 张走代理要 ~8 分钟，且发版时图基本没变；
+    # 更要紧的是这段是整条链路最容易撞 Google 5xx 的地方，一撞整个 edit 连同
+    # 已传的 AAB 一起回滚，白等一轮。改图时单独跑 `listings`（它就是干这个的），
+    # 或本 lane 加 images:true。
+    upload_images = options[:images] == true
     upload_to_play_store(
       track: track,
       aab: "app/build/outputs/bundle/playRelease/app-play-release.aab",
-      skip_upload_images: false,
-      skip_upload_screenshots: false,
+      skip_upload_images: !upload_images,
+      skip_upload_screenshots: !upload_images,
     )
     # 上架生产轨后回调官网，翻出该版本的更新历史（Play 无发布 webhook，故主动通知）。
     notify_website_release if track == "production"

--- a/apps/android/fastlane/README.md
+++ b/apps/android/fastlane/README.md
@@ -45,7 +45,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 [bundle exec] fastlane android deploy
 ```
 
-上传 AAB + 元数据 + 截图到指定轨道。track: internal(默认)/alpha(封闭测试)/beta/production
+上传 AAB + 元数据到指定轨道。track: internal(默认)/alpha(封闭测试)/beta/production；images:true 才连图一起传
 
 ----
 


### PR DESCRIPTION
`deploy` 原先把 `skip_upload_images` / `skip_upload_screenshots` 硬编码成 `false`，每次传二进制都会把 5 语 × 18 张图重推一遍。发版时图基本没变，而仓库里本来就有 `listings` lane 专门推图文——这是重复劳动。

**更要紧的是可靠性**：图这段走代理约 8 分钟，是整条链路最容易撞 Google 5xx 的地方；而 supply 的 edit 是**全有或全无**，图传到一半失败会把已经传上去的 AAB 一起回滚。1.7.2 上架时就撞了一次 `zh-TW - Internal error encountered`，整轮作废。

改成默认跳过：

```bash
fastlane deploy track:production              # 只传 AAB + 文案 + 版本说明
fastlane deploy track:production images:true  # 需要时连图一起
fastlane listings                             # 只推图文（原本就有）
```

`README.md` 是 fastlane 按 lane 描述自动生成的，一并更新。

## 效果

改后重跑约 30 秒完成。回读 Play 确认（不只信 fastlane 的成功输出）：

```
production   status=completed  versionCodes=['22'] name=1.7.2 notes=13 语
已上传过的 versionCode: [1, 2, 11, 17, 21, 22]
```