### PR TITLE
feat(web): Google Play 实时入账并入统一账本

### DIFF
--- a/apps/web/migrations/0007_play_platform.sql
+++ b/apps/web/migrations/0007_play_platform.sql
@@ -1,0 +1,29 @@
+-- Google Play 入账：把既有 Apple 三表账本升级成「双平台统一账本」。
+--
+-- 不新建 play_* 平行表——两边的业务字段几乎一一对应，统一后看板的 KPI /
+-- 图表 / 交易流水无需 UNION 即可同时覆盖两个平台，只多一个 platform 维度：
+--   notifications.notification_uuid  <- Pub/Sub messageId（重投递同 id，幂等口径不变）
+--   subscriptions.original_transaction_id <- purchaseToken（订阅续期内保持不变）
+--   transactions.transaction_id      <- orderId（GPA.xxxx-...，续订每期一个）
+-- 历史行全部是 Apple 的，故默认值 'apple'。
+--
+-- 注意：storefront 列在 Apple 侧是 ISO 3166-1 alpha-3（USA），Play 侧写的是
+-- Orders API 的 buyerAddress.regionCode / 订阅的 regionCode，为 alpha-2（US）。
+-- 两种写法共存，展示层原样显示，不做归一（无业务判断依赖该列）。
+
+ALTER TABLE notifications ADD COLUMN platform TEXT NOT NULL DEFAULT 'apple';
+ALTER TABLE subscriptions ADD COLUMN platform TEXT NOT NULL DEFAULT 'apple';
+ALTER TABLE transactions  ADD COLUMN platform TEXT NOT NULL DEFAULT 'apple';
+
+-- 订阅升降级 / 重新订阅时 Play 会换发新 purchaseToken，并在新购买上带
+-- linkedPurchaseToken 指回旧的；存下来以便把旧行标记为已被替换。
+ALTER TABLE subscriptions ADD COLUMN linked_token TEXT;
+
+-- Play 的 Orders API 直接给出「开发者到手金额（买家币种）」，比 Apple 侧只能
+-- 拿到售价强；Apple 行留 NULL。price_millis 仍是买家实付总额（含税），口径与
+-- Apple 的 transaction.price 对齐，营收卡片继续用它。
+ALTER TABLE transactions ADD COLUMN dev_revenue_millis INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_platform ON notifications (platform);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_platform ON subscriptions (platform);
+CREATE INDEX IF NOT EXISTS idx_transactions_platform ON transactions (platform);

--- a/apps/web/src/app/admin/export/route.ts
+++ b/apps/web/src/app/admin/export/route.ts
@@ -16,6 +16,8 @@ interface Row {
 	price_millis: number | null;
 	revocation_date: number | null;
 	environment: string | null;
+	platform: string | null;
+	dev_revenue_millis: number | null;
 }
 
 function cell(v: unknown): string {
@@ -32,24 +34,27 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
 	const { results } = await env.IAP_DB.prepare(
 		`SELECT purchase_date, notification_type, type, product_id, transaction_id, original_transaction_id,
-		        currency, price_millis, revocation_date, environment
+		        currency, price_millis, revocation_date, environment, platform, dev_revenue_millis
 		 FROM transactions
 		 WHERE COALESCE(environment, '') <> 'Sandbox'
 		 ORDER BY COALESCE(purchase_date, created_at) DESC
 		 LIMIT 5000`,
 	).all<Row>();
 
+	// dev_revenue（开发者到手金额）目前只有 Play 侧有值，Apple 行留空。
 	const header = [
-		"purchase_date", "notification_type", "transaction_type", "product_id",
-		"transaction_id", "original_transaction_id", "currency", "price", "refunded", "revocation_date",
+		"purchase_date", "platform", "notification_type", "transaction_type", "product_id",
+		"transaction_id", "original_transaction_id", "currency", "price", "dev_revenue",
+		"refunded", "revocation_date",
 	];
 	const lines = [header.join(",")];
 	for (const r of results ?? []) {
 		lines.push(
 			[
-				iso(r.purchase_date), r.notification_type, r.type, r.product_id,
+				iso(r.purchase_date), r.platform ?? "apple", r.notification_type, r.type, r.product_id,
 				r.transaction_id, r.original_transaction_id, r.currency,
 				r.price_millis == null ? "" : (r.price_millis / 1000).toFixed(2),
+				r.dev_revenue_millis == null ? "" : (r.dev_revenue_millis / 1000).toFixed(2),
 				r.revocation_date ? "yes" : "no", iso(r.revocation_date),
 			]
 				.map(cell)

--- a/apps/web/src/app/api/play/notifications/route.ts
+++ b/apps/web/src/app/api/play/notifications/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { PlayApi, PlayApiError } from "@/lib/play/api";
+import { enrichNotification } from "@/lib/play/enrich";
+import { buildLedgerRows } from "@/lib/play/logic";
+import { notifyPlayEvent } from "@/lib/play/notify";
+import { storeLedgerRows } from "@/lib/play/store";
+import { PlayVerifyError, verifyPushRequest } from "@/lib/play/verify";
+import type { PlayEnrichment, PubSubEnvelope } from "@/lib/play/types";
+
+// Google Play Real-time Developer Notifications 入口 —— Play 在订阅 / 买断 /
+// 退款事件时经 Cloud Pub/Sub 推来的 push 请求。
+//
+// 安全边界 = Pub/Sub 附带的 Google OIDC ID Token（公钥验签，无需保管密钥）+ 包名校验。
+// 金额 / 状态要另外回查 Play Developer API，需要服务账号私钥（PLAY_SA_JSON）；
+// 未配置时仍记录事件，只是没有金额（看板会显示为无价交易）。
+//
+// 返回码约定（Pub/Sub 对任何非 2xx 都会退避重投递）：
+//   400 信封坏了（重投也没用，但 Pub/Sub 仍会重试，最终进死信 / 过期）
+//   401 验签失败
+//   200 处理成功（含重复投递）
+//   503 未配置 / 富化遇到瞬时故障（故意让 Pub/Sub 重投递以补齐金额）
+//
+// 配置见 README「Google Play 入账」：GCP topic + push 订阅（带 OIDC）、
+// Play Console 绑定 topic、wrangler secret 注入 PLAY_* 三个值。
+
+export const dynamic = "force-dynamic";
+
+const PACKAGE_NAME = "jiamin.chen.orangecloud";
+
+interface PlayEnv {
+	PLAY_PUSH_AUDIENCE?: string;
+	PLAY_PUSH_SA_EMAIL?: string;
+	PLAY_SA_JSON?: string;
+	BARK_KEY?: string;
+	BARK_SERVER?: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+	const { env, ctx } = getCloudflareContext();
+	const cfg = env as CloudflareEnv & PlayEnv;
+
+	// 未配置 audience 一律 fail-closed：宁可不收，也不裸奔接受任何 POST。
+	if (!cfg.PLAY_PUSH_AUDIENCE) {
+		return NextResponse.json({ error: "not configured" }, { status: 503 });
+	}
+
+	let envelope: PubSubEnvelope;
+	try {
+		envelope = (await request.json()) as PubSubEnvelope;
+	} catch {
+		return NextResponse.json({ error: "bad json" }, { status: 400 });
+	}
+
+	let decoded;
+	try {
+		decoded = await verifyPushRequest(request.headers.get("authorization"), envelope, {
+			audience: cfg.PLAY_PUSH_AUDIENCE,
+			serviceAccountEmail: cfg.PLAY_PUSH_SA_EMAIL,
+			packageName: PACKAGE_NAME,
+		});
+	} catch (err) {
+		if (!(err instanceof PlayVerifyError)) {
+			console.error("[play-notifications] unexpected verify error", err);
+			return NextResponse.json({ error: "verify error" }, { status: 500 });
+		}
+		// 信封本身坏掉（不是签名问题）算 400，其余一律 401。
+		const bad = /message\.data|message id|base64/i.test(err.message);
+		return NextResponse.json({ error: err.message }, { status: bad ? 400 : 401 });
+	}
+
+	// 富化：拿金额 / 状态 / 地区。瞬时失败先照常入库，再用 503 换一次重投递补齐。
+	let enrichment: PlayEnrichment = {};
+	let retryForEnrichment = false;
+	try {
+		enrichment = await enrichNotification(
+			PlayApi.from(cfg.PLAY_SA_JSON, PACKAGE_NAME),
+			decoded,
+		);
+	} catch (err) {
+		const retryable = err instanceof PlayApiError ? err.retryable : true;
+		retryForEnrichment = retryable;
+		console.error("[play-notifications] enrich failed", { retryable, err });
+	}
+
+	const rows = buildLedgerRows(decoded, enrichment);
+
+	try {
+		const result = await storeLedgerRows(env.IAP_DB, rows);
+
+		// 入库成功后推一条 Bark（fire-and-forget）。重复投递跳过以免刷屏。
+		if (!result.duplicate) {
+			ctx.waitUntil(notifyPlayEvent(cfg.BARK_KEY, rows, cfg.BARK_SERVER));
+		}
+
+		if (retryForEnrichment) {
+			return NextResponse.json(
+				{ ok: true, stored: true, enriched: false, type: result.notificationType },
+				{ status: 503 },
+			);
+		}
+		return NextResponse.json(
+			{ ok: true, duplicate: result.duplicate, type: result.notificationType },
+			{ status: 200 },
+		);
+	} catch (err) {
+		console.error("[play-notifications] store error", err);
+		return NextResponse.json({ error: "storage error" }, { status: 500 });
+	}
+}

--- a/apps/web/src/components/dashboard/Filters.tsx
+++ b/apps/web/src/components/dashboard/Filters.tsx
@@ -2,7 +2,13 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTransition } from "react";
-import { PRODUCT_LABEL, PRODUCT_ORDER, RANGE_OPTIONS } from "@/lib/dashboard/types";
+import {
+	PLATFORM_LABEL,
+	PLATFORM_ORDER,
+	PRODUCT_LABEL,
+	PRODUCT_ORDER,
+	RANGE_OPTIONS,
+} from "@/lib/dashboard/types";
 
 interface Option {
 	value: string;
@@ -12,6 +18,11 @@ interface Option {
 const PRODUCT_OPTIONS: Option[] = [
 	{ value: "all", label: "全部" },
 	...PRODUCT_ORDER.map((id) => ({ value: id, label: PRODUCT_LABEL[id] })),
+];
+
+const PLATFORM_OPTIONS: Option[] = [
+	{ value: "all", label: "全部" },
+	...PLATFORM_ORDER.map((id) => ({ value: id, label: PLATFORM_LABEL[id] })),
 ];
 
 // Changing any filter resets the per-list page cursors.
@@ -26,6 +37,7 @@ export function Filters() {
 	const current = {
 		days: params.get("days") ?? "all",
 		product: params.get("product") ?? "all",
+		platform: params.get("platform") ?? "all",
 	};
 
 	function setParam(key: string, value: string, defaultValue: string) {
@@ -54,6 +66,12 @@ export function Filters() {
 				options={PRODUCT_OPTIONS}
 				value={current.product}
 				onSelect={(v) => setParam("product", v, "all")}
+			/>
+			<Segmented
+				label="平台"
+				options={PLATFORM_OPTIONS}
+				value={current.platform}
+				onSelect={(v) => setParam("platform", v, "all")}
 			/>
 		</div>
 	);

--- a/apps/web/src/components/dashboard/panels/NotificationRows.tsx
+++ b/apps/web/src/components/dashboard/panels/NotificationRows.tsx
@@ -3,7 +3,7 @@
 import { type ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { TimeText } from "@/components/dashboard/prefs";
-import { Badge } from "@/components/dashboard/ui";
+import { Badge, PlatformBadge } from "@/components/dashboard/ui";
 import { formatMoney } from "@/lib/dashboard/format";
 import type { NotificationRow } from "@/lib/dashboard/queries";
 import {
@@ -34,6 +34,9 @@ export function NotificationRows({ rows }: { rows: NotificationRow[] }) {
 							<TimeText ms={n.received_at} />
 						</td>
 						<td className="px-5 py-2.5 whitespace-nowrap">
+							<PlatformBadge platform={n.platform} />
+						</td>
+						<td className="px-5 py-2.5 whitespace-nowrap">
 							<Badge tone={notificationTone(n.notification_type)}>
 								{notificationLabel(n.notification_type)}
 							</Badge>
@@ -42,7 +45,13 @@ export function NotificationRows({ rows }: { rows: NotificationRow[] }) {
 							{sub ? <Badge tone="muted">{sub}</Badge> : <span className="text-muted">—</span>}
 						</td>
 						<td className="px-5 py-2.5 font-mono text-[11px] whitespace-nowrap text-muted">
-							{n.original_transaction_id ?? "—"}
+							{/* Play 的 purchaseToken 很长（几百字符），截断显示、hover 看全量 */}
+							<span
+								className="inline-block max-w-56 truncate align-bottom"
+								title={n.original_transaction_id ?? undefined}
+							>
+								{n.original_transaction_id ?? "—"}
+							</span>
 						</td>
 						<td className="px-5 py-2.5 text-right whitespace-nowrap tabular-nums">
 							{n.txn?.price_millis != null ? (
@@ -105,6 +114,7 @@ function NotificationModal({
 				<div className="flex items-start justify-between gap-3 border-b border-border px-5 py-4">
 					<div className="min-w-0">
 						<div className="flex flex-wrap items-center gap-1.5">
+							<PlatformBadge platform={n.platform} />
 							<Badge tone={notificationTone(n.notification_type)}>
 								{notificationLabel(n.notification_type)}
 							</Badge>
@@ -197,9 +207,10 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
 
 function IdRow({ label, id }: { label: string; id: string | null }) {
 	return (
-		<div className="flex items-center justify-between gap-3 text-[11px]">
-			<span className="text-muted">{label}</span>
-			<span className="font-mono text-muted">{id ?? "—"}</span>
+		<div className="flex items-start justify-between gap-3 text-[11px]">
+			<span className="shrink-0 text-muted">{label}</span>
+			{/* Play 的 purchaseToken 是长串，允许换行以免撑破弹窗 */}
+			<span className="max-w-[70%] font-mono break-all text-muted">{id ?? "—"}</span>
 		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/panels/PlatformSplit.tsx
+++ b/apps/web/src/components/dashboard/panels/PlatformSplit.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { usePrefs, type DisplayCurrency } from "@/components/dashboard/prefs";
+import { Card, CardHead, PlatformBadge } from "@/components/dashboard/ui";
+import { convertMillis, type FxRates } from "@/lib/dashboard/fx";
+import { formatNumber } from "@/lib/dashboard/format";
+import type { PlatformSummary } from "@/lib/dashboard/queries";
+
+function formatTotal(amount: number, currency: DisplayCurrency): string {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency,
+		maximumFractionDigits: 0,
+	}).format(amount);
+}
+
+/**
+ * App Store / Google Play 横向对比。只有一个平台有数据时不渲染
+ * （那时上面的 KPI 行已经说明了全部）。
+ */
+export function PlatformSplitCard({
+	platforms,
+	fx,
+}: {
+	platforms: PlatformSummary[];
+	fx: FxRates | null;
+}) {
+	const { currency } = usePrefs();
+	if (platforms.length < 2) return null;
+
+	return (
+		<Card>
+			<CardHead title="分平台" hint="同一筛选下各商店的权益、交易与折合营收" />
+			<div className="grid grid-cols-1 gap-3 px-5 pt-4 pb-5 sm:grid-cols-2">
+				{platforms.map((p) => {
+					let revenue: number | null = fx ? 0 : null;
+					if (fx) {
+						for (const r of p.revenueByCurrency) {
+							const converted = convertMillis(r.sumMillis, r.currency, currency, fx.rates);
+							// 缺汇率的币种不计入（与「折合总营收」口径一致）
+							if (converted != null) revenue = (revenue ?? 0) + converted;
+						}
+					}
+					return (
+						<div key={p.platform} className="rounded-lg border border-border bg-surface-2 p-4">
+							<PlatformBadge platform={p.platform} />
+							<p className="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
+								{revenue == null ? "—" : formatTotal(revenue, currency)}
+							</p>
+							<p className="mt-1 text-xs text-muted">
+								活跃权益 {formatNumber(p.activeTotal)} · 交易 {formatNumber(p.transactions)} · 退款{" "}
+								{formatNumber(p.refunds)}
+							</p>
+						</div>
+					);
+				})}
+			</div>
+		</Card>
+	);
+}

--- a/apps/web/src/components/dashboard/panels/Tables.tsx
+++ b/apps/web/src/components/dashboard/panels/Tables.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { TimeText } from "@/components/dashboard/prefs";
-import { Badge, Card, CardHead, EmptyState } from "@/components/dashboard/ui";
+import { Badge, Card, CardHead, EmptyState, PlatformBadge } from "@/components/dashboard/ui";
 import { formatMoney, formatRelativeFuture } from "@/lib/dashboard/format";
 import type { ExpiringRow, NotificationRow, Page, TransactionRow } from "@/lib/dashboard/queries";
 import { offerTypeLabel, productLabel, txTypeLabel } from "@/lib/dashboard/types";
@@ -107,6 +107,7 @@ export function NotificationsTable({ data, query }: { data: Page<NotificationRow
 							<thead>
 								<tr className="border-b border-border text-left text-xs text-muted">
 									<Th>时间</Th>
+									<Th>平台</Th>
 									<Th>类型</Th>
 									<Th>子类型</Th>
 									<Th>原始交易 ID</Th>
@@ -149,6 +150,7 @@ export function TransactionsTable({ data, query }: { data: Page<TransactionRow>;
 							<thead>
 								<tr className="border-b border-border text-left text-xs text-muted">
 									<Th>时间</Th>
+									<Th>平台</Th>
 									<Th>交易 ID</Th>
 									<Th>类型</Th>
 									<Th>产品</Th>
@@ -166,6 +168,9 @@ export function TransactionsTable({ data, query }: { data: Page<TransactionRow>;
 										<tr key={t.transaction_id} className="border-b border-border/50 last:border-0">
 											<Td className="text-muted">
 												<TimeText ms={t.purchase_date} />
+											</Td>
+											<Td>
+												<PlatformBadge platform={t.platform} />
 											</Td>
 											<Td>
 												<MonoId id={t.transaction_id} />
@@ -236,6 +241,7 @@ export function ExpiringSoonTable({ rows }: { rows: ExpiringRow[] }) {
 							<tr className="border-b border-border text-left text-xs text-muted">
 								<Th>到期</Th>
 								<Th>剩余</Th>
+								<Th>平台</Th>
 								<Th>产品</Th>
 								<Th className="text-right">金额</Th>
 								<Th>自动续订</Th>
@@ -251,6 +257,9 @@ export function ExpiringSoonTable({ rows }: { rows: ExpiringRow[] }) {
 										<TimeText ms={s.expires_date} />
 									</Td>
 									<Td>{formatRelativeFuture(s.expires_date)}</Td>
+									<Td>
+										<PlatformBadge platform={s.platform} />
+									</Td>
 									<Td>{productLabel(s.product_id)}</Td>
 									<Td className="text-right tabular-nums">
 										{formatMoney(s.price_millis, s.currency ?? "USD")}

--- a/apps/web/src/components/dashboard/panels/sections.tsx
+++ b/apps/web/src/components/dashboard/panels/sections.tsx
@@ -16,6 +16,7 @@ import {
 	StatusBreakdownCard,
 } from "./Charts";
 import { KpiStats, RevenueCard } from "./Kpis";
+import { PlatformSplitCard } from "./PlatformSplit";
 import { ExpiringSoonTable, NotificationsTable, TransactionsTable } from "./Tables";
 
 // Async server components — each awaits only its own slice of data and is
@@ -27,6 +28,7 @@ export async function OverviewSection({ filters }: { filters: Filters }) {
 		<>
 			<KpiStats overview={overview} />
 			<RevenueCard overview={overview} fx={fx} />
+			<PlatformSplitCard platforms={overview.platforms} fx={fx} />
 		</>
 	);
 }

--- a/apps/web/src/components/dashboard/ui.tsx
+++ b/apps/web/src/components/dashboard/ui.tsx
@@ -63,6 +63,12 @@ export function EnvBadge({ env }: { env: string | null }) {
 	return <Badge tone={env === "Production" ? "accent" : "muted"}>{env}</Badge>;
 }
 
+/** 平台徽章（App Store / Google Play）。历史行无 platform，按 Apple 计。 */
+export function PlatformBadge({ platform }: { platform: string | null }) {
+	const isPlay = platform === "play";
+	return <Badge tone={isPlay ? "info" : "muted"}>{isPlay ? "Google Play" : "App Store"}</Badge>;
+}
+
 export function Legend({ items }: { items: { label: string; color: string }[] }) {
 	return (
 		<ul className="flex flex-wrap items-center gap-x-4 gap-y-1.5">

--- a/apps/web/src/lib/admin/queries.integration.test.ts
+++ b/apps/web/src/lib/admin/queries.integration.test.ts
@@ -1,7 +1,7 @@
 // loadAdminStats 的真实 SQL 集成测试（node:sqlite）：混入 Production / Sandbox 行，
 // 断言所有聚合都把 Sandbox 排除，并验证跨币种 USD 归一。
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { beforeAll, describe, expect, it } from "vitest";
 import { loadAdminStats } from "./queries";
@@ -30,7 +30,13 @@ class FakeD1 {
 	}
 }
 
-const schema = readFileSync(new URL("../../../migrations/0001_init.sql", import.meta.url), "utf8");
+// 全量 migration（含 0007 的 platform 列），保持与生产表结构一致。
+const migDir = new URL("../../../migrations/", import.meta.url);
+const schema = readdirSync(migDir)
+	.filter((f) => f.endsWith(".sql"))
+	.sort()
+	.map((f) => readFileSync(new URL(f, migDir), "utf8"))
+	.join("\n");
 let db: FakeD1;
 const PD = Date.now() - 2 * 86_400_000; // 两天前，落在近 30 天 / 本月窗口内
 

--- a/apps/web/src/lib/admin/queries.ts
+++ b/apps/web/src/lib/admin/queries.ts
@@ -52,6 +52,8 @@ export interface TxnRow {
 	transaction_id: string;
 	currency: string | null;
 	price_millis: number | null;
+	/** 'apple' | 'play'（历史行默认 apple） */
+	platform: string | null;
 	revoked: boolean;
 }
 
@@ -65,6 +67,7 @@ export interface SubRow {
 	price_millis: number | null;
 	currency: string | null;
 	purchase_date: number | null;
+	platform: string | null;
 }
 
 export interface AdminStats {
@@ -87,6 +90,9 @@ const STATUS_META: Record<string, { label: string; color: string; order: number 
 	expired: { label: "已过期 Expired", color: "var(--sys-gray)", order: 3 },
 	refunded: { label: "已退款 Refunded", color: "var(--sys-red)", order: 4 },
 	revoked: { label: "已撤销 Revoked", color: "var(--sys-red)", order: 5 },
+	// Google Play 特有的两种状态（暂停 / 待付款），Apple 侧不会出现
+	paused: { label: "已暂停 Paused", color: "var(--sys-gray)", order: 6 },
+	pending: { label: "待处理 Pending", color: "var(--sys-yellow)", order: 7 },
 };
 
 interface CurSum {
@@ -251,7 +257,7 @@ export async function loadAdminStats(db: D1Database, range: Range = "day"): Prom
 		db
 			.prepare(
 				`SELECT purchase_date, notification_type, product_id, transaction_id, currency, price_millis,
-				        (revocation_date IS NOT NULL) AS revoked
+				        platform, (revocation_date IS NOT NULL) AS revoked
 				 FROM transactions WHERE ${NOT_SANDBOX}
 				 ORDER BY COALESCE(purchase_date, created_at) DESC LIMIT 14`,
 			)
@@ -259,7 +265,7 @@ export async function loadAdminStats(db: D1Database, range: Range = "day"): Prom
 		db
 			.prepare(
 				`SELECT original_transaction_id, product_id, status, auto_renew_status, is_lifetime,
-				        expires_date, price_millis, currency, purchase_date
+				        expires_date, price_millis, currency, purchase_date, platform
 				 FROM subscriptions WHERE ${NOT_SANDBOX}
 				 ORDER BY updated_at DESC LIMIT 50`,
 			)
@@ -306,6 +312,7 @@ export async function loadAdminStats(db: D1Database, range: Range = "day"): Prom
 		transaction_id: r.transaction_id,
 		currency: r.currency,
 		price_millis: r.price_millis,
+		platform: r.platform ?? "apple",
 		revoked: Boolean(r.revoked),
 	}));
 

--- a/apps/web/src/lib/dashboard/queries.ts
+++ b/apps/web/src/lib/dashboard/queries.ts
@@ -1,5 +1,5 @@
 import { getDb, queryAll, queryFirst } from "./db";
-import { ENVIRONMENT, PRODUCT_ORDER, type Filters } from "./types";
+import { ENVIRONMENT, PLATFORM_ORDER, PRODUCT_ORDER, type Filters } from "./types";
 
 // ---------------------------------------------------------------------------
 // Filter helpers
@@ -12,6 +12,8 @@ interface FilterCols {
 	product?: string;
 	/** epoch-ms column the `days` window applies to (omit to ignore). */
 	date?: string;
+	/** platform column name (omit to ignore the store filter). */
+	platform?: string;
 }
 
 /** Build an ` AND ...` SQL fragment + bound params for the active filters. */
@@ -33,6 +35,10 @@ function applyFilters(f: Filters, cols: FilterCols): { sql: string; params: unkn
 		clauses.push(`${cols.date} >= ?`);
 		params.push(Date.now() - f.days * 86_400_000);
 	}
+	if (cols.platform && f.platform) {
+		clauses.push(`${cols.platform} = ?`);
+		params.push(f.platform);
+	}
 
 	return { sql: clauses.length ? ` AND ${clauses.join(" AND ")}` : "", params };
 }
@@ -47,6 +53,15 @@ export interface CurrencyRevenue {
 	sumMillis: number;
 }
 
+/** 单个平台（App Store / Google Play）的横向对比口径。 */
+export interface PlatformSummary {
+	platform: string;
+	activeTotal: number;
+	transactions: number;
+	refunds: number;
+	revenueByCurrency: CurrencyRevenue[];
+}
+
 export interface Overview {
 	activeLifetime: number;
 	activeSubscription: number;
@@ -58,6 +73,8 @@ export interface Overview {
 	autoRenewTotal: number;
 	autoRenewRate: number;
 	revenueByCurrency: CurrencyRevenue[];
+	/** 分平台明细（只含有数据的平台，按 PLATFORM_ORDER 排序）。 */
+	platforms: PlatformSummary[];
 }
 
 export interface StackedDay {
@@ -99,6 +116,7 @@ export interface NotificationRow {
 	transaction_id: string | null;
 	environment: string | null;
 	received_at: number;
+	platform: string | null;
 	/** Associated transaction, or null when none is linked/found. */
 	txn: LinkedTxn | null;
 }
@@ -111,6 +129,7 @@ interface NotificationJoinRow {
 	transaction_id: string | null;
 	environment: string | null;
 	received_at: number;
+	platform: string | null;
 	t_id: string | null;
 	t_product_id: string | null;
 	t_type: string | null;
@@ -137,6 +156,7 @@ export interface TransactionRow {
 	purchase_date: number | null;
 	revocation_date: number | null;
 	notification_type: string | null;
+	platform: string | null;
 }
 
 export interface ExpiringRow {
@@ -147,6 +167,7 @@ export interface ExpiringRow {
 	environment: string | null;
 	price_millis: number | null;
 	currency: string | null;
+	platform: string | null;
 }
 
 export interface Page<T> {
@@ -225,10 +246,20 @@ function paginate(total: number, page: number, pageSize: number) {
 // ---------------------------------------------------------------------------
 
 async function getOverview(db: D1Database, f: Filters): Promise<Overview> {
-	const subActive = applyFilters(f, { env: "environment", product: "product_id" });
-	const tx = applyFilters(f, { env: "environment", product: "product_id", date: "purchase_date" });
+	const subActive = applyFilters(f, {
+		env: "environment",
+		product: "product_id",
+		platform: "platform",
+	});
+	const tx = applyFilters(f, {
+		env: "environment",
+		product: "product_id",
+		date: "purchase_date",
+		platform: "platform",
+	});
 
-	const [lifetimeRows, txRow, autoRow, revenueRows] = await Promise.all([
+	const [lifetimeRows, txRow, autoRow, revenueRows, platformActive, platformTx] =
+		await Promise.all([
 		queryAll<{ is_lifetime: number; c: number }>(
 			db,
 			`SELECT is_lifetime, COUNT(*) c FROM subscriptions
@@ -259,6 +290,30 @@ async function getOverview(db: D1Database, f: Filters): Promise<Overview> {
 			 ORDER BY count DESC, currency ASC`,
 			tx.params,
 		),
+		// 分平台明细：活跃权益来自 subscriptions，交易 / 退款 / 营收来自 transactions。
+		queryAll<{ platform: string; c: number }>(
+			db,
+			`SELECT platform, COUNT(*) c FROM subscriptions
+			 WHERE status = 'active'${subActive.sql} GROUP BY platform`,
+			subActive.params,
+		),
+		queryAll<{
+			platform: string;
+			currency: string | null;
+			total: number;
+			paid: number;
+			refunds: number;
+			sum_millis: number;
+		}>(
+			db,
+			`SELECT platform, currency, COUNT(*) total,
+			        SUM(CASE WHEN revocation_date IS NULL THEN 1 ELSE 0 END) paid,
+			        SUM(CASE WHEN revocation_date IS NOT NULL THEN 1 ELSE 0 END) refunds,
+			        SUM(CASE WHEN revocation_date IS NULL THEN price_millis ELSE 0 END) sum_millis
+			 FROM transactions WHERE 1 = 1${tx.sql}
+			 GROUP BY platform, currency`,
+			tx.params,
+		),
 	]);
 
 	const activeLifetime = lifetimeRows.find((r) => r.is_lifetime === 1)?.c ?? 0;
@@ -266,7 +321,37 @@ async function getOverview(db: D1Database, f: Filters): Promise<Overview> {
 	const txTotals = txRow[0] ?? { total: 0, refunds: 0 };
 	const auto = autoRow[0] ?? { on_count: 0, total: 0 };
 
+	// 把两组分平台行合并成 PlatformSummary[]（只保留真有数据的平台）。
+	const summaries = new Map<string, PlatformSummary>();
+	const summaryFor = (platform: string): PlatformSummary => {
+		let s = summaries.get(platform);
+		if (!s) {
+			s = { platform, activeTotal: 0, transactions: 0, refunds: 0, revenueByCurrency: [] };
+			summaries.set(platform, s);
+		}
+		return s;
+	};
+	for (const r of platformActive) summaryFor(r.platform ?? "apple").activeTotal += r.c;
+	for (const r of platformTx) {
+		const s = summaryFor(r.platform ?? "apple");
+		s.transactions += r.total;
+		s.refunds += r.refunds ?? 0;
+		if ((r.paid ?? 0) > 0) {
+			s.revenueByCurrency.push({
+				currency: r.currency ?? "—",
+				count: r.paid,
+				sumMillis: r.sum_millis ?? 0,
+			});
+		}
+	}
+	const platforms = [...summaries.values()].sort(
+		(a, b) =>
+			PLATFORM_ORDER.indexOf(a.platform as (typeof PLATFORM_ORDER)[number]) -
+			PLATFORM_ORDER.indexOf(b.platform as (typeof PLATFORM_ORDER)[number]),
+	);
+
 	return {
+		platforms,
 		activeLifetime,
 		activeSubscription,
 		activeTotal: activeLifetime + activeSubscription,
@@ -289,6 +374,7 @@ async function getPurchaseTrend(db: D1Database, f: Filters): Promise<StackedSeri
 		env: "environment",
 		product: "product_id",
 		date: "purchase_date",
+		platform: "platform",
 	});
 	const rows = await queryAll<{ d: string; product_id: string | null; c: number }>(
 		db,
@@ -312,6 +398,7 @@ async function getNotificationTrend(db: D1Database, f: Filters): Promise<Stacked
 		env: "n.environment",
 		product: "t.product_id",
 		date: "n.received_at",
+		platform: "n.platform",
 	});
 	const rows = await queryAll<{ d: string; notification_type: string; c: number }>(
 		db,
@@ -327,7 +414,11 @@ async function getNotificationTrend(db: D1Database, f: Filters): Promise<Stacked
 }
 
 async function getProductMix(db: D1Database, f: Filters): Promise<NameValue[]> {
-	const { sql, params } = applyFilters(f, { env: "environment", product: "product_id" });
+	const { sql, params } = applyFilters(f, {
+		env: "environment",
+		product: "product_id",
+		platform: "platform",
+	});
 	const rows = await queryAll<{ product_id: string | null; c: number }>(
 		db,
 		`SELECT product_id, COUNT(*) c FROM subscriptions
@@ -338,7 +429,11 @@ async function getProductMix(db: D1Database, f: Filters): Promise<NameValue[]> {
 }
 
 async function getStatusBreakdown(db: D1Database, f: Filters): Promise<NameValue[]> {
-	const { sql, params } = applyFilters(f, { env: "environment", product: "product_id" });
+	const { sql, params } = applyFilters(f, {
+		env: "environment",
+		product: "product_id",
+		platform: "platform",
+	});
 	const rows = await queryAll<{ status: string | null; c: number }>(
 		db,
 		`SELECT status, COUNT(*) c FROM subscriptions
@@ -360,6 +455,7 @@ async function getNotificationsPage(
 		env: "n.environment",
 		product: "t.product_id",
 		date: "n.received_at",
+		platform: "n.platform",
 	});
 	const totalRow = await queryFirst<{ c: number }>(
 		db,
@@ -376,7 +472,7 @@ async function getNotificationsPage(
 	const raw = await queryAll<NotificationJoinRow>(
 		db,
 		`SELECT n.notification_uuid, n.notification_type, n.subtype,
-		        n.original_transaction_id, n.transaction_id, n.environment, n.received_at,
+		        n.original_transaction_id, n.transaction_id, n.environment, n.received_at, n.platform,
 		        t.transaction_id AS t_id, t.product_id AS t_product_id, t.type AS t_type,
 		        t.offer_type AS t_offer_type, t.price_millis AS t_price_millis,
 		        t.currency AS t_currency, t.purchase_date AS t_purchase_date,
@@ -397,6 +493,7 @@ async function getNotificationsPage(
 		transaction_id: r.transaction_id,
 		environment: r.environment,
 		received_at: r.received_at,
+		platform: r.platform,
 		txn: r.t_id
 			? {
 					transaction_id: r.t_id,
@@ -425,6 +522,7 @@ async function getTransactionsPage(
 		env: "environment",
 		product: "product_id",
 		date: "purchase_date",
+		platform: "platform",
 	});
 	const totalRow = await queryFirst<{ c: number }>(
 		db,
@@ -437,7 +535,7 @@ async function getTransactionsPage(
 		db,
 		`SELECT transaction_id, original_transaction_id, product_id, type, offer_type,
 		        offer_identifier, storefront, price_millis, currency, environment, purchase_date,
-		        revocation_date, notification_type
+		        revocation_date, notification_type, platform
 		 FROM transactions
 		 WHERE 1 = 1${sql}
 		 ORDER BY created_at DESC LIMIT ? OFFSET ?`,
@@ -447,11 +545,15 @@ async function getTransactionsPage(
 }
 
 async function getExpiringSoon(db: D1Database, f: Filters): Promise<ExpiringRow[]> {
-	const { sql, params } = applyFilters(f, { env: "environment", product: "product_id" });
+	const { sql, params } = applyFilters(f, {
+		env: "environment",
+		product: "product_id",
+		platform: "platform",
+	});
 	return queryAll<ExpiringRow>(
 		db,
 		`SELECT original_transaction_id, product_id, expires_date,
-		        auto_renew_status, environment, price_millis, currency
+		        auto_renew_status, environment, price_millis, currency, platform
 		 FROM subscriptions
 		 WHERE status = 'active' AND is_lifetime = 0
 		   AND expires_date IS NOT NULL AND expires_date > ?${sql}

--- a/apps/web/src/lib/dashboard/types.ts
+++ b/apps/web/src/lib/dashboard/types.ts
@@ -5,6 +5,21 @@ export interface Filters {
 	productId: string | null;
 	/** Trailing window in days, or null for all time. */
 	days: number | null;
+	/** Single store scope ("apple" / "play"), or null for both. */
+	platform: string | null;
+}
+
+/** 账本里的平台维度（migrations/0007 起），按展示顺序。 */
+export const PLATFORM_ORDER = ["apple", "play"] as const;
+
+export const PLATFORM_LABEL: Record<string, string> = {
+	apple: "App Store",
+	play: "Google Play",
+};
+
+export function platformLabel(id?: string | null): string {
+	if (!id) return "—";
+	return PLATFORM_LABEL[id] ?? id;
 }
 
 /** The dashboard only ever shows Production data; Sandbox is filtered out. */
@@ -49,6 +64,30 @@ export const NOTIFICATION_LABEL: Record<string, string> = {
 	REVOKE: "权益撤销",
 	PRICE_INCREASE: "涨价",
 	RENEWAL_EXTENDED: "续订延长",
+
+	// Google Play RTDN（数字枚举已在入库时翻成串，见 lib/play/types.ts）
+	SUBSCRIPTION_PURCHASED: "订阅开始",
+	SUBSCRIPTION_RENEWED: "续订成功",
+	SUBSCRIPTION_RECOVERED: "保留期恢复",
+	SUBSCRIPTION_RESTARTED: "订阅重启",
+	SUBSCRIPTION_CANCELED: "关闭自动续订",
+	SUBSCRIPTION_ON_HOLD: "进入账号保留期",
+	SUBSCRIPTION_IN_GRACE_PERIOD: "进入宽限期",
+	SUBSCRIPTION_PAUSED: "订阅暂停",
+	SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED: "暂停计划变更",
+	SUBSCRIPTION_DEFERRED: "续订延长",
+	SUBSCRIPTION_REVOKED: "权益撤销",
+	SUBSCRIPTION_EXPIRED: "订阅过期",
+	SUBSCRIPTION_PRICE_CHANGE_CONFIRMED: "涨价已确认",
+	SUBSCRIPTION_PRICE_CHANGE_UPDATED: "价格变更更新",
+	SUBSCRIPTION_ITEMS_CHANGED: "套餐内容变更",
+	SUBSCRIPTION_CANCELLATION_SCHEDULED: "已排期取消",
+	SUBSCRIPTION_PENDING_PURCHASE_CANCELED: "待处理购买取消",
+	SUBSCRIPTION_PRICE_STEP_UP_CONSENT_UPDATED: "涨价同意期变更",
+	ONE_TIME_PRODUCT_PURCHASED: "一次性购买",
+	ONE_TIME_PRODUCT_CANCELED: "一次性购买取消",
+	VOIDED_PURCHASE: "退款",
+	PLAY_TEST: "测试通知",
 };
 
 export function notificationLabel(type?: string | null): string {
@@ -75,6 +114,12 @@ export const SUBTYPE_LABEL: Record<string, string> = {
 	ACCEPTED: "已接受",
 	PENDING: "待处理",
 	UNREPORTED: "未上报",
+
+	// Google Play 退款通知的 subtype（productType_refundType 组合）
+	SUBSCRIPTION_FULL_REFUND: "订阅全额退款",
+	SUBSCRIPTION_PARTIAL_REFUND: "订阅部分退款",
+	ONE_TIME_FULL_REFUND: "买断全额退款",
+	ONE_TIME_PARTIAL_REFUND: "买断部分退款",
 };
 
 /** Returns a labeled subtype, or null when there is no subtype. */
@@ -123,18 +168,38 @@ export function revocationReasonLabel(reason?: number | null): string | null {
 
 export type BadgeTone = "muted" | "accent" | "positive" | "negative" | "info";
 
+const POSITIVE_TYPES = new Set([
+	// Apple
+	"SUBSCRIBED",
+	"DID_RENEW",
+	"ONE_TIME_CHARGE",
+	// Play
+	"SUBSCRIPTION_PURCHASED",
+	"SUBSCRIPTION_RENEWED",
+	"SUBSCRIPTION_RECOVERED",
+	"SUBSCRIPTION_RESTARTED",
+	"ONE_TIME_PRODUCT_PURCHASED",
+]);
+
+const NEGATIVE_TYPES = new Set([
+	// Apple
+	"REVOKE",
+	"EXPIRED",
+	"DID_FAIL_TO_RENEW",
+	// Play
+	"VOIDED_PURCHASE",
+	"SUBSCRIPTION_REVOKED",
+	"SUBSCRIPTION_EXPIRED",
+	"SUBSCRIPTION_ON_HOLD",
+	"ONE_TIME_PRODUCT_CANCELED",
+	"SUBSCRIPTION_PENDING_PURCHASE_CANCELED",
+]);
+
 /** Shared tone for a notification type, used by tables and the detail modal. */
 export function notificationTone(type: string): BadgeTone {
 	if (type === "REFUND_DECLINED" || type === "REFUND_REVERSED") return "info";
-	if (
-		type.startsWith("REFUND") ||
-		type === "REVOKE" ||
-		type === "EXPIRED" ||
-		type === "DID_FAIL_TO_RENEW"
-	) {
-		return "negative";
-	}
-	if (type === "SUBSCRIBED" || type === "DID_RENEW" || type === "ONE_TIME_CHARGE") return "positive";
+	if (type.startsWith("REFUND") || NEGATIVE_TYPES.has(type)) return "negative";
+	if (POSITIVE_TYPES.has(type)) return "positive";
 	return "info";
 }
 
@@ -161,7 +226,13 @@ export function parseFilters(sp: RawSearchParams): Filters {
 	const match = RANGE_OPTIONS.find((o) => o.value === daysRaw);
 	const days = match ? match.days : null;
 
-	return { productId, days };
+	const platformRaw = getParam(sp, "platform");
+	const platform =
+		platformRaw && (PLATFORM_ORDER as readonly string[]).includes(platformRaw)
+			? platformRaw
+			: null;
+
+	return { productId, days, platform };
 }
 
 /** Parse a 1-based page number from a search param (defaults to 1). */

--- a/apps/web/src/lib/play/api.ts
+++ b/apps/web/src/lib/play/api.ts
@@ -92,6 +92,19 @@ async function getAccessToken(sa: ServiceAccount): Promise<string> {
 	return json.access_token;
 }
 
+/**
+ * 哪些 HTTP 状态值得让 Pub/Sub 重投递。
+ *
+ * 429 / 5xx 是常规瞬时故障。401 / 403（insufficient permissions）也算——Play Console
+ * 里给服务账号加「查看财务数据」/「管理订单和订阅」后，各 API 面的生效时间不同步，
+ * 官方口径最长 24 小时。这个窗口里的真实购买若按「不可重试」处理，就会永久落成一笔
+ * 没有金额的交易；对账本来说，那比重试噪音糟得多。权限一生效，重投递即自动补齐金额；
+ * 真的配错了，也只是在 7 天投递窗口内退避重试后进死信，不会静默丢数据。
+ */
+export function isRetryableStatus(status: number): boolean {
+	return status === 401 || status === 403 || status === 429 || status >= 500;
+}
+
 async function apiGet<T>(sa: ServiceAccount, path: string): Promise<T | null> {
 	const token = await getAccessToken(sa);
 	const res = await fetch(`${API_BASE}/${path}`, {
@@ -100,8 +113,11 @@ async function apiGet<T>(sa: ServiceAccount, path: string): Promise<T | null> {
 	if (res.status === 404 || res.status === 410) return null; // token/订单不存在：不重试
 	if (!res.ok) {
 		const body = await res.text();
-		const retryable = res.status === 429 || res.status >= 500;
-		throw new PlayApiError(`GET ${path} -> ${res.status}: ${body.slice(0, 200)}`, res.status, retryable);
+		throw new PlayApiError(
+			`GET ${path} -> ${res.status}: ${body.slice(0, 200)}`,
+			res.status,
+			isRetryableStatus(res.status),
+		);
 	}
 	return (await res.json()) as T;
 }

--- a/apps/web/src/lib/play/api.ts
+++ b/apps/web/src/lib/play/api.ts
@@ -1,0 +1,138 @@
+// Google Play Developer API 客户端（富化 RTDN 用）。
+//
+// RTDN 只给 purchaseToken：金额 / 到期 / 地区 / 退款状态都得回查这里。
+// 鉴权是「服务账号自签 JWT -> access token」，因此必须保管一份私钥
+// （Worker secret PLAY_SA_JSON = 服务账号 JSON 全文）。这是 Play 侧唯一可行的路子，
+// 与 Apple 的「纯验签、零密钥」不同 —— 未配置时全部降级为「只记事件、不记金额」。
+//
+// 用到的三个端点：
+//   purchases.subscriptionsv2.get  订阅状态 / 到期 / 续订开关 / 地区 / latestOrderId
+//   purchases.products.get         一次性购买（买断）的购买状态与时间
+//   orders.get                     订单金额：实付总额、税、开发者到手金额、买家国家
+
+import { importPKCS8, SignJWT } from "jose";
+import type { PlayOrder, ProductPurchaseV1, SubscriptionPurchaseV2 } from "./types";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const API_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3/applications";
+const SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+
+export class PlayApiError extends Error {
+	constructor(
+		message: string,
+		readonly status: number,
+		/** true = 值得让 Pub/Sub 重投递（限流 / 服务端故障 / 网络）。 */
+		readonly retryable: boolean,
+	) {
+		super(message);
+		this.name = "PlayApiError";
+	}
+}
+
+interface ServiceAccount {
+	client_email: string;
+	private_key: string;
+}
+
+/** 解析 PLAY_SA_JSON；未配置或格式不对返回 null（调用方降级）。 */
+export function parseServiceAccount(raw?: string | null): ServiceAccount | null {
+	if (!raw?.trim()) return null;
+	try {
+		const sa = JSON.parse(raw) as Partial<ServiceAccount>;
+		if (!sa.client_email || !sa.private_key) return null;
+		// wrangler secret 经命令行传入时换行常被写成字面量 \n，这里统一还原。
+		return { client_email: sa.client_email, private_key: sa.private_key.replace(/\\n/g, "\n") };
+	} catch {
+		return null;
+	}
+}
+
+// access token 按 isolate 缓存（有效期 1h，提前 60s 过期）。
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+async function getAccessToken(sa: ServiceAccount): Promise<string> {
+	const cached = tokenCache.get(sa.client_email);
+	if (cached && cached.expiresAt > Date.now()) return cached.token;
+
+	const now = Math.floor(Date.now() / 1000);
+	let assertion: string;
+	try {
+		const key = await importPKCS8(sa.private_key, "RS256");
+		assertion = await new SignJWT({ scope: SCOPE })
+			.setProtectedHeader({ alg: "RS256", typ: "JWT" })
+			.setIssuer(sa.client_email)
+			.setAudience(TOKEN_URL)
+			.setIssuedAt(now)
+			.setExpirationTime(now + 3600)
+			.sign(key);
+	} catch (err) {
+		// 私钥坏了不是瞬时故障，重投递也修不好。
+		throw new PlayApiError(`bad service account key: ${(err as Error).message}`, 0, false);
+	}
+
+	const res = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: { "content-type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			assertion,
+		}),
+	});
+	if (!res.ok) {
+		const body = await res.text();
+		throw new PlayApiError(`token exchange failed: ${body.slice(0, 200)}`, res.status, res.status >= 500);
+	}
+	const json = (await res.json()) as { access_token?: string; expires_in?: number };
+	if (!json.access_token) throw new PlayApiError("token exchange returned no token", 500, true);
+
+	tokenCache.set(sa.client_email, {
+		token: json.access_token,
+		expiresAt: Date.now() + ((json.expires_in ?? 3600) - 60) * 1000,
+	});
+	return json.access_token;
+}
+
+async function apiGet<T>(sa: ServiceAccount, path: string): Promise<T | null> {
+	const token = await getAccessToken(sa);
+	const res = await fetch(`${API_BASE}/${path}`, {
+		headers: { authorization: `Bearer ${token}` },
+	});
+	if (res.status === 404 || res.status === 410) return null; // token/订单不存在：不重试
+	if (!res.ok) {
+		const body = await res.text();
+		const retryable = res.status === 429 || res.status >= 500;
+		throw new PlayApiError(`GET ${path} -> ${res.status}: ${body.slice(0, 200)}`, res.status, retryable);
+	}
+	return (await res.json()) as T;
+}
+
+export class PlayApi {
+	constructor(
+		private readonly sa: ServiceAccount,
+		private readonly packageName: string,
+	) {}
+
+	/** 未配置服务账号时返回 null，调用方据此降级。 */
+	static from(rawSecret: string | undefined | null, packageName: string): PlayApi | null {
+		const sa = parseServiceAccount(rawSecret);
+		return sa ? new PlayApi(sa, packageName) : null;
+	}
+
+	getSubscription(purchaseToken: string): Promise<SubscriptionPurchaseV2 | null> {
+		return apiGet<SubscriptionPurchaseV2>(
+			this.sa,
+			`${this.packageName}/purchases/subscriptionsv2/tokens/${encodeURIComponent(purchaseToken)}`,
+		);
+	}
+
+	getProduct(productId: string, purchaseToken: string): Promise<ProductPurchaseV1 | null> {
+		return apiGet<ProductPurchaseV1>(
+			this.sa,
+			`${this.packageName}/purchases/products/${encodeURIComponent(productId)}/tokens/${encodeURIComponent(purchaseToken)}`,
+		);
+	}
+
+	getOrder(orderId: string): Promise<PlayOrder | null> {
+		return apiGet<PlayOrder>(this.sa, `${this.packageName}/orders/${encodeURIComponent(orderId)}`);
+	}
+}

--- a/apps/web/src/lib/play/enrich.ts
+++ b/apps/web/src/lib/play/enrich.ts
@@ -1,0 +1,53 @@
+// 用 Play Developer API 把一条 RTDN 补全成「有金额、有状态」的事件。
+//
+// RTDN 本身只有 purchaseToken + 类型，所以每条通知按种类回查 1～2 个接口：
+//   订阅   -> subscriptionsv2.get（状态/到期/续订开关/latestOrderId）+ orders.get（金额）
+//   买断   -> products.get（购买状态/时间/orderId）+ orders.get（金额）
+//   退款   -> orders.get（金额 + 退款状态）+ 视类型补订阅或买断详情
+// 未配置服务账号（PlayApi 为 null）时全部跳过，返回空富化。
+
+import type { PlayApi } from "./api";
+import { purchaseTokenOf } from "./logic";
+import type { DecodedPlayNotification, PlayEnrichment } from "./types";
+
+export async function enrichNotification(
+	api: PlayApi | null,
+	decoded: DecodedPlayNotification,
+): Promise<PlayEnrichment> {
+	const token = purchaseTokenOf(decoded);
+	if (!api || !token) return {};
+
+	const n = decoded.notification;
+	const out: PlayEnrichment = {};
+
+	if (n.subscriptionNotification) {
+		out.subscription = (await api.getSubscription(token)) ?? undefined;
+		const orderId = out.subscription?.latestOrderId;
+		if (orderId) out.order = (await api.getOrder(orderId)) ?? undefined;
+		return out;
+	}
+
+	if (n.oneTimeProductNotification) {
+		const sku = n.oneTimeProductNotification.sku;
+		if (sku) out.product = (await api.getProduct(sku, token)) ?? undefined;
+		const orderId = out.product?.orderId;
+		if (orderId) out.order = (await api.getOrder(orderId)) ?? undefined;
+		return out;
+	}
+
+	if (n.voidedPurchaseNotification) {
+		const v = n.voidedPurchaseNotification;
+		if (v.orderId) out.order = (await api.getOrder(v.orderId)) ?? undefined;
+		if (v.productType === 1) {
+			// 订阅退款：状态接口还能查到这条被撤销的订阅。
+			out.subscription = (await api.getSubscription(token)) ?? undefined;
+		} else if (v.productType === 2) {
+			// 买断退款：RTDN 不带 sku，从订单行反查商品后再取购买详情。
+			const productId = out.order?.lineItems?.[0]?.productId;
+			if (productId) out.product = (await api.getProduct(productId, token)) ?? undefined;
+		}
+		return out;
+	}
+
+	return out;
+}

--- a/apps/web/src/lib/play/logic.ts
+++ b/apps/web/src/lib/play/logic.ts
@@ -1,0 +1,307 @@
+// RTDN（+ Developer API 富化结果）-> 统一账本三表的行。纯函数，可单测。
+//
+// 字段对齐（左 Apple / 右 Play）：
+//   notification_uuid       = Pub/Sub messageId
+//   original_transaction_id = purchaseToken（订阅续期内不变，升降级会换发）
+//   transaction_id          = orderId（每期续订一个新 orderId）
+//   signed_date             = eventTimeMillis（同时是乱序保护水位）
+//   price_millis            = 订单实付总额（含税），与 Apple 的 transaction.price 同口径
+
+import {
+	moneyToMillis,
+	ONE_TIME_NOTIFICATION_TYPE,
+	PLAY_TEST_NOTIFICATION_TYPE,
+	rfc3339ToMillis,
+	SUBSCRIPTION_NOTIFICATION_TYPE,
+	toMillis,
+	VOIDED_PURCHASE_TYPE,
+	type DecodedPlayNotification,
+	type PlayEnrichment,
+} from "./types";
+
+export interface PlayNotificationRow {
+	notificationUuid: string;
+	notificationType: string;
+	subtype: string | null;
+	purchaseToken: string | null;
+	orderId: string | null;
+	packageName: string | null;
+	environment: string;
+	eventTime: number;
+	receivedAt: number;
+	raw: string;
+}
+
+export interface PlayTransactionRow {
+	orderId: string;
+	purchaseToken: string;
+	productId: string | null;
+	/** 与 Apple 的 transactions.type 同列：自动续订 / 买断 */
+	type: string | null;
+	purchaseDate: number | null;
+	expiresDate: number | null;
+	priceMillis: number | null;
+	devRevenueMillis: number | null;
+	currency: string | null;
+	storefront: string | null;
+	offerIdentifier: string | null;
+	revocationDate: number | null;
+	environment: string;
+}
+
+export interface PlaySubscriptionRow {
+	purchaseToken: string;
+	productId: string | null;
+	status: string;
+	autoRenewStatus: number | null;
+	linkedToken: string | null;
+	environment: string;
+	purchaseDate: number | null;
+	expiresDate: number | null;
+	isLifetime: boolean;
+	priceMillis: number | null;
+	currency: string | null;
+}
+
+export interface PlayLedgerRows {
+	notification: PlayNotificationRow;
+	transaction: PlayTransactionRow | null;
+	subscription: PlaySubscriptionRow | null;
+}
+
+const TX_TYPE_SUBSCRIPTION = "Auto-Renewable Subscription";
+const TX_TYPE_ONE_TIME = "Non-Consumable";
+
+/** Play 订阅状态 -> 账本 status（与 Apple 侧同一套取值）。 */
+export function mapSubscriptionState(state?: string, expiresDate?: number | null): string | null {
+	switch (state) {
+		case "SUBSCRIPTION_STATE_ACTIVE":
+			return "active";
+		case "SUBSCRIPTION_STATE_CANCELED":
+			// Play 的 canceled = 已关自动续订但仍在有效期内，到期后才失去权益。
+			return expiresDate != null && expiresDate <= Date.now() ? "expired" : "active";
+		case "SUBSCRIPTION_STATE_IN_GRACE_PERIOD":
+			return "grace";
+		case "SUBSCRIPTION_STATE_ON_HOLD":
+			return "billing_retry";
+		case "SUBSCRIPTION_STATE_PAUSED":
+			return "paused";
+		case "SUBSCRIPTION_STATE_EXPIRED":
+		case "SUBSCRIPTION_STATE_PENDING_PURCHASE_CANCELED":
+			return "expired";
+		case "SUBSCRIPTION_STATE_PENDING":
+			return "pending";
+		default:
+			return null;
+	}
+}
+
+/** 拿不到订阅详情时的兜底：只按通知类型推状态。 */
+export function statusFromNotificationType(type: string): string {
+	switch (type) {
+		case "SUBSCRIPTION_PURCHASED":
+		case "SUBSCRIPTION_RENEWED":
+		case "SUBSCRIPTION_RECOVERED":
+		case "SUBSCRIPTION_RESTARTED":
+		case "SUBSCRIPTION_DEFERRED":
+		case "SUBSCRIPTION_CANCELED": // 仍在有效期内，只是关了续订
+			return "active";
+		case "SUBSCRIPTION_IN_GRACE_PERIOD":
+			return "grace";
+		case "SUBSCRIPTION_ON_HOLD":
+			return "billing_retry";
+		case "SUBSCRIPTION_PAUSED":
+			return "paused";
+		case "SUBSCRIPTION_EXPIRED":
+		case "SUBSCRIPTION_PENDING_PURCHASE_CANCELED":
+			return "expired";
+		case "SUBSCRIPTION_REVOKED":
+			return "revoked";
+		default:
+			return "active";
+	}
+}
+
+/** 一条通知的名字（写进 notifications.notification_type，与 Apple 类型同列不冲突）。 */
+export function notificationTypeName(decoded: DecodedPlayNotification): string {
+	const n = decoded.notification;
+	if (n.subscriptionNotification) {
+		const t = n.subscriptionNotification.notificationType ?? 0;
+		return SUBSCRIPTION_NOTIFICATION_TYPE[t] ?? `SUBSCRIPTION_${t}`;
+	}
+	if (n.oneTimeProductNotification) {
+		const t = n.oneTimeProductNotification.notificationType ?? 0;
+		return ONE_TIME_NOTIFICATION_TYPE[t] ?? `ONE_TIME_PRODUCT_${t}`;
+	}
+	if (n.voidedPurchaseNotification) return VOIDED_PURCHASE_TYPE;
+	if (n.testNotification) return PLAY_TEST_NOTIFICATION_TYPE;
+	return "PLAY_UNKNOWN";
+}
+
+/** 通知涉及的 purchaseToken（幂等 / 关联用）。 */
+export function purchaseTokenOf(decoded: DecodedPlayNotification): string | null {
+	const n = decoded.notification;
+	return (
+		n.subscriptionNotification?.purchaseToken ??
+		n.oneTimeProductNotification?.purchaseToken ??
+		n.voidedPurchaseNotification?.purchaseToken ??
+		null
+	);
+}
+
+const VOID_PRODUCT_TYPE: Record<number, string> = { 1: "SUBSCRIPTION", 2: "ONE_TIME" };
+const VOID_REFUND_TYPE: Record<number, string> = { 1: "FULL_REFUND", 2: "PARTIAL_REFUND" };
+
+function subtypeOf(decoded: DecodedPlayNotification): string | null {
+	const v = decoded.notification.voidedPurchaseNotification;
+	if (!v) return null;
+	const parts = [
+		v.productType != null ? VOID_PRODUCT_TYPE[v.productType] : null,
+		v.refundType != null ? VOID_REFUND_TYPE[v.refundType] : null,
+	].filter(Boolean);
+	return parts.length ? parts.join("_") : null;
+}
+
+/**
+ * 是否测试购买（license tester）—— 与 Apple 的 Sandbox 同义，看板默认排除。
+ * products.get 的 purchaseType：0=Test、1=Promo（真实但免费）、2=Rewarded，
+ * 只有 0 算测试。未富化时无从判断，一律按 Production 计。
+ */
+function environmentOf(e: PlayEnrichment): string {
+	if (e.subscription?.testPurchase) return "Sandbox";
+	if (e.product?.purchaseType === 0) return "Sandbox";
+	return "Production";
+}
+
+/** 富化后的完整映射。enrichment 为空时只产出通知行 + 尽可能的状态行。 */
+export function buildLedgerRows(
+	decoded: DecodedPlayNotification,
+	enrichment: PlayEnrichment,
+	receivedAt: number = Date.now(),
+): PlayLedgerRows {
+	const n = decoded.notification;
+	const type = notificationTypeName(decoded);
+	const token = purchaseTokenOf(decoded);
+	const environment = environmentOf(enrichment);
+	const eventTime = decoded.eventTimeMillis;
+
+	const order = enrichment.order;
+	const orderId =
+		n.voidedPurchaseNotification?.orderId ??
+		order?.orderId ??
+		enrichment.subscription?.latestOrderId ??
+		enrichment.product?.orderId ??
+		null;
+
+	const notification: PlayNotificationRow = {
+		notificationUuid: decoded.messageId,
+		notificationType: type,
+		subtype: subtypeOf(decoded),
+		purchaseToken: token,
+		orderId,
+		packageName: n.packageName ?? null,
+		environment,
+		eventTime,
+		receivedAt,
+		// 审计存档：原始通知 + 富化结果，便于日后回填（与 Apple 侧 raw_payload 同用途）。
+		raw: JSON.stringify({ notification: n, enrichment }),
+	};
+
+	const money = order?.total ?? enrichment.subscription?.lineItems?.[0]?.autoRenewingPlan?.recurringPrice;
+	const currency = money?.currencyCode ?? null;
+	const priceMillis = moneyToMillis(money);
+	const devRevenueMillis = moneyToMillis(order?.developerRevenueInBuyerCurrency);
+	const storefront =
+		order?.buyerAddress?.buyerCountry ??
+		enrichment.subscription?.regionCode ??
+		enrichment.product?.regionCode ??
+		null;
+
+	const isVoided = Boolean(n.voidedPurchaseNotification);
+	const isOneTime =
+		Boolean(n.oneTimeProductNotification) ||
+		n.voidedPurchaseNotification?.productType === 2 ||
+		(!n.subscriptionNotification && Boolean(enrichment.product));
+
+	const line = enrichment.subscription?.lineItems?.[0];
+	const productId =
+		line?.productId ??
+		n.oneTimeProductNotification?.sku ??
+		enrichment.product?.productId ??
+		n.subscriptionNotification?.subscriptionId ??
+		order?.lineItems?.[0]?.productId ??
+		null;
+
+	const expiresDate = rfc3339ToMillis(line?.expiryTime);
+	const purchaseDate =
+		rfc3339ToMillis(order?.createTime) ??
+		toMillis(enrichment.product?.purchaseTimeMillis) ??
+		rfc3339ToMillis(enrichment.subscription?.startTime) ??
+		(isVoided ? null : eventTime);
+
+	// 财务流水行：必须有 orderId 才能落库（它是主键）。拿不到（没配服务账号 /
+	// 订阅通知未富化）就只更新状态，不造假流水。
+	const transaction: PlayTransactionRow | null =
+		orderId && token
+			? {
+					orderId,
+					purchaseToken: token,
+					productId,
+					type: isOneTime ? TX_TYPE_ONE_TIME : TX_TYPE_SUBSCRIPTION,
+					purchaseDate,
+					expiresDate,
+					priceMillis,
+					devRevenueMillis,
+					currency,
+					storefront,
+					offerIdentifier: line?.offerDetails?.offerId ?? line?.offerDetails?.basePlanId ?? null,
+					revocationDate: isVoided ? eventTime : null,
+					environment,
+				}
+			: null;
+
+	// 权益状态行
+	let subscription: PlaySubscriptionRow | null = null;
+	if (token && !n.testNotification) {
+		let status: string;
+		if (isVoided) {
+			status = "refunded";
+		} else if (isOneTime) {
+			const state = enrichment.product?.purchaseState;
+			status =
+				type === "ONE_TIME_PRODUCT_CANCELED" || state === 1
+					? "expired"
+					: state === 2
+						? "pending"
+						: "active";
+		} else {
+			status =
+				mapSubscriptionState(enrichment.subscription?.subscriptionState, expiresDate) ??
+				statusFromNotificationType(type);
+		}
+
+		const autoRenew = line?.autoRenewingPlan
+			? line.autoRenewingPlan.autoRenewEnabled === true
+				? 1
+				: 0
+			: type === "SUBSCRIPTION_CANCELED"
+				? 0
+				: null;
+
+		subscription = {
+			purchaseToken: token,
+			productId,
+			status,
+			autoRenewStatus: isOneTime ? null : autoRenew,
+			linkedToken: enrichment.subscription?.linkedPurchaseToken ?? null,
+			environment,
+			purchaseDate,
+			expiresDate: isOneTime ? null : expiresDate,
+			isLifetime: isOneTime,
+			priceMillis,
+			currency,
+		};
+	}
+
+	return { notification, transaction, subscription };
+}

--- a/apps/web/src/lib/play/notify.ts
+++ b/apps/web/src/lib/play/notify.ts
@@ -1,0 +1,120 @@
+// 把一条 Play 通知转成 Bark 推送（与 lib/appstore/notify.ts 同款，标题带 ▶ 区分平台）。
+// buildPlayBarkMessage 是纯函数（可单测）；notifyPlayEvent 负责发送（无 key 则跳过）。
+
+import { type BarkPush, sendBark } from "../notify/bark";
+import type { PlayLedgerRows } from "./logic";
+
+// 「入账」类型：真正有钱进账的事件。SUBSCRIPTION_CANCELED（关自动续订）、
+// SUBSCRIPTION_EXPIRED、VOIDED_PURCHASE 等都不算。
+const REVENUE_TYPES = new Set<string>([
+	"SUBSCRIPTION_PURCHASED",
+	"SUBSCRIPTION_RENEWED",
+	"SUBSCRIPTION_RECOVERED",
+	"SUBSCRIPTION_RESTARTED",
+	"ONE_TIME_PRODUCT_PURCHASED",
+]);
+
+const TYPE_LABEL: Record<string, string> = {
+	SUBSCRIPTION_PURCHASED: "🎉 新订阅",
+	SUBSCRIPTION_RENEWED: "🔁 订阅续期",
+	SUBSCRIPTION_RECOVERED: "💚 账号保留期恢复",
+	SUBSCRIPTION_RESTARTED: "↩️ 订阅重启",
+	SUBSCRIPTION_CANCELED: "⚙️ 已关闭自动续订",
+	SUBSCRIPTION_ON_HOLD: "⏸️ 进入账号保留期",
+	SUBSCRIPTION_IN_GRACE_PERIOD: "⚠️ 进入宽限期",
+	SUBSCRIPTION_PAUSED: "⏯️ 订阅已暂停",
+	SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED: "📅 暂停计划变更",
+	SUBSCRIPTION_DEFERRED: "📅 续订已延长",
+	SUBSCRIPTION_REVOKED: "🔕 权益撤销",
+	SUBSCRIPTION_EXPIRED: "📕 订阅到期",
+	SUBSCRIPTION_PRICE_CHANGE_CONFIRMED: "💱 涨价已确认",
+	SUBSCRIPTION_PRICE_CHANGE_UPDATED: "💱 价格变更更新",
+	SUBSCRIPTION_ITEMS_CHANGED: "🔀 套餐内容变更",
+	SUBSCRIPTION_CANCELLATION_SCHEDULED: "🗓️ 已排期取消",
+	SUBSCRIPTION_PENDING_PURCHASE_CANCELED: "🚫 待处理购买取消",
+	ONE_TIME_PRODUCT_PURCHASED: "💰 买断购买",
+	ONE_TIME_PRODUCT_CANCELED: "🚫 买断购买取消",
+	VOIDED_PURCHASE: "↩️ 退款",
+	PLAY_TEST: "🧪 测试通知",
+};
+
+const PRODUCT_LABEL: Record<string, string> = {
+	"jiamin.chen.orange_cloud.pro.monthly": "Pro 月度",
+	"jiamin.chen.orange_cloud.pro.yearly": "Pro 年度",
+	"jiamin.chen.orange_cloud.pro.lifetime": "Pro 买断",
+};
+
+function formatPrice(millis: number | null, currency: string | null): string | null {
+	if (millis == null || !currency) return null;
+	return `${(millis / 1000).toFixed(2)} ${currency}`;
+}
+
+export interface BuiltPlayMessage {
+	title: string;
+	body: string;
+	group: string;
+	isSandbox: boolean;
+	level: NonNullable<BarkPush["level"]>;
+}
+
+/** 账本行 -> Bark 标题/正文（纯函数）。 */
+export function buildPlayBarkMessage(rows: PlayLedgerRows): BuiltPlayMessage {
+	const { notification: nf, transaction: tx, subscription: sub } = rows;
+	const isSandbox = nf.environment === "Sandbox";
+	const label = TYPE_LABEL[nf.notificationType] ?? `📣 ${nf.notificationType}`;
+	// ▶ = Play，与 Apple 侧同组推送并列时一眼分平台。
+	const title = `${isSandbox ? "🧪 " : ""}▶ ${label}`;
+
+	const productId = tx?.productId ?? sub?.productId ?? null;
+	const priceMillis = tx?.priceMillis ?? sub?.priceMillis ?? null;
+	const currency = tx?.currency ?? sub?.currency ?? null;
+
+	const parts: string[] = [];
+	if (nf.subtype) parts.push(nf.subtype);
+	if (productId) parts.push(PRODUCT_LABEL[productId] ?? productId);
+	const price = formatPrice(priceMillis, currency);
+	if (price) parts.push(price);
+	if (tx?.storefront) parts.push(tx.storefront);
+	parts.push("Google Play");
+	if (isSandbox) parts.push("Sandbox");
+
+	const isPaidRevenue =
+		REVENUE_TYPES.has(nf.notificationType) && priceMillis != null && priceMillis > 0;
+	const level: BuiltPlayMessage["level"] = isSandbox
+		? "passive"
+		: isPaidRevenue
+			? "timeSensitive"
+			: "active";
+
+	return {
+		title,
+		body: parts.join(" · "),
+		// 与 Apple 侧同组，收入通知归拢在一起。
+		group: isSandbox ? "[🧪]Orange Cloud IAP" : "Orange Cloud IAP",
+		isSandbox,
+		level,
+	};
+}
+
+/** 构造并发送。无 deviceKey（未配置）则静默跳过；失败仅记日志、不抛。 */
+export async function notifyPlayEvent(
+	deviceKey: string | undefined,
+	rows: PlayLedgerRows,
+	server?: string,
+): Promise<void> {
+	if (!deviceKey) return;
+	const msg = buildPlayBarkMessage(rows);
+	const push: BarkPush = {
+		title: msg.title,
+		body: msg.body,
+		group: msg.group,
+		icon: "https://o-c.do/icons/icon-64.png",
+		level: msg.level,
+		...(msg.level === "timeSensitive" ? { sound: "paymentsuccess" } : {}),
+	};
+	try {
+		await sendBark(deviceKey, push, server);
+	} catch (err) {
+		console.error("[play-notifications] bark push failed", err);
+	}
+}

--- a/apps/web/src/lib/play/play.test.ts
+++ b/apps/web/src/lib/play/play.test.ts
@@ -6,7 +6,7 @@ import { decodeEnvelope, PlayVerifyError, verifyPushRequest, verifyPushToken } f
 import { buildLedgerRows, mapSubscriptionState, notificationTypeName } from "./logic";
 import { buildPlayBarkMessage } from "./notify";
 import { moneyToMillis, type DeveloperNotification, type PlayEnrichment } from "./types";
-import { parseServiceAccount } from "./api";
+import { isRetryableStatus, parseServiceAccount } from "./api";
 
 const PACKAGE = "jiamin.chen.orangecloud";
 const AUDIENCE = "https://o-c.do/api/play/notifications";
@@ -346,6 +346,24 @@ describe("buildPlayBarkMessage", () => {
 			subscription: { ...SUB_ENRICHMENT.subscription, testPurchase: {} },
 		});
 		expect(buildPlayBarkMessage(rows).level).toBe("passive");
+	});
+});
+
+describe("isRetryableStatus", () => {
+	it("401 / 403 算可重试：Play Console 权限最长 24h 才生效，别把真实购买永久记成无金额", () => {
+		expect(isRetryableStatus(401)).toBe(true);
+		expect(isRetryableStatus(403)).toBe(true);
+	});
+
+	it("限流与服务端故障可重试", () => {
+		expect(isRetryableStatus(429)).toBe(true);
+		expect(isRetryableStatus(500)).toBe(true);
+		expect(isRetryableStatus(503)).toBe(true);
+	});
+
+	it("参数错这类不可重试（重投递也修不好）", () => {
+		expect(isRetryableStatus(400)).toBe(false);
+		expect(isRetryableStatus(404)).toBe(false);
 	});
 });
 

--- a/apps/web/src/lib/play/play.test.ts
+++ b/apps/web/src/lib/play/play.test.ts
@@ -1,0 +1,366 @@
+// Play RTDN 的验签、解码与账本映射（纯逻辑，不碰 D1 / 网络）。
+
+import { describe, expect, it } from "vitest";
+import { generateKeyPair, SignJWT, type JWTVerifyGetKey } from "jose";
+import { decodeEnvelope, PlayVerifyError, verifyPushRequest, verifyPushToken } from "./verify";
+import { buildLedgerRows, mapSubscriptionState, notificationTypeName } from "./logic";
+import { buildPlayBarkMessage } from "./notify";
+import { moneyToMillis, type DeveloperNotification, type PlayEnrichment } from "./types";
+import { parseServiceAccount } from "./api";
+
+const PACKAGE = "jiamin.chen.orangecloud";
+const AUDIENCE = "https://o-c.do/api/play/notifications";
+const SA_EMAIL = "play-rtdn@example.iam.gserviceaccount.com";
+
+function envelope(n: DeveloperNotification, messageId = "m1") {
+	return {
+		message: { data: btoa(JSON.stringify(n)), messageId, publishTime: "2026-08-01T00:00:00Z" },
+		subscription: "projects/p/subscriptions/s",
+	};
+}
+
+const SUB_PURCHASE: DeveloperNotification = {
+	version: "1.0",
+	packageName: PACKAGE,
+	eventTimeMillis: "1754006400000",
+	subscriptionNotification: { version: "1.0", notificationType: 4, purchaseToken: "tok-abc" },
+};
+
+// ---------------------------------------------------------------------------
+// OIDC 验签
+// ---------------------------------------------------------------------------
+
+async function signedToken(claims: Record<string, unknown>, key: CryptoKey) {
+	return new SignJWT(claims)
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuedAt()
+		.setExpirationTime("5m")
+		.sign(key);
+}
+
+describe("verifyPushToken", () => {
+	it("接受 Google 签发、aud / email 都对的 token", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("RS256");
+		const keys = (async () => publicKey) as unknown as JWTVerifyGetKey;
+		const token = await signedToken(
+			{ iss: "https://accounts.google.com", aud: AUDIENCE, email: SA_EMAIL, email_verified: true },
+			privateKey,
+		);
+		await expect(
+			verifyPushToken(`Bearer ${token}`, {
+				audience: AUDIENCE,
+				serviceAccountEmail: SA_EMAIL,
+				packageName: PACKAGE,
+				keys,
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("拒绝 audience 不符的 token", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("RS256");
+		const keys = (async () => publicKey) as unknown as JWTVerifyGetKey;
+		const token = await signedToken(
+			{ iss: "https://accounts.google.com", aud: "https://evil.example", email: SA_EMAIL },
+			privateKey,
+		);
+		await expect(
+			verifyPushToken(`Bearer ${token}`, { audience: AUDIENCE, packageName: PACKAGE, keys }),
+		).rejects.toBeInstanceOf(PlayVerifyError);
+	});
+
+	it("拒绝别的服务账号签发的 token", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("RS256");
+		const keys = (async () => publicKey) as unknown as JWTVerifyGetKey;
+		const token = await signedToken(
+			{
+				iss: "https://accounts.google.com",
+				aud: AUDIENCE,
+				email: "someone-else@example.com",
+				email_verified: true,
+			},
+			privateKey,
+		);
+		await expect(
+			verifyPushToken(`Bearer ${token}`, {
+				audience: AUDIENCE,
+				serviceAccountEmail: SA_EMAIL,
+				packageName: PACKAGE,
+				keys,
+			}),
+		).rejects.toThrow(/unexpected token subject/);
+	});
+
+	it("拒绝篡改过的 token（换密钥签名）", async () => {
+		const attacker = await generateKeyPair("RS256");
+		const google = await generateKeyPair("RS256");
+		const keys = (async () => google.publicKey) as unknown as JWTVerifyGetKey;
+		const token = await signedToken(
+			{ iss: "https://accounts.google.com", aud: AUDIENCE, email: SA_EMAIL },
+			attacker.privateKey,
+		);
+		await expect(
+			verifyPushToken(`Bearer ${token}`, { audience: AUDIENCE, packageName: PACKAGE, keys }),
+		).rejects.toBeInstanceOf(PlayVerifyError);
+	});
+
+	it("缺 Authorization 头直接拒", async () => {
+		await expect(
+			verifyPushToken(null, { audience: AUDIENCE, packageName: PACKAGE }),
+		).rejects.toThrow(/missing bearer token/);
+	});
+});
+
+describe("verifyPushRequest 包名校验", () => {
+	it("拒绝别的 App 的通知", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("RS256");
+		const keys = (async () => publicKey) as unknown as JWTVerifyGetKey;
+		const token = await signedToken(
+			{ iss: "https://accounts.google.com", aud: AUDIENCE, email: SA_EMAIL },
+			privateKey,
+		);
+		await expect(
+			verifyPushRequest(
+				`Bearer ${token}`,
+				envelope({ ...SUB_PURCHASE, packageName: "com.evil.app" }),
+				{ audience: AUDIENCE, packageName: PACKAGE, keys },
+			),
+		).rejects.toThrow(/unexpected packageName/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 信封解码
+// ---------------------------------------------------------------------------
+
+describe("decodeEnvelope", () => {
+	it("解出 messageId / eventTime / 通知体", () => {
+		const d = decodeEnvelope(envelope(SUB_PURCHASE, "msg-7"));
+		expect(d.messageId).toBe("msg-7");
+		expect(d.eventTimeMillis).toBe(1_754_006_400_000);
+		expect(d.notification.subscriptionNotification?.purchaseToken).toBe("tok-abc");
+	});
+
+	it("data 不是 base64 JSON 时报错", () => {
+		expect(() => decodeEnvelope({ message: { data: "!!!", messageId: "x" } })).toThrow(
+			PlayVerifyError,
+		);
+	});
+
+	it("缺 messageId 时报错（没有幂等键）", () => {
+		expect(() => decodeEnvelope({ message: { data: btoa("{}") } })).toThrow(/message id/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 金额与状态映射
+// ---------------------------------------------------------------------------
+
+describe("moneyToMillis", () => {
+	it("units + nanos -> milliunits", () => {
+		expect(moneyToMillis({ currencyCode: "USD", units: "19", nanos: 990_000_000 })).toBe(19_990);
+		expect(moneyToMillis({ currencyCode: "JPY", units: 1200, nanos: 0 })).toBe(1_200_000);
+		expect(moneyToMillis(null)).toBeNull();
+	});
+});
+
+describe("mapSubscriptionState", () => {
+	it("CANCELED 在有效期内仍算 active，过期后才 expired", () => {
+		const future = Date.now() + 86_400_000;
+		const past = Date.now() - 86_400_000;
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_CANCELED", future)).toBe("active");
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_CANCELED", past)).toBe("expired");
+	});
+
+	it("其余状态一一映射", () => {
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_ACTIVE")).toBe("active");
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_IN_GRACE_PERIOD")).toBe("grace");
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_ON_HOLD")).toBe("billing_retry");
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_PAUSED")).toBe("paused");
+		expect(mapSubscriptionState("SUBSCRIPTION_STATE_EXPIRED")).toBe("expired");
+		expect(mapSubscriptionState("WHAT_IS_THIS")).toBeNull();
+	});
+});
+
+describe("notificationTypeName", () => {
+	it("数字枚举翻成可读串", () => {
+		expect(notificationTypeName(decodeEnvelopeOf(SUB_PURCHASE))).toBe("SUBSCRIPTION_PURCHASED");
+		expect(
+			notificationTypeName(
+				decodeEnvelopeOf({
+					packageName: PACKAGE,
+					oneTimeProductNotification: { notificationType: 1, purchaseToken: "t", sku: "s" },
+				}),
+			),
+		).toBe("ONE_TIME_PRODUCT_PURCHASED");
+		expect(
+			notificationTypeName(decodeEnvelopeOf({ packageName: PACKAGE, testNotification: {} })),
+		).toBe("PLAY_TEST");
+	});
+});
+
+function decodeEnvelopeOf(n: DeveloperNotification) {
+	return decodeEnvelope(envelope(n));
+}
+
+// ---------------------------------------------------------------------------
+// 账本映射
+// ---------------------------------------------------------------------------
+
+const SUB_ENRICHMENT: PlayEnrichment = {
+	subscription: {
+		subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+		latestOrderId: "GPA.1111-2222-3333-44444",
+		regionCode: "US",
+		startTime: "2026-08-01T00:00:00Z",
+		lineItems: [
+			{
+				productId: "jiamin.chen.orange_cloud.pro.yearly",
+				expiryTime: "2027-08-01T00:00:00Z",
+				autoRenewingPlan: {
+					autoRenewEnabled: true,
+					recurringPrice: { currencyCode: "USD", units: "19", nanos: 990_000_000 },
+				},
+				offerDetails: { basePlanId: "yearly" },
+			},
+		],
+	},
+	order: {
+		orderId: "GPA.1111-2222-3333-44444",
+		state: "PROCESSED",
+		createTime: "2026-08-01T00:00:00Z",
+		total: { currencyCode: "USD", units: "19", nanos: 990_000_000 },
+		developerRevenueInBuyerCurrency: { currencyCode: "USD", units: "16", nanos: 990_000_000 },
+		buyerAddress: { buyerCountry: "US" },
+	},
+};
+
+describe("buildLedgerRows", () => {
+	it("订阅首购：交易 + 状态都齐，金额取订单实付", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf(SUB_PURCHASE), SUB_ENRICHMENT, 1_754_006_500_000);
+		expect(rows.notification.notificationType).toBe("SUBSCRIPTION_PURCHASED");
+		expect(rows.notification.environment).toBe("Production");
+		expect(rows.transaction).toMatchObject({
+			orderId: "GPA.1111-2222-3333-44444",
+			purchaseToken: "tok-abc",
+			productId: "jiamin.chen.orange_cloud.pro.yearly",
+			priceMillis: 19_990,
+			devRevenueMillis: 16_990,
+			currency: "USD",
+			storefront: "US",
+			type: "Auto-Renewable Subscription",
+			revocationDate: null,
+		});
+		expect(rows.subscription).toMatchObject({
+			purchaseToken: "tok-abc",
+			status: "active",
+			autoRenewStatus: 1,
+			isLifetime: false,
+		});
+		expect(rows.subscription?.expiresDate).toBe(Date.parse("2027-08-01T00:00:00Z"));
+	});
+
+	it("测试购买标成 Sandbox（看板会排除）", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf(SUB_PURCHASE), {
+			...SUB_ENRICHMENT,
+			subscription: { ...SUB_ENRICHMENT.subscription, testPurchase: {} },
+		});
+		expect(rows.notification.environment).toBe("Sandbox");
+		expect(rows.transaction?.environment).toBe("Sandbox");
+	});
+
+	it("没配服务账号（无富化）：只记事件与状态，不造假流水", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf(SUB_PURCHASE), {});
+		expect(rows.transaction).toBeNull();
+		expect(rows.subscription).toMatchObject({ status: "active", priceMillis: null });
+	});
+
+	it("买断：is_lifetime、无到期时间", () => {
+		const n: DeveloperNotification = {
+			packageName: PACKAGE,
+			eventTimeMillis: "1754006400000",
+			oneTimeProductNotification: {
+				notificationType: 1,
+				purchaseToken: "tok-life",
+				sku: "jiamin.chen.orange_cloud.pro.lifetime",
+			},
+		};
+		const rows = buildLedgerRows(decodeEnvelopeOf(n), {
+			product: { orderId: "GPA.9", purchaseState: 0, purchaseTimeMillis: "1754006400000" },
+			order: {
+				orderId: "GPA.9",
+				total: { currencyCode: "CNY", units: "198", nanos: 0 },
+				buyerAddress: { buyerCountry: "CN" },
+			},
+		});
+		expect(rows.transaction).toMatchObject({
+			orderId: "GPA.9",
+			type: "Non-Consumable",
+			priceMillis: 198_000,
+			currency: "CNY",
+		});
+		expect(rows.subscription).toMatchObject({ isLifetime: true, status: "active", expiresDate: null });
+	});
+
+	it("退款：状态 refunded、流水写撤销时间", () => {
+		const n: DeveloperNotification = {
+			packageName: PACKAGE,
+			eventTimeMillis: "1754092800000",
+			voidedPurchaseNotification: {
+				purchaseToken: "tok-abc",
+				orderId: "GPA.1111-2222-3333-44444",
+				productType: 1,
+				refundType: 1,
+			},
+		};
+		const rows = buildLedgerRows(decodeEnvelopeOf(n), SUB_ENRICHMENT);
+		expect(rows.notification.subtype).toBe("SUBSCRIPTION_FULL_REFUND");
+		expect(rows.transaction?.revocationDate).toBe(1_754_092_800_000);
+		expect(rows.subscription?.status).toBe("refunded");
+	});
+
+	it("测试通知不产生业务行", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf({ packageName: PACKAGE, testNotification: {} }), {});
+		expect(rows.transaction).toBeNull();
+		expect(rows.subscription).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bark 文案 / 服务账号解析
+// ---------------------------------------------------------------------------
+
+describe("buildPlayBarkMessage", () => {
+	it("入账事件穿透专注模式，正文带商品与金额", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf(SUB_PURCHASE), SUB_ENRICHMENT);
+		const msg = buildPlayBarkMessage(rows);
+		expect(msg.level).toBe("timeSensitive");
+		expect(msg.title).toContain("新订阅");
+		expect(msg.body).toContain("Pro 年度");
+		expect(msg.body).toContain("19.99 USD");
+		expect(msg.body).toContain("Google Play");
+	});
+
+	it("沙盒事件静默入列", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf(SUB_PURCHASE), {
+			...SUB_ENRICHMENT,
+			subscription: { ...SUB_ENRICHMENT.subscription, testPurchase: {} },
+		});
+		expect(buildPlayBarkMessage(rows).level).toBe("passive");
+	});
+});
+
+describe("parseServiceAccount", () => {
+	it("未配置 / 残缺 JSON 一律返回 null（调用方降级）", () => {
+		expect(parseServiceAccount(undefined)).toBeNull();
+		expect(parseServiceAccount("")).toBeNull();
+		expect(parseServiceAccount("{}")).toBeNull();
+		expect(parseServiceAccount("not json")).toBeNull();
+	});
+
+	it("还原被转义的换行", () => {
+		const sa = parseServiceAccount(
+			JSON.stringify({ client_email: "a@b.com", private_key: "-----BEGIN-----\\nX\\n-----END-----" }),
+		);
+		expect(sa?.private_key).toBe("-----BEGIN-----\nX\n-----END-----");
+	});
+});

--- a/apps/web/src/lib/play/store.integration.test.ts
+++ b/apps/web/src/lib/play/store.integration.test.ts
@@ -1,0 +1,227 @@
+// Play 入库层针对「真实 SQL 引擎」的集成测试（node:sqlite）：
+// messageId 幂等、orderId upsert、eventTime 乱序保护、换 token 时旧行落幕。
+
+import { readdirSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { beforeEach, describe, expect, it } from "vitest";
+import { storeLedgerRows } from "./store";
+import type { PlayLedgerRows } from "./logic";
+
+// ---- 最小 D1 适配器（仅覆盖 store.ts 用到的接口）----
+class FakeStmt {
+	private args: unknown[] = [];
+	constructor(
+		private readonly db: DatabaseSync,
+		private readonly sql: string,
+	) {}
+	bind(...args: unknown[]): this {
+		this.args = args;
+		return this;
+	}
+	run() {
+		const info = this.db.prepare(this.sql).run(...(this.args as never[]));
+		return { success: true, meta: { changes: Number(info.changes) } };
+	}
+}
+class FakeD1 {
+	constructor(private readonly db: DatabaseSync) {}
+	prepare(sql: string): FakeStmt {
+		return new FakeStmt(this.db, sql);
+	}
+	async batch(stmts: FakeStmt[]) {
+		this.db.exec("BEGIN");
+		try {
+			const results = stmts.map((s) => s.run());
+			this.db.exec("COMMIT");
+			return results;
+		} catch (e) {
+			this.db.exec("ROLLBACK");
+			throw e;
+		}
+	}
+}
+
+const migDir = new URL("../../../migrations/", import.meta.url);
+const migrations = readdirSync(migDir)
+	.filter((f) => f.endsWith(".sql"))
+	.sort()
+	.map((f) => readFileSync(new URL(f, migDir), "utf8"));
+
+let raw: DatabaseSync;
+let db: FakeD1;
+
+beforeEach(() => {
+	raw = new DatabaseSync(":memory:");
+	for (const m of migrations) raw.exec(m);
+	db = new FakeD1(raw);
+});
+
+interface RowInput {
+	messageId: string;
+	type: string;
+	eventTime: number;
+	token?: string;
+	orderId?: string | null;
+	status?: string;
+	priceMillis?: number | null;
+	revocationDate?: number | null;
+	linkedToken?: string | null;
+	isLifetime?: boolean;
+	expiresDate?: number | null;
+}
+
+function makeRows(i: RowInput): PlayLedgerRows {
+	const token = i.token ?? "tok-A";
+	const orderId = i.orderId === undefined ? "GPA.1" : i.orderId;
+	return {
+		notification: {
+			notificationUuid: i.messageId,
+			notificationType: i.type,
+			subtype: null,
+			purchaseToken: token,
+			orderId,
+			packageName: "jiamin.chen.orangecloud",
+			environment: "Production",
+			eventTime: i.eventTime,
+			receivedAt: i.eventTime + 10,
+			raw: "{}",
+		},
+		transaction: orderId
+			? {
+					orderId,
+					purchaseToken: token,
+					productId: "jiamin.chen.orange_cloud.pro.yearly",
+					type: "Auto-Renewable Subscription",
+					purchaseDate: i.eventTime,
+					expiresDate: i.expiresDate ?? null,
+					priceMillis: i.priceMillis === undefined ? 19_990 : i.priceMillis,
+					devRevenueMillis: 16_990,
+					currency: "USD",
+					storefront: "US",
+					offerIdentifier: null,
+					revocationDate: i.revocationDate ?? null,
+					environment: "Production",
+				}
+			: null,
+		subscription: {
+			purchaseToken: token,
+			productId: "jiamin.chen.orange_cloud.pro.yearly",
+			status: i.status ?? "active",
+			autoRenewStatus: 1,
+			linkedToken: i.linkedToken ?? null,
+			environment: "Production",
+			purchaseDate: i.eventTime,
+			expiresDate: i.expiresDate ?? null,
+			isLifetime: i.isLifetime ?? false,
+			priceMillis: i.priceMillis === undefined ? 19_990 : i.priceMillis,
+			currency: "USD",
+		},
+	};
+}
+
+function sub(token = "tok-A") {
+	return raw.prepare("SELECT * FROM subscriptions WHERE original_transaction_id = ?").get(token) as
+		| Record<string, unknown>
+		| undefined;
+}
+function count(table: string): number {
+	return Number((raw.prepare(`SELECT count(*) c FROM ${table}`).get() as { c: number }).c);
+}
+
+describe("storeLedgerRows（真实 SQL）", () => {
+	it("首购 + 续订：状态有效、到期推进、流水累加，platform 标记为 play", async () => {
+		await storeLedgerRows(
+			db as never,
+			makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000, orderId: "GPA.1", expiresDate: 5000 }),
+		);
+		await storeLedgerRows(
+			db as never,
+			makeRows({ messageId: "m2", type: "SUBSCRIPTION_RENEWED", eventTime: 2000, orderId: "GPA.2", expiresDate: 9000 }),
+		);
+		expect(sub()?.status).toBe("active");
+		expect(sub()?.expires_date).toBe(9000);
+		expect(sub()?.platform).toBe("play");
+		expect(count("transactions")).toBe(2);
+		const tx = raw.prepare("SELECT * FROM transactions WHERE transaction_id = 'GPA.2'").get() as Record<string, unknown>;
+		expect(tx.platform).toBe("play");
+		expect(tx.dev_revenue_millis).toBe(16_990);
+	});
+
+	it("重复 messageId 幂等：标记 duplicate 且不重复入审计", async () => {
+		const rows = makeRows({ messageId: "dup", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000 });
+		const first = await storeLedgerRows(db as never, rows);
+		const second = await storeLedgerRows(db as never, rows);
+		expect(first.duplicate).toBe(false);
+		expect(second.duplicate).toBe(true);
+		expect(count("notifications")).toBe(1);
+		expect(count("transactions")).toBe(1);
+	});
+
+	it("重投递能补齐金额：先无价入库，重放带价时回填", async () => {
+		await storeLedgerRows(
+			db as never,
+			makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000, priceMillis: null }),
+		);
+		expect(
+			(raw.prepare("SELECT price_millis p FROM transactions WHERE transaction_id='GPA.1'").get() as { p: number | null }).p,
+		).toBeNull();
+
+		await storeLedgerRows(
+			db as never,
+			makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000, priceMillis: 19_990 }),
+		);
+		expect(
+			(raw.prepare("SELECT price_millis p FROM transactions WHERE transaction_id='GPA.1'").get() as { p: number }).p,
+		).toBe(19_990);
+	});
+
+	it("乱序保护：迟到的更旧 EXPIRED 不把状态写回过期", async () => {
+		await storeLedgerRows(db as never, makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000, expiresDate: 5000 }));
+		await storeLedgerRows(db as never, makeRows({ messageId: "m2", type: "SUBSCRIPTION_RENEWED", eventTime: 2000, orderId: "GPA.2", expiresDate: 9000 }));
+		await storeLedgerRows(db as never, makeRows({ messageId: "m3", type: "SUBSCRIPTION_EXPIRED", eventTime: 1500, orderId: null, status: "expired" }));
+		expect(sub()?.status).toBe("active");
+		expect(sub()?.last_signed_date).toBe(2000);
+		expect(count("notifications")).toBe(3); // 审计仍记录
+
+		await storeLedgerRows(db as never, makeRows({ messageId: "m4", type: "SUBSCRIPTION_EXPIRED", eventTime: 3000, orderId: null, status: "expired" }));
+		expect(sub()?.status).toBe("expired");
+	});
+
+	it("退款：状态 refunded、流水回写撤销时间", async () => {
+		await storeLedgerRows(db as never, makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000 }));
+		await storeLedgerRows(
+			db as never,
+			makeRows({ messageId: "m2", type: "VOIDED_PURCHASE", eventTime: 4000, status: "refunded", revocationDate: 4000 }),
+		);
+		expect(sub()?.status).toBe("refunded");
+		const tx = raw.prepare("SELECT * FROM transactions WHERE transaction_id = 'GPA.1'").get() as Record<string, unknown>;
+		expect(tx.revocation_date).toBe(4000);
+	});
+
+	it("升降级换发 token：旧行落幕，活跃权益不重复计数", async () => {
+		await storeLedgerRows(db as never, makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000, token: "tok-old" }));
+		await storeLedgerRows(
+			db as never,
+			makeRows({ messageId: "m2", type: "SUBSCRIPTION_PURCHASED", eventTime: 2000, token: "tok-new", orderId: "GPA.2", linkedToken: "tok-old" }),
+		);
+		expect(sub("tok-old")?.status).toBe("expired");
+		expect(sub("tok-new")?.status).toBe("active");
+		const active = raw.prepare("SELECT count(*) c FROM subscriptions WHERE status='active'").get() as { c: number };
+		expect(Number(active.c)).toBe(1);
+	});
+
+	it("与 Apple 行共存：platform 列把两边分得开", async () => {
+		raw.exec(
+			`INSERT INTO subscriptions (original_transaction_id, status, environment, is_lifetime, last_signed_date, updated_at)
+			 VALUES ('apple-1', 'active', 'Production', 0, 1, 1)`,
+		);
+		await storeLedgerRows(db as never, makeRows({ messageId: "m1", type: "SUBSCRIPTION_PURCHASED", eventTime: 1000 }));
+		const byPlatform = raw
+			.prepare("SELECT platform, count(*) c FROM subscriptions GROUP BY platform ORDER BY platform")
+			.all() as { platform: string; c: number }[];
+		expect(byPlatform.map((r) => [r.platform, Number(r.c)])).toEqual([
+			["apple", 1],
+			["play", 1],
+		]);
+	});
+});

--- a/apps/web/src/lib/play/store.ts
+++ b/apps/web/src/lib/play/store.ts
@@ -1,0 +1,174 @@
+// 把一条 Play 通知写入统一账本（platform='play'）。
+//
+// 结构与 lib/appstore/store.ts 完全对称：一次 db.batch 原子提交，
+//   notifications —— INSERT OR IGNORE，Pub/Sub messageId 去重（重投递幂等）
+//   transactions  —— 按 orderId upsert（退款回写 revocation_date）
+//   subscriptions —— 按 purchaseToken upsert，带 eventTime 乱序保护
+// 全是幂等写，因此返回 5xx 让 Pub/Sub 重投递是安全的（重放不会污染数据）。
+
+import type { PlayLedgerRows } from "./logic";
+
+export interface PlayProcessResult {
+	/** messageId 已存在（重复投递，业务表仍会被幂等重放） */
+	duplicate: boolean;
+	notificationType: string;
+	messageId: string;
+	transactionRecorded: boolean;
+	subscriptionUpdated: boolean;
+}
+
+export async function storeLedgerRows(
+	db: D1Database,
+	rows: PlayLedgerRows,
+): Promise<PlayProcessResult> {
+	const { notification: nf, transaction: tx, subscription: sub } = rows;
+	const statements: D1PreparedStatement[] = [];
+
+	// 1) 原始通知审计 + 幂等（app_apple_id 是 Apple 专属，Play 恒 NULL）
+	statements.push(
+		db
+			.prepare(
+				`INSERT OR IGNORE INTO notifications
+				 (notification_uuid, notification_type, subtype, original_transaction_id,
+				  transaction_id, bundle_id, environment, signed_date, app_apple_id,
+				  received_at, raw_payload, platform)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, 'play')`,
+			)
+			.bind(
+				nf.notificationUuid,
+				nf.notificationType,
+				nf.subtype,
+				nf.purchaseToken,
+				nf.orderId,
+				nf.packageName,
+				nf.environment,
+				nf.eventTime,
+				nf.receivedAt,
+				nf.raw,
+			),
+	);
+
+	// 2) 财务流水（offer_type / in_app_ownership_type / revocation_reason 是 Apple 专属，留空）
+	if (tx) {
+		statements.push(
+			db
+				.prepare(
+					`INSERT INTO transactions
+					 (transaction_id, original_transaction_id, product_id, type, purchase_date,
+					  expires_date, price_millis, dev_revenue_millis, currency, in_app_ownership_type,
+					  offer_type, offer_identifier, storefront, revocation_date, revocation_reason,
+					  environment, notification_type, notification_subtype, signed_date,
+					  created_at, updated_at, platform)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, 'play')
+					 ON CONFLICT(transaction_id) DO UPDATE SET
+					   expires_date = COALESCE(excluded.expires_date, transactions.expires_date),
+					   price_millis = COALESCE(excluded.price_millis, transactions.price_millis),
+					   dev_revenue_millis = COALESCE(excluded.dev_revenue_millis, transactions.dev_revenue_millis),
+					   currency = COALESCE(excluded.currency, transactions.currency),
+					   product_id = COALESCE(excluded.product_id, transactions.product_id),
+					   purchase_date = COALESCE(transactions.purchase_date, excluded.purchase_date),
+					   offer_identifier = COALESCE(excluded.offer_identifier, transactions.offer_identifier),
+					   storefront = COALESCE(excluded.storefront, transactions.storefront),
+					   revocation_date = COALESCE(excluded.revocation_date, transactions.revocation_date),
+					   environment = excluded.environment,
+					   notification_type = excluded.notification_type,
+					   notification_subtype = excluded.notification_subtype,
+					   signed_date = excluded.signed_date,
+					   updated_at = excluded.updated_at`,
+				)
+				.bind(
+					tx.orderId,
+					tx.purchaseToken,
+					tx.productId,
+					tx.type,
+					tx.purchaseDate,
+					tx.expiresDate,
+					tx.priceMillis,
+					tx.devRevenueMillis,
+					tx.currency,
+					tx.offerIdentifier,
+					tx.storefront,
+					tx.revocationDate,
+					tx.environment,
+					nf.notificationType,
+					nf.subtype,
+					nf.eventTime,
+					nf.receivedAt,
+					nf.receivedAt,
+				),
+		);
+	}
+
+	// 3) 权益状态（乱序保护：仅当 eventTime 不旧于已存水位才覆盖）
+	if (sub) {
+		statements.push(
+			db
+				.prepare(
+					`INSERT INTO subscriptions
+					 (original_transaction_id, product_id, status, auto_renew_status,
+					  auto_renew_product_id, environment, purchase_date, expires_date,
+					  is_lifetime, last_notification_type, last_subtype, price_millis,
+					  currency, offer_type, last_signed_date, updated_at, platform, linked_token)
+					 VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, 'play', ?)
+					 ON CONFLICT(original_transaction_id) DO UPDATE SET
+					   product_id = COALESCE(excluded.product_id, subscriptions.product_id),
+					   status = excluded.status,
+					   auto_renew_status = COALESCE(excluded.auto_renew_status, subscriptions.auto_renew_status),
+					   environment = excluded.environment,
+					   purchase_date = COALESCE(subscriptions.purchase_date, excluded.purchase_date),
+					   expires_date = COALESCE(excluded.expires_date, subscriptions.expires_date),
+					   is_lifetime = MAX(excluded.is_lifetime, subscriptions.is_lifetime),
+					   last_notification_type = excluded.last_notification_type,
+					   last_subtype = excluded.last_subtype,
+					   price_millis = COALESCE(excluded.price_millis, subscriptions.price_millis),
+					   currency = COALESCE(excluded.currency, subscriptions.currency),
+					   linked_token = COALESCE(excluded.linked_token, subscriptions.linked_token),
+					   last_signed_date = excluded.last_signed_date,
+					   updated_at = excluded.updated_at
+					 WHERE excluded.last_signed_date >= subscriptions.last_signed_date`,
+				)
+				.bind(
+					sub.purchaseToken,
+					sub.productId,
+					sub.status,
+					sub.autoRenewStatus,
+					sub.environment,
+					sub.purchaseDate,
+					sub.expiresDate,
+					sub.isLifetime ? 1 : 0,
+					nf.notificationType,
+					nf.subtype,
+					sub.priceMillis,
+					sub.currency,
+					nf.eventTime,
+					nf.receivedAt,
+					sub.linkedToken,
+				),
+		);
+
+		// 升降级 / 重新订阅会换发 purchaseToken：把被顶替的旧行落幕，
+		// 否则「活跃权益」会把同一个用户数两次。已退款 / 已撤销的不动。
+		if (sub.linkedToken) {
+			statements.push(
+				db
+					.prepare(
+						`UPDATE subscriptions SET status = 'expired', updated_at = ?
+						 WHERE original_transaction_id = ? AND platform = 'play'
+						   AND status NOT IN ('refunded', 'revoked', 'expired')`,
+					)
+					.bind(nf.receivedAt, sub.linkedToken),
+			);
+		}
+	}
+
+	const results = await db.batch(statements);
+	const duplicate = (results[0]?.meta?.changes ?? 0) === 0;
+
+	return {
+		duplicate,
+		notificationType: nf.notificationType,
+		messageId: nf.notificationUuid,
+		transactionRecorded: Boolean(tx),
+		subscriptionUpdated: Boolean(sub),
+	};
+}

--- a/apps/web/src/lib/play/types.ts
+++ b/apps/web/src/lib/play/types.ts
@@ -1,0 +1,194 @@
+// Google Play Real-time Developer Notifications（RTDN）与 Play Developer API 的类型。
+//
+// RTDN 走 Cloud Pub/Sub：Play 把 DeveloperNotification 发到我们的 topic，
+// topic 配一个 push 订阅 POST 到 /api/play/notifications。请求体是 Pub/Sub 信封，
+// message.data 是 base64 的 DeveloperNotification JSON。
+//
+// 关键差异（与 Apple 对照）：RTDN **只给 purchaseToken + 类型**，没有金额、
+// 没有到期时间、没有地区。要拿这些必须回调 Play Developer API（见 api.ts）。
+
+/** Pub/Sub push 信封。 */
+export interface PubSubEnvelope {
+	message?: {
+		data?: string;
+		messageId?: string;
+		message_id?: string;
+		publishTime?: string;
+		publish_time?: string;
+		attributes?: Record<string, string>;
+	};
+	subscription?: string;
+}
+
+export interface SubscriptionNotification {
+	version?: string;
+	notificationType?: number;
+	purchaseToken?: string;
+	subscriptionId?: string;
+}
+
+export interface OneTimeProductNotification {
+	version?: string;
+	notificationType?: number;
+	purchaseToken?: string;
+	sku?: string;
+}
+
+export interface VoidedPurchaseNotification {
+	purchaseToken?: string;
+	orderId?: string;
+	/** 1 = 订阅，2 = 一次性购买 */
+	productType?: number;
+	/** 1 = 全额退款，2 = 按数量部分退款 */
+	refundType?: number;
+}
+
+export interface DeveloperNotification {
+	version?: string;
+	packageName?: string;
+	eventTimeMillis?: string | number;
+	subscriptionNotification?: SubscriptionNotification;
+	oneTimeProductNotification?: OneTimeProductNotification;
+	voidedPurchaseNotification?: VoidedPurchaseNotification;
+	testNotification?: { version?: string };
+}
+
+/** 验签 + 解码后交给业务层的一条通知。 */
+export interface DecodedPlayNotification {
+	/** Pub/Sub messageId —— 幂等键（重投递复用同一个 id）。 */
+	messageId: string;
+	/** 事件发生时刻（ms epoch），用作乱序保护的水位。 */
+	eventTimeMillis: number;
+	notification: DeveloperNotification;
+}
+
+// ---------------------------------------------------------------------------
+// 通知类型枚举 —— RTDN 传数字，账本里存可读串（与 Apple 侧的字符串类型同列）
+// ---------------------------------------------------------------------------
+
+export const SUBSCRIPTION_NOTIFICATION_TYPE: Record<number, string> = {
+	1: "SUBSCRIPTION_RECOVERED",
+	2: "SUBSCRIPTION_RENEWED",
+	3: "SUBSCRIPTION_CANCELED",
+	4: "SUBSCRIPTION_PURCHASED",
+	5: "SUBSCRIPTION_ON_HOLD",
+	6: "SUBSCRIPTION_IN_GRACE_PERIOD",
+	7: "SUBSCRIPTION_RESTARTED",
+	8: "SUBSCRIPTION_PRICE_CHANGE_CONFIRMED",
+	9: "SUBSCRIPTION_DEFERRED",
+	10: "SUBSCRIPTION_PAUSED",
+	11: "SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED",
+	12: "SUBSCRIPTION_REVOKED",
+	13: "SUBSCRIPTION_EXPIRED",
+	17: "SUBSCRIPTION_ITEMS_CHANGED",
+	18: "SUBSCRIPTION_CANCELLATION_SCHEDULED",
+	19: "SUBSCRIPTION_PRICE_CHANGE_UPDATED",
+	20: "SUBSCRIPTION_PENDING_PURCHASE_CANCELED",
+	22: "SUBSCRIPTION_PRICE_STEP_UP_CONSENT_UPDATED",
+};
+
+export const ONE_TIME_NOTIFICATION_TYPE: Record<number, string> = {
+	1: "ONE_TIME_PRODUCT_PURCHASED",
+	2: "ONE_TIME_PRODUCT_CANCELED",
+};
+
+export const VOIDED_PURCHASE_TYPE = "VOIDED_PURCHASE";
+export const PLAY_TEST_NOTIFICATION_TYPE = "PLAY_TEST";
+
+// ---------------------------------------------------------------------------
+// Play Developer API 响应（只声明我们用到的字段）
+// ---------------------------------------------------------------------------
+
+/** google.type.Money —— units 是「整数部分」字符串，nanos 是十亿分之一。 */
+export interface Money {
+	currencyCode?: string;
+	units?: string | number;
+	nanos?: number;
+}
+
+export interface SubscriptionPurchaseV2 {
+	subscriptionState?: string;
+	latestOrderId?: string;
+	regionCode?: string;
+	startTime?: string;
+	linkedPurchaseToken?: string;
+	testPurchase?: Record<string, unknown>;
+	canceledStateContext?: Record<string, unknown>;
+	lineItems?: {
+		productId?: string;
+		expiryTime?: string;
+		autoRenewingPlan?: {
+			autoRenewEnabled?: boolean;
+			recurringPrice?: Money;
+		};
+		prepaidPlan?: Record<string, unknown>;
+		offerDetails?: { basePlanId?: string; offerId?: string };
+	}[];
+}
+
+export interface ProductPurchaseV1 {
+	orderId?: string;
+	purchaseTimeMillis?: string | number;
+	/** 0 已购买 / 1 已取消 / 2 待处理 */
+	purchaseState?: number;
+	/** 0 未确认 / 1 已确认 */
+	acknowledgementState?: number;
+	/** 0 正式 / 1 测试（license tester、内部测试） */
+	purchaseType?: number;
+	productId?: string;
+	regionCode?: string;
+	quantity?: number;
+}
+
+export interface PlayOrder {
+	orderId?: string;
+	purchaseToken?: string;
+	state?: string;
+	createTime?: string;
+	lastEventTime?: string;
+	total?: Money;
+	tax?: Money;
+	developerRevenueInBuyerCurrency?: Money;
+	buyerAddress?: { buyerCountry?: string; buyerState?: string; buyerPostcode?: string };
+	lineItems?: {
+		productId?: string;
+		productTitle?: string;
+		listingPrice?: Money;
+		total?: Money;
+		tax?: Money;
+	}[];
+}
+
+/** 富化结果：能拿到多少算多少，缺 Service Account 时全部为空。 */
+export interface PlayEnrichment {
+	subscription?: SubscriptionPurchaseV2;
+	product?: ProductPurchaseV1;
+	order?: PlayOrder;
+}
+
+// ---------------------------------------------------------------------------
+// 小工具
+// ---------------------------------------------------------------------------
+
+/** google.type.Money -> milliunits（与 Apple 的 price 口径一致：$19.99 -> 19990）。 */
+export function moneyToMillis(m?: Money | null): number | null {
+	if (!m) return null;
+	const units = typeof m.units === "string" ? Number(m.units) : (m.units ?? 0);
+	const nanos = m.nanos ?? 0;
+	if (!Number.isFinite(units)) return null;
+	return Math.round(units * 1000 + nanos / 1_000_000);
+}
+
+/** RFC3339 时间串 -> ms epoch（无效返回 null）。 */
+export function rfc3339ToMillis(s?: string | null): number | null {
+	if (!s) return null;
+	const t = Date.parse(s);
+	return Number.isFinite(t) ? t : null;
+}
+
+/** 字符串 / 数字型 epoch 毫秒 -> number（无效返回 null）。 */
+export function toMillis(v?: string | number | null): number | null {
+	if (v == null) return null;
+	const n = typeof v === "string" ? Number(v) : v;
+	return Number.isFinite(n) ? n : null;
+}

--- a/apps/web/src/lib/play/verify.ts
+++ b/apps/web/src/lib/play/verify.ts
@@ -1,0 +1,120 @@
+// Pub/Sub push 请求的鉴权与解码。
+//
+// 安全边界 = Google 签发的 OIDC ID Token：在 Pub/Sub 订阅上配置
+// 「身份验证 → 服务账号 + audience」后，每次推送都会带
+//   Authorization: Bearer <ID Token>
+// 该 token 由 Google 用 https://www.googleapis.com/oauth2/v3/certs 的私钥签发，
+// 我们只需公钥验签 + 校验 aud / iss / email —— 与 Apple 侧一样不需要保管任何密钥。
+//
+// 解码后再校验 packageName，拒绝别人的 topic 误配 / 恶意转发到本端点。
+
+import { createRemoteJWKSet, jwtVerify, type JWTVerifyGetKey } from "jose";
+import type { DecodedPlayNotification, DeveloperNotification, PubSubEnvelope } from "./types";
+import { toMillis } from "./types";
+
+export class PlayVerifyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PlayVerifyError";
+	}
+}
+
+const GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+const GOOGLE_ISSUERS = ["https://accounts.google.com", "accounts.google.com"];
+
+let remoteJwks: JWTVerifyGetKey | undefined;
+function googleJwks(): JWTVerifyGetKey {
+	// createRemoteJWKSet 自带缓存与轮换，模块级复用即可（每个 isolate 一份）。
+	remoteJwks ??= createRemoteJWKSet(new URL(GOOGLE_JWKS_URL));
+	return remoteJwks;
+}
+
+export interface PlayVerifyOptions {
+	/** Pub/Sub 订阅里配置的 audience（建议填端点 URL）。 */
+	audience: string;
+	/** 推送用的服务账号邮箱；配置后强制比对 token 的 email 声明。 */
+	serviceAccountEmail?: string;
+	/** 期望的 Android 包名，用于拒绝非本 App 的通知。 */
+	packageName: string;
+	/** 测试注入的验签公钥来源；缺省用 Google 的远端 JWKS。 */
+	keys?: JWTVerifyGetKey;
+}
+
+/** 校验 Authorization 头里的 Google OIDC token。 */
+export async function verifyPushToken(
+	authorization: string | null,
+	opts: PlayVerifyOptions,
+): Promise<void> {
+	// 必须是 `Bearer <token>`：没有头、没有前缀、空 token 一律未鉴权。
+	const token = /^Bearer\s+(\S+)$/i.exec((authorization ?? "").trim())?.[1];
+	if (!token) throw new PlayVerifyError("missing bearer token");
+
+	let payload: Record<string, unknown>;
+	try {
+		const verified = await jwtVerify(token, opts.keys ?? googleJwks(), {
+			issuer: GOOGLE_ISSUERS,
+			audience: opts.audience,
+		});
+		payload = verified.payload as Record<string, unknown>;
+	} catch (err) {
+		throw new PlayVerifyError(`invalid id token: ${(err as Error).message}`);
+	}
+
+	if (opts.serviceAccountEmail) {
+		const email = typeof payload.email === "string" ? payload.email : "";
+		if (email !== opts.serviceAccountEmail || payload.email_verified !== true) {
+			throw new PlayVerifyError("unexpected token subject");
+		}
+	}
+}
+
+/** base64 / base64url 文本 -> UTF-8 字符串。 */
+function decodeBase64(data: string): string {
+	const normalized = data.replace(/-/g, "+").replace(/_/g, "/");
+	const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+	const binary = atob(padded);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return new TextDecoder().decode(bytes);
+}
+
+/** 解析 Pub/Sub 信封 -> DeveloperNotification。 */
+export function decodeEnvelope(envelope: PubSubEnvelope): DecodedPlayNotification {
+	const message = envelope.message;
+	if (!message?.data) throw new PlayVerifyError("missing message.data");
+
+	const messageId = message.messageId ?? message.message_id;
+	if (!messageId) throw new PlayVerifyError("missing message id");
+
+	let notification: DeveloperNotification;
+	try {
+		notification = JSON.parse(decodeBase64(message.data)) as DeveloperNotification;
+	} catch {
+		throw new PlayVerifyError("message.data is not base64 JSON");
+	}
+
+	// eventTimeMillis 缺失（理论上不会）时退回 publishTime，再退回当下，
+	// 保证乱序保护始终有一个单调可比的水位。
+	const eventTimeMillis =
+		toMillis(notification.eventTimeMillis) ??
+		(message.publishTime ?? message.publish_time
+			? Date.parse((message.publishTime ?? message.publish_time) as string)
+			: Date.now());
+
+	return { messageId, eventTimeMillis, notification };
+}
+
+/** 完整校验一次 push 请求：token -> 信封 -> 包名。 */
+export async function verifyPushRequest(
+	authorization: string | null,
+	envelope: PubSubEnvelope,
+	opts: PlayVerifyOptions,
+): Promise<DecodedPlayNotification> {
+	await verifyPushToken(authorization, opts);
+	const decoded = decodeEnvelope(envelope);
+	const pkg = decoded.notification.packageName;
+	if (pkg && pkg !== opts.packageName) {
+		throw new PlayVerifyError(`unexpected packageName ${pkg}`);
+	}
+	return decoded;
+}


### PR DESCRIPTION
后台账本此前只有 Apple 与 Stripe 两条线，Play 的订阅 / 买断完全看不见。这一版把 Play 的 Real-time Developer Notifications 接进来，与 Apple 共用同一本账。

## 与 Apple 的根本差异

| | App Store | Google Play |
|---|---|---|
| 通知内容 | 完整（金额、地区、到期、退款原因） | **只有 `purchaseToken` + 事件类型** |
| 拿金额 | 通知自带 | 必须回查 Play Developer API |
| 鉴权 | 纯验签，零密钥 | 验签零密钥，**富化必须存服务账号私钥** |

`PLAY_SA_JSON` 缺失时走降级：事件照记，但没有金额、也不落流水行（`orderId` 是流水主键，拿不到就不造假数据）。推送本身的鉴权仍是零密钥——Pub/Sub 带 Google 签发的 OIDC ID Token，远端 JWKS 验签 + `aud`/`iss`/服务账号 email + packageName 校验。

## 数据模型

没建 `play_*` 平行表，`migrations/0007` 给既有三表加 `platform` 列（历史行默认 `apple`）。对齐口径：`messageId`→`notification_uuid`、`purchaseToken`→`original_transaction_id`、`orderId`→`transaction_id`、`eventTimeMillis`→`signed_date`（同为乱序保护水位）。Orders API 额外给出开发者到手金额，Apple 侧拿不到，单列 `dev_revenue_millis`。

一个易漏点：升降级 / 重新订阅会换发 purchaseToken，新购买用 `linkedPurchaseToken` 指回旧的；不处理会让同一用户在「活跃权益」里数两次，故入库时把旧行置为 `expired`。

## 看板

平台筛选 + 表格平台徽章 + 「分平台」对比卡（≥2 平台才显示）；CSV 导出补 `platform` / `dev_revenue`；Play 的长 purchaseToken 表格截断、弹窗换行。

## 验证

- `pnpm test` 126 passed（新增 30 例：OIDC 验签四态、信封解码、金额状态映射，以及 node:sqlite 真实 SQL 的幂等 / 乱序 / 换 token 落幕 / 与 Apple 共存）
- `tsc --noEmit` 干净，`pnpm build` 通过，`/api/play/notifications` 已进路由表
- 生产 D1 已 apply 0007，269 条既有交易全部落在 `platform='apple'`
- GCP 侧已配好：topic `play-rtdn`、授权 Play 发布、push 订阅（OIDC，audience = 端点 URL）、`play-api` 服务账号 + 密钥；token 交换实测 200，androidpublisher 探针 401（等 Play Console 授权）
- 三个 Worker secret 已上线

## 仍需人工（Play Console 网页端）

1. 变现设置 → 实时开发者通知：填 `projects/project-fed20aff-ffa4-40ca-b6b/topics/play-rtdn`，勾「启用已作废购买交易的实时通知」
2. 用户和权限 → 邀请 `play-api@project-fed20aff-ffa4-40ca-b6b.iam.gserviceaccount.com`，授「查看财务数据」+「管理订单和订阅」

配置 runbook 见 `docs/05-web-backend.md`「Google Play 实时入账」。
