### PR TITLE
release(ios): 2.0.0 (build 39)

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.3;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/AppNotifications.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/AppNotifications.swift
@@ -39,6 +39,13 @@ enum AppNotifications {
         if defaults.bool(forKey: "notifyZoneStatus") {
             await checkZoneStatusChanges(zoneService: ZoneService(client: client))
         }
+        if defaults.bool(forKey: "notifyBuildFailures"),
+           authManager.hasScope("workers-ci.read") {
+            await checkBuildFailures(
+                buildService: WorkerBuildService(client: client),
+                accountService: AccountService(client: client)
+            )
+        }
         if defaults.bool(forKey: "notifyWorkerErrors"),
            authManager.hasScope("account-analytics.read") {
             await checkWorkerErrors(
@@ -111,6 +118,70 @@ enum AppNotifications {
             body: String(localized: "过去 1 小时共 \(errors.formatted()) 次调用错误，点击查看详情"),
             id: "worker-errors"
         )
+    }
+
+    /// 构建失败：Cloudflare **没有** Workers Builds 的告警类型（69 个 alert_type 里无对应项），
+    /// 所以走不了服务端 webhook，只能在后台刷新窗口里自己比对。
+    /// 已通知过的 build_uuid 落盘去重，避免同一次失败反复提醒。
+    private static func checkBuildFailures(
+        buildService: WorkerBuildService,
+        accountService: AccountService
+    ) async {
+        let defaults = UserDefaults.standard
+        // 用户在 Worker 详情页勾选要盯的脚本；没勾就不做任何请求
+        let watched = defaults.stringArray(forKey: watchedBuildScriptsKey) ?? []
+        guard !watched.isEmpty,
+              let account = try? await accountService.listAccounts().first else { return }
+
+        var notified = Set(defaults.stringArray(forKey: notifiedBuildsKey) ?? [])
+        var failures: [(script: String, uuid: String)] = []
+
+        // 后台时间预算有限，最多盯 5 个脚本
+        for script in watched.prefix(5) {
+            guard let builds = try? await buildService.builds(accountId: account.id, scriptId: script),
+                  let latest = builds.first else { continue }
+            guard latest.displayState == .failed, !notified.contains(latest.buildUuid) else { continue }
+            failures.append((script, latest.buildUuid))
+            notified.insert(latest.buildUuid)
+        }
+
+        guard !failures.isEmpty else { return }
+        // 去重集合只保留最近 200 条，避免无限膨胀
+        defaults.set(Array(notified.suffix(200)), forKey: notifiedBuildsKey)
+
+        if failures.count == 1, let failure = failures.first {
+            notify(
+                title: String(localized: "构建失败"),
+                body: String(localized: "\(failure.script) 的最新一次构建失败了"),
+                id: "build-failed-\(failure.uuid)"
+            )
+        } else {
+            notify(
+                title: String(localized: "构建失败"),
+                body: String(localized: "\(failures.count) 个 Worker 的最新构建失败了：\(failures.map(\.script).formatted())"),
+                id: "build-failed-multi"
+            )
+        }
+    }
+
+    // MARK: - 盯构建的脚本清单（Worker 详情页勾选）
+
+    static let watchedBuildScriptsKey = "watchedBuildScripts"
+    private static let notifiedBuildsKey = "notifiedBuildUuids"
+
+    static func isWatchingBuilds(_ scriptName: String) -> Bool {
+        (UserDefaults.standard.stringArray(forKey: watchedBuildScriptsKey) ?? []).contains(scriptName)
+    }
+
+    static func setWatchingBuilds(_ scriptName: String, _ on: Bool) {
+        var list = UserDefaults.standard.stringArray(forKey: watchedBuildScriptsKey) ?? []
+        if on {
+            guard !list.contains(scriptName) else { return }
+            list.append(scriptName)
+        } else {
+            list.removeAll { $0 == scriptName }
+        }
+        UserDefaults.standard.set(list, forKey: watchedBuildScriptsKey)
     }
 
     // MARK: - 发送

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -305,6 +305,82 @@
         }
       }
     },
+    "DNSSEC 与 DNS 进阶设置": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC and advanced DNS settings"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC 與 DNS 進階設定"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC 同 DNS 進階設定"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC と DNS の詳細設定"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC y ajustes avanzados de DNS"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC 및 고급 DNS 설정"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC e configurações avançadas de DNS"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC e definições avançadas de DNS"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC und erweiterte DNS-Einstellungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC et réglages DNS avancés"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC وإعدادات DNS المتقدمة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC ve gelişmiş DNS ayarları"
+          }
+        }
+      }
+    },
     "Email Routing": {
       "localizations": {
         "en": {
@@ -1673,6 +1749,158 @@
         }
       }
     },
+    "Worker 构建失败会提醒你": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get told when a Worker build fails"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 建置失敗會提醒你"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 建置失敗會提你"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker のビルド失敗をお知らせ"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te avisamos cuando falla una compilación de Worker"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 빌드가 실패하면 알려 드립니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisamos quando um build do Worker falha"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisamos quando uma compilação do Worker falha"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melden, wenn ein Worker-Build fehlschlägt"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soyez averti quand un build de Worker échoue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنبيه عند فشل بناء Worker"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir Worker derlemesi başarısız olunca haber alın"
+          }
+        }
+      }
+    },
+    "Worker 详情页新增构建记录：每次构建的状态、耗时与触发来源都能看到。挑几个关心的 Worker 开启监视，构建失败时会收到通知。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker details now show build history — status, duration and what triggered each build. Watch the Workers you care about and you’ll get a notification when a build fails."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 詳情頁新增建置記錄：每次建置的狀態、耗時與觸發來源都能看到。挑幾個在意的 Worker 開啟監看，建置失敗時就會收到通知。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 詳情頁新增建置記錄：每次建置嘅狀態、耗時同觸發來源都睇得到。揀幾個關心嘅 Worker 開咗監察，建置失敗就會收到通知。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 詳細にビルド履歴が加わりました。各ビルドの状態・所要時間・トリガー元を確認できます。気になる Worker を監視対象にしておくと、ビルド失敗時に通知が届きます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los detalles del Worker ahora muestran el historial de compilaciones: estado, duración y qué disparó cada una. Vigila los Workers que te importan y recibirás un aviso cuando una compilación falle."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker 상세 화면에 빌드 기록이 추가됐습니다. 각 빌드의 상태, 소요 시간, 트리거 출처를 볼 수 있습니다. 신경 쓰는 Worker를 감시로 지정해 두면 빌드 실패 시 알림이 옵니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do Worker agora mostram o histórico de builds: status, duração e o que disparou cada um. Monitore os Workers que importam e você recebe um aviso quando um build falhar."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do Worker passam a mostrar o histórico de compilações: estado, duração e o que despoletou cada uma. Vigie os Workers que lhe interessam e receberá um aviso quando uma compilação falhar."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Worker-Details zeigen jetzt den Build-Verlauf: Status, Dauer und Auslöser jedes Builds. Beobachte die Workers, die dir wichtig sind, und du bekommst eine Meldung, wenn ein Build fehlschlägt."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les détails du Worker affichent désormais l’historique des builds : état, durée et déclencheur de chacun. Surveillez les Workers qui comptent et vous serez notifié dès qu’un build échoue."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعرض تفاصيل الـ Worker الآن سجل عمليات البناء: الحالة والمدة ومصدر التشغيل لكل عملية. راقِب الـ Workers التي تهمّك لتصلك إشعارات عند فشل أي عملية بناء."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker ayrıntılarında artık derleme geçmişi var: her derlemenin durumu, süresi ve neyin tetiklediği. Önemsediğiniz Worker’ları izlemeye alın, bir derleme başarısız olduğunda bildirim alın."
+          }
+        }
+      }
+    },
     "Worker 部署历史": {
       "localizations": {
         "en": {
@@ -2125,6 +2353,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "workers.dev alt alan adına doğrudan erişim"
+          }
+        }
+      }
+    },
+    "一个开关拦住 AI 爬虫": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block AI crawlers with one switch"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一個開關擋住 AI 爬蟲"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一個開關擋住 AI 爬蟲"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI クローラーをスイッチひとつでブロック"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquea rastreadores de IA con un interruptor"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스위치 하나로 AI 크롤러 차단"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueie rastreadores de IA com um botão"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueie rastreadores de IA com um interruptor"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Crawler mit einem Schalter blocken"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquez les robots d’IA en un geste"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أوقف زواحف الذكاء الاصطناعي بمفتاح واحد"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapay zekâ tarayıcılarını tek anahtarla engelleyin"
           }
         }
       }
@@ -4409,6 +4713,82 @@
         }
       }
     },
+    "域名到期日一眼看到": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See domain expiry at a glance"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域到期日一眼看到"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名到期日一眼看到"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメインの有効期限がひと目で"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mira el vencimiento del dominio de un vistazo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 만료일을 한눈에"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja o vencimento do domínio num relance"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja a expiração do domínio num relance"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain-Ablauf auf einen Blick"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’expiration du domaine en un coup d’œil"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تاريخ انتهاء النطاق في لمحة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı bitiş tarihini bir bakışta görün"
+          }
+        }
+      }
+    },
     "域名详情新增「规则」统一入口：单条重定向、源站、配置、压缩与自定义错误五类规则支持查看、启停、新建、编辑与删除；Page Rules 与 URL 正规化支持查看与启停。": {
       "localizations": {
         "en": {
@@ -4557,6 +4937,234 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alan adı ayrıntılarındaki İşlemler bölümüne “Cloudflare’i duraklat” anahtarı eklendi. Duraklatıldığında trafik Cloudflare üzerinden geçmez; WAF, önbellek hızlandırma ve kaynak IP gizleme devre dışı kalır, DNS çözümlemesi Cloudflare’de sürer. Sürdürmek de tek dokunuş ve her ikisi de yaklaşık 5 dakikada etkili olur."
+          }
+        }
+      }
+    },
+    "域名详情页新增 DNS 设置：一键开关 DNSSEC 并复制要填到注册商那边的 DS 记录，另可调整 CNAME 展平方式与域名服务器类型。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone details gains a DNS settings screen: switch DNSSEC on or off and copy the DS record you need to paste at your registrar, plus adjust CNAME flattening and the nameserver type."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域詳情頁新增 DNS 設定：一鍵開關 DNSSEC 並複製要填到註冊商那邊的 DS 記錄，另可調整 CNAME 扁平化方式與名稱伺服器類型。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名詳情頁新增 DNS 設定：一鍵開關 DNSSEC 並複製要填去註冊商嗰邊嘅 DS 記錄，仲可以調整 CNAME 扁平化方式同域名伺服器類型。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン詳細に DNS 設定が加わりました。DNSSEC をワンタップで切り替え、レジストラ側に貼り付ける DS レコードをコピーできます。CNAME フラット化とネームサーバーの種類も変更できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los detalles del dominio suman una pantalla de ajustes DNS: activa o desactiva DNSSEC y copia el registro DS que debes pegar en tu registrador, además de ajustar el aplanamiento de CNAME y el tipo de servidor de nombres."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 상세 화면에 DNS 설정이 생겼습니다. DNSSEC을 한 번에 켜고 끄면서 등록기관에 붙여 넣을 DS 레코드를 복사할 수 있고, CNAME 평탄화와 네임서버 유형도 조정할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do domínio ganham uma tela de configurações de DNS: ligue ou desligue o DNSSEC e copie o registro DS para colar no seu registrador, além de ajustar o achatamento de CNAME e o tipo de servidor de nomes."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do domínio ganham um ecrã de definições de DNS: ligue ou desligue o DNSSEC e copie o registo DS para colar no seu registador, além de ajustar o achatamento de CNAME e o tipo de servidor de nomes."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Domain-Details bekommen einen DNS-Einstellungsbildschirm: DNSSEC ein- oder ausschalten und den DS-Eintrag kopieren, den du beim Registrar einträgst – dazu CNAME-Flattening und Nameserver-Typ anpassen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les détails du domaine gagnent un écran de réglages DNS : activez ou désactivez DNSSEC et copiez l’enregistrement DS à coller chez votre bureau d’enregistrement, et ajustez l’aplatissement CNAME et le type de serveurs de noms."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا إلى تفاصيل النطاق شاشة إعدادات DNS: فعِّل DNSSEC أو أوقفه وانسخ سجل DS المطلوب لصقه لدى المُسجِّل، مع إمكانية ضبط تسطيح CNAME ونوع خوادم الأسماء."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı ayrıntılarına DNS ayarları ekranı eklendi: DNSSEC’i açıp kapatın ve kayıt kuruluşunuza yapıştıracağınız DS kaydını kopyalayın; ayrıca CNAME düzleştirmesini ve ad sunucusu türünü ayarlayın."
+          }
+        }
+      }
+    },
+    "域名详情页新增「AI 爬虫」一栏，三档任选：不拦截、只拦广告页、全站拦截。AI 内容相关的两个设置也挪到了同一页，不必再开控制台。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone details now has an AI crawlers row with three modes: off, ad pages only, or block everywhere. The two AI content settings moved to the same screen, so you no longer need the dashboard."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域詳情頁新增「AI 爬蟲」一欄，三檔任選：不攔截、只攔廣告頁、全站攔截。AI 內容相關的兩個設定也移到同一頁，不必再開主控台。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名詳情頁新增「AI 爬蟲」一欄，三檔任選：不攔截、只攔廣告頁、全站攔截。AI 內容相關的兩個設定也移到同一頁，不必再開控制台。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン詳細に「AI クローラー」の項目が加わりました。ブロックしない／広告ページのみ／サイト全体の 3 段階から選べます。AI コンテンツ関連の 2 つの設定も同じ画面に移り、ダッシュボードを開く必要はありません。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los detalles del dominio ahora incluyen una fila de rastreadores de IA con tres modos: sin bloqueo, solo páginas con anuncios o todo el sitio. Los dos ajustes de contenido de IA pasaron a la misma pantalla, así que ya no hace falta el panel."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 상세 화면에 ‘AI 크롤러’ 항목이 생겼습니다. 차단 안 함, 광고 페이지만, 사이트 전체 중에서 고를 수 있습니다. AI 콘텐츠 설정 두 개도 같은 화면으로 옮겨서 대시보드를 열 필요가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do domínio agora têm uma linha de rastreadores de IA com três modos: sem bloqueio, só páginas com anúncios ou o site todo. As duas configurações de conteúdo de IA foram para a mesma tela, então o painel não é mais necessário."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do domínio passam a ter uma linha de rastreadores de IA com três modos: sem bloqueio, apenas páginas com anúncios ou todo o site. As duas definições de conteúdo de IA passaram para o mesmo ecrã, pelo que já não precisa do painel."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In den Domain-Details gibt es jetzt eine Zeile für KI-Crawler mit drei Stufen: nicht blocken, nur Anzeigenseiten oder die ganze Website. Die beiden KI-Inhaltseinstellungen sind auf denselben Bildschirm gewandert – das Dashboard brauchst du dafür nicht mehr."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les détails du domaine comportent désormais une ligne « robots d’IA » avec trois niveaux : aucun blocage, pages publicitaires uniquement, ou tout le site. Les deux réglages de contenu IA ont rejoint le même écran : plus besoin du tableau de bord."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا إلى تفاصيل النطاق صفًّا لزواحف الذكاء الاصطناعي بثلاثة أوضاع: بلا حظر، أو صفحات الإعلانات فقط، أو الموقع كله. كما انتقل إعدادا محتوى الذكاء الاصطناعي إلى الشاشة نفسها، فلم تعد بحاجة إلى لوحة التحكم."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı ayrıntılarına üç modlu bir yapay zekâ tarayıcı satırı eklendi: engelleme yok, yalnızca reklam sayfaları ya da tüm site. İki yapay zekâ içerik ayarı da aynı ekrana taşındı; artık panele gitmeniz gerekmiyor."
+          }
+        }
+      }
+    },
+    "域名详情页新增独立健康检查：查看每个源站的状态与失败原因，左滑暂停、右滑删除。打开「源站异常时通知我」后，由 Cloudflare 在状态变化时直接推送，App 不用开着。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone details now lists standalone health checks — status and failure reason per origin, swipe to suspend or delete. Turn on origin alerts and Cloudflare pushes you the moment status changes, whether or not the app is running."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域詳情頁新增獨立健康檢查：查看每個來源伺服器的狀態與失敗原因，左滑暫停、右滑刪除。開啟「來源異常時通知我」後，由 Cloudflare 在狀態變化時直接推播，App 不必開著。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名詳情頁新增獨立健康檢查：查看每個源站的狀態與失敗原因，左滑暫停、右滑刪除。開啟「源站異常時通知我」後，由 Cloudflare 在狀態變化時直接推送，App 不用開著。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン詳細にスタンドアロンのヘルスチェックが加わりました。オリジンごとの状態と失敗理由を確認でき、スワイプで一時停止や削除ができます。「オリジン異常時に通知」をオンにすると、状態が変わった時点で Cloudflare が直接通知するので、アプリを開いていなくても届きます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los detalles del dominio ahora listan comprobaciones de estado independientes: estado y motivo del fallo por origen, y desliza para pausar o eliminar. Activa el aviso de origen y Cloudflare te lo envía en cuanto cambie el estado, con la app abierta o no."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 상세 화면에 독립 상태 검사가 추가됐습니다. 오리진별 상태와 실패 사유를 보고, 밀어서 일시중지하거나 삭제할 수 있습니다. ‘오리진 이상 시 알림’을 켜면 상태가 바뀌는 순간 Cloudflare가 직접 알림을 보내므로 앱을 켜 둘 필요가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do domínio agora listam verificações de integridade independentes: status e motivo da falha por origem, deslize para pausar ou excluir. Ative o alerta de origem e o Cloudflare envia assim que o status mudar, com o app aberto ou não."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os detalhes do domínio passam a listar verificações de estado independentes: estado e motivo da falha por origem, deslize para pausar ou eliminar. Ative o alerta de origem e o Cloudflare envia assim que o estado mudar, com a app aberta ou não."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In den Domain-Details stehen jetzt eigenständige Health Checks: Status und Fehlergrund je Origin, per Wischen pausieren oder löschen. Aktivierst du die Origin-Benachrichtigung, schickt Cloudflare sie direkt beim Statuswechsel – auch wenn die App geschlossen ist."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les détails du domaine listent désormais les contrôles d’intégrité autonomes : état et cause de l’échec par origine, balayez pour suspendre ou supprimer. Activez l’alerte d’origine et Cloudflare vous l’envoie dès que l’état change, application ouverte ou non."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعرض تفاصيل النطاق الآن فحوص السلامة المستقلة: حالة كل خادم مصدر وسبب الإخفاق، مع السحب للإيقاف المؤقت أو الحذف. وبتفعيل تنبيه المصدر يرسل Cloudflare الإشعار فور تغيّر الحالة، سواء كان التطبيق مفتوحًا أم لا."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı ayrıntılarında artık bağımsız sağlık kontrolleri listeleniyor: her kaynak için durum ve hata nedeni, kaydırarak duraklatma veya silme. Kaynak uyarısını açtığınızda Cloudflare, durum değişir değişmez bildirimi doğrudan gönderir; uygulamanın açık olması gerekmez."
           }
         }
       }
@@ -6005,6 +6613,82 @@
         }
       }
     },
+    "新增 R2 数据目录、托管请求头、URL 安全扫描与 Email 抑制列表。审计日志点进任意一条即可查看同一资源的完整变更历史；缓存规则表达式加了常用字段速插（含 Bot 分数与来源 ASN）；Durable Objects 增加内存分位数。并修复隧道详情页不显示活跃连接的问题。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added R2 Data Catalog, Managed Transforms, URL security scanning and the Email suppression list. Tap any audit log entry to see the full change history of that resource; cache rule expressions got quick-insert chips for common fields (including bot score and source ASN); and Durable Objects now show memory percentiles. Also fixed tunnel details not listing active connections."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 R2 資料目錄、託管請求標頭、URL 安全掃描與 Email 抑制清單。審計日誌點進任一筆即可查看同一資源的完整變更歷史；快取規則運算式加了常用欄位速插（含 Bot 分數與來源 ASN）；Durable Objects 增加記憶體分位數。並修正通道詳情頁不顯示使用中連線的問題。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 R2 數據目錄、託管請求標頭、URL 安全掃描同 Email 抑制清單。審計日誌撳入任何一條就可以睇到同一資源嘅完整變更歷史；緩存規則運算式加咗常用欄位速插（包括 Bot 分數同來源 ASN）；Durable Objects 加咗記憶體分位數。另外修正咗隧道詳情頁唔顯示使用中連線嘅問題。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 データカタログ、マネージドヘッダー、URL セキュリティスキャン、Email 抑制リストを追加しました。監査ログはどの項目からでも、そのリソースの変更履歴全体を辿れます。キャッシュルールの式にはよく使うフィールド（ボットスコアや送信元 ASN を含む）のクイック挿入を追加。Durable Objects にはメモリのパーセンタイルが加わりました。トンネル詳細でアクティブな接続が表示されない問題も修正しています。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregamos R2 Data Catalog, encabezados administrados, escaneo de seguridad de URL y la lista de supresión de Email. Toca cualquier entrada del registro de auditoría para ver el historial completo de cambios de ese recurso; las expresiones de reglas de caché ahora tienen atajos para campos comunes (incluidos la puntuación de bot y el ASN de origen); y Durable Objects muestra percentiles de memoria. También corregimos que los detalles del túnel no listaran las conexiones activas."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 데이터 카탈로그, 관리형 헤더, URL 보안 검사, Email 억제 목록을 추가했습니다. 감사 로그의 아무 항목이나 누르면 해당 리소스의 전체 변경 기록을 볼 수 있습니다. 캐시 규칙 식에는 자주 쓰는 필드(봇 점수, 출발지 ASN 포함) 빠른 삽입이 생겼고, Durable Objects에는 메모리 백분위수가 추가됐습니다. 터널 상세에서 활성 연결이 표시되지 않던 문제도 고쳤습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionamos o R2 Data Catalog, cabeçalhos gerenciados, varredura de segurança de URL e a lista de supressão de Email. Toque em qualquer entrada do log de auditoria para ver todo o histórico de alterações daquele recurso; as expressões de regras de cache ganharam atalhos para campos comuns (incluindo pontuação de bot e ASN de origem); e os Durable Objects mostram percentis de memória. Também corrigimos os detalhes do túnel não listarem conexões ativas."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionámos o R2 Data Catalog, cabeçalhos geridos, análise de segurança de URL e a lista de supressão de Email. Toque em qualquer entrada do registo de auditoria para ver todo o histórico de alterações desse recurso; as expressões de regras de cache ganharam atalhos para campos comuns (incluindo pontuação de bot e ASN de origem); e os Durable Objects mostram percentis de memória. Corrigimos ainda os detalhes do túnel não listarem ligações ativas."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neu dabei: R2 Data Catalog, Managed Transforms, URL-Sicherheitsscan und die E-Mail-Sperrliste. Tippe im Audit-Log auf einen Eintrag, um den vollständigen Änderungsverlauf dieser Ressource zu sehen; Cache-Regel-Ausdrücke haben jetzt Schnellbausteine für gängige Felder (inklusive Bot-Score und Quell-ASN); und Durable Objects zeigen Speicher-Perzentile. Außerdem behoben: In den Tunnel-Details fehlten die aktiven Verbindungen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajout de R2 Data Catalog, des en-têtes gérés, de l’analyse de sécurité d’URL et de la liste de suppression Email. Touchez n’importe quelle entrée du journal d’audit pour voir tout l’historique des modifications de la ressource ; les expressions de règles de cache disposent de raccourcis pour les champs courants (score de bot et ASN source compris) ; et les Durable Objects affichent des percentiles de mémoire. Correction également des détails de tunnel qui n’affichaient pas les connexions actives."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا R2 Data Catalog والعناوين المُدارة وفحص أمان الروابط وقائمة حظر البريد. اضغط أي سجل تدقيق لعرض سجل التغييرات الكامل لذلك المورد؛ وأضفنا إلى تعبيرات قواعد التخزين المؤقت إدراجًا سريعًا للحقول الشائعة (بما فيها درجة الروبوت ورقم النظام المصدر ASN)؛ كما تعرض Durable Objects الآن مئينات الذاكرة. وأصلحنا كذلك عدم ظهور الاتصالات النشطة في تفاصيل النفق."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 Data Catalog, yönetilen başlıklar, URL güvenlik taraması ve E-posta engelleme listesi eklendi. Denetim günlüğünde herhangi bir kayda dokunarak o kaynağın tüm değişiklik geçmişini görebilirsiniz; önbellek kuralı ifadelerine sık kullanılan alanlar için hızlı ekleme geldi (bot puanı ve kaynak ASN dahil); Durable Objects artık bellek yüzdeliklerini gösteriyor. Ayrıca tünel ayrıntılarında etkin bağlantıların listelenmemesi sorunu giderildi."
+          }
+        }
+      }
+    },
     "新增「减少动画」开关让界面更跟手，优化多账号切换的稳定性，并在后台预热数据，切回前台更快看到最新内容。": {
       "localizations": {
         "en": {
@@ -6609,6 +7293,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Oturum açmadan kullanabileceğiniz pratik ağ araçları: DNS sorgusu, SSL sertifikası incelemesi, HTTP başlıkları, WHOIS, IP konumu, CIDR hesaplayıcı ve Cloudflare trace — giriş ekranından doğrudan erişilebilir."
+          }
+        }
+      }
+    },
+    "更多模块，以及一处处打磨": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More modules, and a lot of polish"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更多模組，以及一處處打磨"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更多模組，同埋一處處打磨"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モジュールの追加と細部の磨き込み"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más módulos y muchos detalles pulidos"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모듈 추가와 곳곳의 다듬기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais módulos e muito polimento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais módulos e muito polimento"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr Module und viel Feinschliff"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De nouveaux modules et beaucoup de finitions"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وحدات إضافية ولمسات صقل كثيرة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daha fazla modül ve bolca cila"
           }
         }
       }
@@ -7449,6 +8209,158 @@
         }
       }
     },
+    "概览页新增「域名注册商」：在 Cloudflare 注册的域名，到期日、自动续费与转移锁状态都列在一起，快到期的会标出来。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The overview gains a Registrar section: for domains registered with Cloudflare you get expiry date, auto-renew and transfer lock in one list, with the ones expiring soon called out."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總覽頁新增「網域註冊商」：在 Cloudflare 註冊的網域，到期日、自動續約與移轉鎖狀態列在一起，快到期的會標示出來。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概覽頁新增「域名註冊商」：在 Cloudflare 註冊的域名，到期日、自動續費與轉移鎖狀態列在一起，快到期的會標出來。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要ページに「ドメイン登録」が加わりました。Cloudflare で登録したドメインの有効期限・自動更新・移管ロックが一覧で並び、期限が近いものは目立つように表示されます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El resumen suma una sección de registrador: para los dominios registrados en Cloudflare verás vencimiento, renovación automática y bloqueo de transferencia en una sola lista, con los próximos a vencer destacados."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면에 ‘도메인 등록’ 섹션이 생겼습니다. Cloudflare에 등록한 도메인의 만료일, 자동 갱신, 이전 잠금을 한 목록에서 보고, 곧 만료되는 항목은 따로 표시됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A visão geral ganha uma seção de registrador: para domínios registrados na Cloudflare você vê vencimento, renovação automática e bloqueio de transferência numa lista só, com os que vencem em breve destacados."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A descrição geral ganha uma secção de registador: para domínios registados na Cloudflare vê expiração, renovação automática e bloqueio de transferência numa só lista, com os que expiram em breve destacados."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Übersicht bekommt einen Registrar-Bereich: Für bei Cloudflare registrierte Domains stehen Ablaufdatum, automatische Verlängerung und Transfer-Sperre in einer Liste – bald ablaufende sind hervorgehoben."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’aperçu gagne une section Bureau d’enregistrement : pour les domaines enregistrés chez Cloudflare, expiration, renouvellement automatique et verrou de transfert dans une même liste, avec un repère sur ceux qui expirent bientôt."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا إلى صفحة النظرة العامة قسم «مُسجِّل النطاقات»: للنطاقات المسجّلة لدى Cloudflare تظهر تواريخ الانتهاء والتجديد التلقائي وقفل النقل في قائمة واحدة، مع إبراز ما يقترب انتهاؤه."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakışa bir kayıt kuruluşu bölümü eklendi: Cloudflare’de kayıtlı alan adlarının bitiş tarihi, otomatik yenileme ve transfer kilidi tek listede; yakında dolacaklar ayrıca işaretleniyor."
+          }
+        }
+      }
+    },
+    "概览页新增「请求追踪」：填一个网址就能看到这条请求依次命中了哪些规则——重定向、WAF、缓存规则、Worker，每一步是否生效都写清楚，调规则不用再靠猜。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The overview gains Request Tracing: enter a URL and see, step by step, which rules the request hits — redirects, WAF, cache rules, Workers — and whether each one fired. No more guessing why a rule didn’t apply."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總覽頁新增「請求追蹤」：填一個網址就能看到這筆請求依序命中了哪些規則——重新導向、WAF、快取規則、Worker，每一步是否生效都寫清楚，調規則不必再靠猜。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概覽頁新增「請求追蹤」：填一個網址就能看到這條請求依次命中咗邊啲規則——重新導向、WAF、緩存規則、Worker，每一步有冇生效都寫得清清楚楚，調規則唔使再靠估。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要ページに「リクエスト追跡」が加わりました。URL を入力すると、そのリクエストがリダイレクト・WAF・キャッシュルール・Worker のどれに順番に当たり、各ステップが実際に効いたかまで表示されます。ルール調整で当て推量は不要です。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El resumen suma Rastreo de solicitudes: escribe una URL y verás, paso a paso, qué reglas alcanza la solicitud —redirecciones, WAF, reglas de caché, Workers— y si cada una se aplicó. Se acabó adivinar por qué una regla no entró."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면에 ‘요청 추적’이 추가됐습니다. URL을 넣으면 그 요청이 리디렉션, WAF, 캐시 규칙, Worker 중 무엇을 순서대로 거치고 각 단계가 실제로 적용됐는지까지 보여 줍니다. 규칙이 왜 안 먹는지 더 이상 짐작하지 않아도 됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A visão geral ganha Rastreamento de requisições: informe uma URL e veja, passo a passo, quais regras a requisição atinge — redirecionamentos, WAF, regras de cache, Workers — e se cada uma foi aplicada. Chega de adivinhar por que uma regra não pegou."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A descrição geral ganha Rastreio de pedidos: indique um URL e veja, passo a passo, que regras o pedido atinge — redirecionamentos, WAF, regras de cache, Workers — e se cada uma foi aplicada. Deixa de ser preciso adivinhar."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Übersicht bekommt Request Tracing: Gib eine URL ein und sieh Schritt für Schritt, auf welche Regeln die Anfrage trifft – Redirects, WAF, Cache-Regeln, Workers – und ob jede davon gegriffen hat. Kein Raten mehr, warum eine Regel nicht zieht."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’aperçu gagne le traçage de requêtes : saisissez une URL et voyez, étape par étape, quelles règles la requête rencontre — redirections, WAF, règles de cache, Workers — et si chacune s’est appliquée. Fini les suppositions."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا إلى صفحة النظرة العامة «تتبّع الطلبات»: أدخل عنوانًا لترى خطوة بخطوة القواعد التي يمرّ بها الطلب — إعادة التوجيه وWAF وقواعد التخزين المؤقت وWorkers — وما إذا كانت كل قاعدة قد طُبِّقت فعلًا. لا حاجة بعد الآن للتخمين."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakışa istek izleme eklendi: bir URL girin, isteğin sırayla hangi kurallara çarptığını — yönlendirmeler, WAF, önbellek kuralları, Worker’lar — ve her adımın gerçekten uygulanıp uygulanmadığını görün. Bir kuralın neden işlemediğini artık tahmin etmeyin."
+          }
+        }
+      }
+    },
     "概览页新增告警卡片，汇总需要注意的资源——未启用的域名、状态异常的隧道等，点一下直达。": {
       "localizations": {
         "en": {
@@ -7901,6 +8813,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alan adı ekle"
+          }
+        }
+      }
+    },
+    "源站掉线，Cloudflare 直接推给你": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare pings you when your origin goes down"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來源伺服器掉線，Cloudflare 直接推給你"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "源站掉線，Cloudflare 直接推給你"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オリジンが落ちたら Cloudflare が直接通知"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare te avisa si tu servidor de origen se cae"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오리진이 죽으면 Cloudflare가 바로 알려줍니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Cloudflare te avisa quando a origem cai"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Cloudflare avisa-o quando a origem fica em baixo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare meldet sich, wenn dein Origin ausfällt"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare vous prévient quand votre origine tombe"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يخبرك Cloudflare مباشرةً عند تعطّل خادم المصدر"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak sunucunuz düşerse Cloudflare doğrudan haber verir"
           }
         }
       }
@@ -8585,6 +9573,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Canlı kaynağı yükleyip düzenleyin ve yeniden dağıtın; değişkenleriniz, gizli anahtarlarınız ve bağlamalarınız korunur. Ayrıca bir .js dosyasından içe aktarabilir veya Worker’ın tamamını silebilirsiniz."
+          }
+        }
+      }
+    },
+    "看清一条请求在 Cloudflare 里走过什么": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See what a request actually hits inside Cloudflare"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "看清一筆請求在 Cloudflare 裡走過什麼"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "睇清一條請求喺 Cloudflare 裡面經過咗啲乜"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエストが Cloudflare 内で何を通ったかを可視化"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mira por qué reglas pasa una solicitud dentro de Cloudflare"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청이 Cloudflare 안에서 무엇을 거치는지 확인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja por onde uma requisição passa dentro da Cloudflare"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja por onde passa um pedido dentro da Cloudflare"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sieh, was eine Anfrage in Cloudflare wirklich trifft"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voyez ce qu’une requête traverse réellement dans Cloudflare"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعرف ما يمرّ به الطلب فعليًا داخل Cloudflare"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir isteğin Cloudflare içinde neye çarptığını görün"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,43 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "2.0.0", items: [
+            WhatsNewItem(
+                icon:   "brain",
+                title:  String(localized: "一个开关拦住 AI 爬虫", table: "WhatsNew"),
+                detail: String(localized: "域名详情页新增「AI 爬虫」一栏，三档任选：不拦截、只拦广告页、全站拦截。AI 内容相关的两个设置也挪到了同一页，不必再开控制台。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "waveform.path.ecg",
+                title:  String(localized: "源站掉线，Cloudflare 直接推给你", table: "WhatsNew"),
+                detail: String(localized: "域名详情页新增独立健康检查：查看每个源站的状态与失败原因，左滑暂停、右滑删除。打开「源站异常时通知我」后，由 Cloudflare 在状态变化时直接推送，App 不用开着。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "calendar.badge.clock",
+                title:  String(localized: "域名到期日一眼看到", table: "WhatsNew"),
+                detail: String(localized: "概览页新增「域名注册商」：在 Cloudflare 注册的域名，到期日、自动续费与转移锁状态都列在一起，快到期的会标出来。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "scope",
+                title:  String(localized: "看清一条请求在 Cloudflare 里走过什么", table: "WhatsNew"),
+                detail: String(localized: "概览页新增「请求追踪」：填一个网址就能看到这条请求依次命中了哪些规则——重定向、WAF、缓存规则、Worker，每一步是否生效都写清楚，调规则不用再靠猜。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "lock.shield",
+                title:  String(localized: "DNSSEC 与 DNS 进阶设置", table: "WhatsNew"),
+                detail: String(localized: "域名详情页新增 DNS 设置：一键开关 DNSSEC 并复制要填到注册商那边的 DS 记录，另可调整 CNAME 展平方式与域名服务器类型。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "hammer",
+                title:  String(localized: "Worker 构建失败会提醒你", table: "WhatsNew"),
+                detail: String(localized: "Worker 详情页新增构建记录：每次构建的状态、耗时与触发来源都能看到。挑几个关心的 Worker 开启监视，构建失败时会收到通知。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "square.grid.2x2",
+                title:  String(localized: "更多模块，以及一处处打磨", table: "WhatsNew"),
+                detail: String(localized: "新增 R2 数据目录、托管请求头、URL 安全扫描与 Email 抑制列表。审计日志点进任意一条即可查看同一资源的完整变更历史；缓存规则表达式加了常用字段速插（含 Bot 分数与来源 ASN）；Durable Objects 增加内存分位数。并修复隧道详情页不显示活跃连接的问题。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "1.9.3", items: [
             WhatsNewItem(
                 icon:   "pause.circle",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -152480,6 +152480,10722 @@
           }
         }
       }
+    },
+    "AI 内容控制": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحكم في محتوى الذكاء الاصطناعي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Inhaltssteuerung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI Content Controls"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controles de contenido de IA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôles de contenu IA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI コンテンツ制御"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 콘텐츠 제어"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controles de conteúdo de IA"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlos de conteúdo de IA"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapay Zekâ İçerik Denetimi"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 內容控制"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 內容控制"
+          }
+        }
+      }
+    },
+    "AI 训练重定向": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة توجيه تدريب الذكاء الاصطناعي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Trainings-Weiterleitungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI Training Redirects"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redirecciones de entrenamiento de IA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redirections pour l'entraînement IA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 学習リダイレクト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 학습 리디렉션"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redirecionamentos de treinamento de IA"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redirecionamentos de treino de IA"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapay zekâ eğitimi yönlendirmeleri"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 訓練重新導向"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 訓練重定向"
+          }
+        }
+      }
+    },
+    "把用于模型训练的爬虫引走": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة توجيه الزواحف التي تجمع المحتوى لتدريب النماذج"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crawler umleiten, die Inhalte für das Modelltraining sammeln"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redirect crawlers that collect content for model training"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desvía los rastreadores que recopilan contenido para entrenar modelos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détourne les robots qui collectent du contenu pour entraîner des modèles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデル学習用のクローラーを迂回させます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 학습용 크롤러를 다른 곳으로 보냅니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desvia os rastreadores que coletam conteúdo para treinar modelos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desvia os rastreadores que recolhem conteúdo para treinar modelos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model eğitimi için içerik toplayan tarayıcıları başka yöne yönlendirir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將用於模型訓練的爬蟲導走"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將用於模型訓練的爬蟲引走"
+          }
+        }
+      }
+    },
+    "面向 Agent 的 Markdown": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown للوكلاء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown für Agenten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown for Agents"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown para agentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown pour les agents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント向け Markdown"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트용 Markdown"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown para agentes"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown para agentes"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aracılar için Markdown"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面向 Agent 的 Markdown"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面向 Agent 的 Markdown"
+          }
+        }
+      }
+    },
+    "按请求把页面转成 Markdown 返回": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تقديم الصفحات بصيغة Markdown عندما يطلبها العميل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seiten auf Anfrage als Markdown ausliefern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serve pages as Markdown when a client asks for it"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrega las páginas en Markdown cuando el cliente lo solicita"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renvoie les pages en Markdown lorsque le client le demande"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クライアントが要求したときにページを Markdown に変換して返します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라이언트가 요청하면 페이지를 Markdown으로 변환해 반환합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrega as páginas em Markdown quando o cliente solicita"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fornece as páginas em Markdown quando o cliente o solicita"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İstemci istediğinde sayfaları Markdown olarak sunar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在用戶端要求時，將頁面轉成 Markdown 回傳"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在客戶端要求時，將頁面轉成 Markdown 返回"
+          }
+        }
+      }
+    },
+    "AI 爬虫": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زواحف الذكاء الاصطناعي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Crawler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI Crawlers"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreadores de IA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Robots d'IA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI クローラー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 크롤러"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreadores de IA"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreadores de IA"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapay zekâ tarayıcıları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 爬蟲"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 爬蟲"
+          }
+        }
+      }
+    },
+    "抓取内容用于训练或问答的机器人": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روبوتات تجمع المحتوى للتدريب أو للإجابة عن الأسئلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bots, die Inhalte für Training oder Antworten sammeln"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bots that collect content for training or answering questions"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bots que recopilan contenido para entrenar modelos o responder preguntas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Robots qui collectent du contenu pour l'entraînement ou les réponses"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学習や質問応答のためにコンテンツを収集するボット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학습이나 질의응답을 위해 콘텐츠를 수집하는 봇"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bots que coletam conteúdo para treinar modelos ou responder perguntas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bots que recolhem conteúdo para treinar modelos ou responder a perguntas"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eğitim veya soru yanıtlama için içerik toplayan botlar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "擷取內容用於訓練或問答的機器人"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抓取內容用於訓練或問答的機械人"
+          }
+        }
+      }
+    },
+    "链接迷宫": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متاهة الروابط"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link-Labyrinth"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link Maze"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laberinto de enlaces"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Labyrinthe de liens"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクの迷路"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "링크 미로"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Labirinto de links"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Labirinto de ligações"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantı labirenti"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結迷宮"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結迷宮"
+          }
+        }
+      }
+    },
+    "用无尽链接消耗违规爬虫": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاع الزواحف المخالفة في روابط لا تنتهي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regelwidrige Crawler in endlosen Links binden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trap misbehaving crawlers in endless links"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrapa a los rastreadores infractores en enlaces sin fin"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piège les robots indélicats dans des liens sans fin"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規約違反のクローラーを無限のリンクで消耗させます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "규칙을 어기는 크롤러를 끝없는 링크에 가둡니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prende rastreadores abusivos em links infinitos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prende rastreadores abusivos em ligações infinitas"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kural dışı tarayıcıları sonsuz bağlantılarda oyalar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用無盡連結消耗違規爬蟲"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用無盡連結消耗違規爬蟲"
+          }
+        }
+      }
+    },
+    "拦截内容机器人": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حظر روبوتات المحتوى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Content-Bots blockieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block Content Bots"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear bots de contenido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquer les robots de contenu"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンテンツボットをブロック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "콘텐츠 봇 차단"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear bots de conteúdo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear bots de conteúdo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İçerik botlarını engelle"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "攔截內容機器人"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "攔截內容機械人"
+          }
+        }
+      }
+    },
+    "拦下低可信自动流量，已验证的机器人除外": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حظر حركة المرور الآلية منخفضة الموثوقية، باستثناء الروبوتات المُوثَّقة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisierten Traffic mit geringer Vertrauenswürdigkeit blockieren, verifizierte Bots ausgenommen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block low-confidence automated traffic, except verified bots"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquea el tráfico automatizado poco confiable, salvo los bots verificados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloque le trafic automatisé peu fiable, sauf les robots vérifiés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度の低い自動トラフィックをブロックします（検証済みボットを除く）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신뢰도가 낮은 자동화 트래픽을 차단합니다. 검증된 봇은 제외합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueia tráfego automatizado de baixa confiança, exceto bots verificados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueia tráfego automatizado de baixa confiança, exceto bots verificados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doğrulanmış botlar hariç, güven düzeyi düşük otomatik trafiği engeller"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "攔下低可信自動流量，已驗證的機器人除外"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "攔下低可信自動流量，已驗證的機械人除外"
+          }
+        }
+      }
+    },
+    "托管 robots.txt": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "robots.txt مُدار"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwaltete robots.txt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Managed robots.txt"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "robots.txt administrado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "robots.txt géré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マネージド robots.txt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "관리형 robots.txt"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "robots.txt gerenciado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "robots.txt gerido"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yönetilen robots.txt"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "託管 robots.txt"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "託管 robots.txt"
+          }
+        }
+      }
+    },
+    "由 Cloudflare 维护，置于现有内容之前": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتولى Cloudflare صيانته ويوضع قبل المحتوى الحالي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von Cloudflare gepflegt und vor Ihren vorhandenen Inhalt gesetzt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintained by Cloudflare and placed before your existing content"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare lo mantiene y lo coloca antes de tu contenido actual"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenu par Cloudflare et placé avant votre contenu existant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare が管理し、既存の内容の前に配置されます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare가 관리하며 기존 내용 앞에 배치됩니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantido pela Cloudflare e colocado antes do conteúdo existente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantido pela Cloudflare e colocado antes do conteúdo existente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare tarafından bakımı yapılır ve mevcut içeriğinizin önüne yerleştirilir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 維護，置於現有內容之前"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 維護，置於現有內容之前"
+          }
+        }
+      }
+    },
+    "内容使用声明": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سياسة استخدام المحتوى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzungsrichtlinie für Inhalte"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Content Usage Policy"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de uso del contenido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Politique d'utilisation du contenu"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンテンツ利用ポリシー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "콘텐츠 사용 정책"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de uso do conteúdo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de utilização do conteúdo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İçerik kullanım politikası"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "內容使用聲明"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "內容使用聲明"
+          }
+        }
+      }
+    },
+    "在 robots.txt 中声明内容的使用许可": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حدِّد في robots.txt كيفية استخدام المحتوى الخاص بك"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In der robots.txt angeben, wie Ihre Inhalte genutzt werden dürfen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Declare how your content may be used in robots.txt"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Declara en robots.txt cómo puede usarse tu contenido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déclare dans robots.txt comment votre contenu peut être utilisé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンテンツの利用許諾を robots.txt で宣言します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "robots.txt에 콘텐츠 사용 허가를 명시합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Declare no robots.txt como seu conteúdo pode ser usado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Declare no robots.txt como o seu conteúdo pode ser utilizado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İçeriğinizin nasıl kullanılabileceğini robots.txt içinde belirtir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 robots.txt 中聲明內容的使用授權"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 robots.txt 中聲明內容的使用授權"
+          }
+        }
+      }
+    },
+    "仅拦广告页": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صفحات الإعلانات فقط"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur Seiten mit Werbung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ad pages only"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo páginas con anuncios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pages avec publicité uniquement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "広告ページのみ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "광고 페이지만"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Somente páginas com anúncios"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apenas páginas com anúncios"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yalnızca reklamlı sayfalar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅攔廣告頁"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅攔廣告頁"
+          }
+        }
+      }
+    },
+    "全站拦截": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحظر في الموقع بالكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überall blockieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block everywhere"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear en todo el sitio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquer sur tout le site"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイト全体でブロック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이트 전체 차단"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear em todo o site"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear em todo o site"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitenin tamamında engelle"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全站攔截"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全站攔截"
+          }
+        }
+      }
+    },
+    "AI 与机器人": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الذكاء الاصطناعي والروبوتات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI und Bots"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI & Bots"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IA y bots"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IA et robots"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI とボット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 및 봇"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IA e bots"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IA e bots"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapay zekâ ve botlar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 與機器人"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 與機械人"
+          }
+        }
+      }
+    },
+    "管控 AI 爬虫、内容机器人与 robots.txt": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة زواحف الذكاء الاصطناعي وروبوتات المحتوى وrobots.txt"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Crawler, Content-Bots und robots.txt verwalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage AI crawlers, content bots, and robots.txt"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administra rastreadores de IA, bots de contenido y robots.txt"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérez les robots d'IA, les robots de contenu et robots.txt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI クローラー、コンテンツボット、robots.txt を管理します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 크롤러, 콘텐츠 봇, robots.txt를 관리합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie rastreadores de IA, bots de conteúdo e robots.txt"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faça a gestão de rastreadores de IA, bots de conteúdo e robots.txt"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapay zekâ tarayıcılarını, içerik botlarını ve robots.txt dosyasını yönetin"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管控 AI 爬蟲、內容機器人與 robots.txt"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管控 AI 爬蟲、內容機械人與 robots.txt"
+          }
+        }
+      }
+    },
+    "健康检查": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فحوصات السلامة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integritätsprüfungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Health Checks"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobaciones de estado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôles d'intégrité"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルスチェック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상태 확인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificações de integridade"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificações de estado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sağlık denetimleri"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "健康檢查"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "健康檢查"
+          }
+        }
+      }
+    },
+    "此域名暂无健康检查。可在 Cloudflare 控制台创建后回到这里查看与暂停。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد فحوصات سلامة لهذا النطاق بعد. أنشئ واحدًا من لوحة تحكم Cloudflare ثم عد إلى هنا لعرضه وإيقافه مؤقتًا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für diese Domain gibt es noch keine Integritätsprüfungen. Legen Sie eine im Cloudflare-Dashboard an und kehren Sie hierher zurück, um sie anzusehen und zu pausieren."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No health checks on this domain yet. Create one in the Cloudflare dashboard, then come back here to view and pause it."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dominio aún no tiene comprobaciones de estado. Crea una en el panel de Cloudflare y vuelve aquí para verla y pausarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun contrôle d'intégrité sur ce domaine. Créez-en un dans le tableau de bord Cloudflare, puis revenez ici pour le consulter et le suspendre."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このドメインにはヘルスチェックがまだありません。Cloudflare ダッシュボードで作成すると、ここで確認や一時停止ができます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 도메인에는 아직 상태 확인이 없습니다. Cloudflare 대시보드에서 만든 뒤 여기에서 확인하고 일시 중지할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este domínio ainda não tem verificações de integridade. Crie uma no painel da Cloudflare e volte aqui para ver e pausar."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este domínio ainda não tem verificações de estado. Crie uma no painel da Cloudflare e volte aqui para ver e colocar em pausa."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu alan adında henüz sağlık denetimi yok. Cloudflare panelinden bir tane oluşturup görüntülemek ve duraklatmak için buraya dönün."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此網域暫無健康檢查。可在 Cloudflare 主控台建立後回到這裡查看與暫停。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此域名暫無健康檢查。可在 Cloudflare 控制台建立後回到這裡查看與暫停。"
+          }
+        }
+      }
+    },
+    "恢复": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استئناف"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再開"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sürdür"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復"
+          }
+        }
+      }
+    },
+    "源站监控（%@）": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مراقبة الخادم المصدر (%@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Origin-Überwachung (%@)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Origin monitoring (%@)"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoreo del origen (%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surveillance de l'origine (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オリジン監視（%@）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오리진 모니터링(%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoramento da origem (%@)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitorização da origem (%@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak sunucu izleme (%@)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來源伺服器監控（%@）"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "源站監控（%@）"
+          }
+        }
+      }
+    },
+    "点按查看详情，左滑暂停或恢复，右滑删除。暂停后不再向源站发送检查。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط لعرض التفاصيل، واسحب لليسار للإيقاف المؤقت أو الاستئناف، ولليمين للحذف. لا تُرسَل الفحوصات إلى الخادم المصدر أثناء الإيقاف المؤقت."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippen für Details, nach links wischen zum Pausieren oder Fortsetzen, nach rechts zum Löschen. Pausierte Prüfungen werden nicht mehr an den Origin gesendet."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap for details, swipe left to pause or resume, swipe right to delete. Paused checks are no longer sent to the origin."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca para ver los detalles, desliza a la izquierda para pausar o reanudar y a la derecha para eliminar. En pausa no se envían comprobaciones al origen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez pour les détails, balayez vers la gauche pour suspendre ou reprendre, vers la droite pour supprimer. En pause, aucun contrôle n'est envoyé à l'origine."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップで詳細、左スワイプで一時停止・再開、右スワイプで削除します。一時停止中はオリジンへチェックを送信しません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭하면 세부 정보를 보고, 왼쪽으로 밀면 일시 중지하거나 재개하며, 오른쪽으로 밀면 삭제합니다. 일시 중지하면 오리진으로 확인을 보내지 않습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para ver detalhes, deslize à esquerda para pausar ou retomar e à direita para excluir. Em pausa, nenhuma verificação é enviada à origem."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para ver detalhes, deslize para a esquerda para pausar ou retomar e para a direita para eliminar. Em pausa, não são enviadas verificações à origem."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayrıntılar için dokunun, duraklatmak veya sürdürmek için sola, silmek için sağa kaydırın. Duraklatıldığında kaynak sunucuya denetim gönderilmez."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點按查看詳情，左滑暫停或恢復，右滑刪除。暫停後不再向來源伺服器傳送檢查。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點按查看詳情，左滑暫停或恢復，右滑刪除。暫停後不再向源站發送檢查。"
+          }
+        }
+      }
+    },
+    "当前授权仅限读取（healthcheck.read）。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التفويض الحالي للقراءة فقط (healthcheck.read)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die aktuelle Autorisierung ist schreibgeschützt (healthcheck.read)."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current authorization is read-only (healthcheck.read)."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La autorización actual es solo de lectura (healthcheck.read)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation actuelle est en lecture seule (healthcheck.read)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の認可は読み取りのみです（healthcheck.read）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 권한은 읽기 전용입니다(healthcheck.read)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é somente leitura (healthcheck.read)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é apenas de leitura (healthcheck.read)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut yetkilendirme salt okunurdur (healthcheck.read)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（healthcheck.read）。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（healthcheck.read）。"
+          }
+        }
+      }
+    },
+    "删除健康检查": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف فحص السلامة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integritätsprüfung löschen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Health Check"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar comprobación de estado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le contrôle d'intégrité"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルスチェックを削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상태 확인 삭제"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir verificação de integridade"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar verificação de estado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sağlık denetimini sil"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除健康檢查"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除健康檢查"
+          }
+        }
+      }
+    },
+    "删除后将不再监控该源站，也不会再收到相关通知。不可撤销。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لن تتم مراقبة الخادم المصدر بعد الآن ولن تصلك إشعاراته. لا يمكن التراجع."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Origin wird nicht mehr überwacht und Sie erhalten keine zugehörigen Benachrichtigungen mehr. Nicht rückgängig zu machen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The origin will no longer be monitored and you will stop receiving its notifications. This cannot be undone."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El origen dejará de monitorearse y ya no recibirás sus notificaciones. No se puede deshacer."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'origine ne sera plus surveillée et vous ne recevrez plus ses notifications. Action irréversible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除するとこのオリジンは監視されなくなり、関連する通知も届かなくなります。元に戻せません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제하면 해당 오리진을 더 이상 모니터링하지 않으며 관련 알림도 오지 않습니다. 되돌릴 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A origem deixará de ser monitorada e você não receberá mais as notificações dela. Não é possível desfazer."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A origem deixará de ser monitorizada e deixará de receber as respetivas notificações. Não é possível anular."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak sunucu artık izlenmeyecek ve bildirimleri gelmeyecek. Geri alınamaz."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除後將不再監控該來源伺服器，也不會再收到相關通知。無法復原。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除後將不再監控該源站，也不會再收到相關通知。無法復原。"
+          }
+        }
+      }
+    },
+    "当前状态": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحالة الحالية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktueller Status"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current Status"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado actual"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État actuel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の状態"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 상태"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status atual"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado atual"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçerli durum"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前狀態"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前狀態"
+          }
+        }
+      }
+    },
+    "失败原因": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبب الفشل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehlerursache"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failure Reason"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motivo del fallo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cause de l'échec"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗の理由"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실패 원인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motivo da falha"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motivo da falha"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başarısızlık nedeni"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗原因"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗原因"
+          }
+        }
+      }
+    },
+    "连续失败": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إخفاقات متتالية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufeinanderfolgende Fehler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consecutive Failures"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fallos consecutivos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échecs consécutifs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連続失敗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연속 실패"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falhas consecutivas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falhas consecutivas"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ardışık başarısızlık"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連續失敗"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連續失敗"
+          }
+        }
+      }
+    },
+    "连续成功": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نجاحات متتالية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufeinanderfolgende Erfolge"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consecutive Successes"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Éxitos consecutivos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Succès consécutifs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連続成功"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연속 성공"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sucessos consecutivos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sucessos consecutivos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ardışık başarı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連續成功"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連續成功"
+          }
+        }
+      }
+    },
+    "检查间隔": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فاصل الفحص"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfintervall"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check Interval"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalo de comprobación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalle de contrôle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェック間隔"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 간격"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalo de verificação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalo de verificação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denetim aralığı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查間隔"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查間隔"
+          }
+        }
+      }
+    },
+    "检查区域": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مناطق الفحص"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfregionen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check Regions"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regiones de comprobación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Régions de contrôle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェック地域"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 지역"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regiões de verificação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regiões de verificação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denetim bölgeleri"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查區域"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查區域"
+          }
+        }
+      }
+    },
+    "由 Cloudflare 自选": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تختارها Cloudflare"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von Cloudflare gewählt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chosen by Cloudflare"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegidas por Cloudflare"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisies par Cloudflare"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare が選択"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare가 선택"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolhidas pela Cloudflare"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolhidas pela Cloudflare"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare tarafından seçilir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 自選"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 自選"
+          }
+        }
+      }
+    },
+    "监控源站是否在线；读写可暂停与删除": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مراقبة ما إذا كان الخادم المصدر متصلاً؛ صلاحية الكتابة تتيح الإيقاف المؤقت والحذف"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überwacht, ob Ihr Origin online ist; mit Schreibzugriff pausieren und löschen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitor whether your origin is online; write access can pause and delete"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitorea si tu origen está en línea; con escritura puedes pausar y eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surveille si votre origine est en ligne ; l'accès en écriture permet de suspendre et supprimer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オリジンがオンラインかを監視します。読み書きでは一時停止と削除ができます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오리진이 온라인 상태인지 모니터링합니다. 쓰기 권한으로 일시 중지와 삭제가 가능합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitore se a origem está on-line; com escrita é possível pausar e excluir"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitorize se a origem está online; com escrita pode pausar e eliminar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak sunucunuzun çevrimiçi olup olmadığını izler; yazma yetkisiyle duraklatıp silebilirsiniz"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控來源伺服器是否在線；讀寫可暫停與刪除"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控源站是否在線；讀寫可暫停與刪除"
+          }
+        }
+      }
+    },
+    "DNS 设置": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعدادات DNS"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS-Einstellungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS Settings"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración de DNS"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres DNS"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 설정"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurações de DNS"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definições de DNS"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS ayarları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 設定"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 設定"
+          }
+        }
+      }
+    },
+    "读不到该域名的 DNS 设置。可能是权限不足，或此域名不支持这些选项。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّرت قراءة إعدادات DNS لهذا النطاق. قد تكون الصلاحية ناقصة أو أن النطاق لا يدعم هذه الخيارات."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS-Einstellungen dieser Domain können nicht gelesen werden. Möglicherweise fehlt die Berechtigung oder die Domain unterstützt diese Optionen nicht."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not read DNS settings for this domain. You may lack permission, or the domain may not support these options."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron leer las configuraciones de DNS de este dominio. Puede que falten permisos o que el dominio no admita estas opciones."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de lire les paramètres DNS de ce domaine. Il peut manquer une autorisation, ou le domaine ne prend pas en charge ces options."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このドメインの DNS 設定を読み取れません。権限が不足しているか、このドメインが対応していない可能性があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 도메인의 DNS 설정을 읽을 수 없습니다. 권한이 없거나 도메인이 이 옵션을 지원하지 않을 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível ler as configurações de DNS deste domínio. Pode faltar permissão ou o domínio não oferece suporte a essas opções."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível ler as definições de DNS deste domínio. Pode faltar permissão ou o domínio não suporta estas opções."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu alan adının DNS ayarları okunamadı. İzin eksik olabilir veya alan adı bu seçenekleri desteklemiyor olabilir."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讀不到此網域的 DNS 設定。可能是權限不足，或此網域不支援這些選項。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讀不到此域名的 DNS 設定。可能是權限不足，或此域名不支援這些選項。"
+          }
+        }
+      }
+    },
+    "DS 记录": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجل DS"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS-Eintrag"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS Record"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro DS"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement DS"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS レコード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS 레코드"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro DS"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registo DS"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS kaydı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS 記錄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS 記錄"
+          }
+        }
+      }
+    },
+    "复制 DS 记录": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ سجل DS"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS-Eintrag kopieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy DS Record"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar registro DS"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier l'enregistrement DS"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS レコードをコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS 레코드 복사"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar registro DS"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar registo DS"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DS kaydını kopyala"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製 DS 記錄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製 DS 記錄"
+          }
+        }
+      }
+    },
+    "还需把上面的 DS 记录添加到你的域名注册商处，DNSSEC 才会真正生效。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضف سجل DS أعلاه لدى مُسجِّل النطاق لكي يصبح DNSSEC ساري المفعول."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fügen Sie den DS-Eintrag oben bei Ihrem Domain-Registrar hinzu, damit DNSSEC wirksam wird."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add the DS record above at your domain registrar for DNSSEC to take effect."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agrega el registro DS anterior en tu registrador de dominios para que DNSSEC surta efecto."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajoutez l'enregistrement DS ci-dessus chez votre bureau d'enregistrement pour que DNSSEC prenne effet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上の DS レコードをドメインレジストラーに追加すると、DNSSEC が有効になります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC가 적용되려면 위의 DS 레코드를 도메인 등록기관에 추가해야 합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicione o registro DS acima no seu registrador de domínios para o DNSSEC entrar em vigor."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicione o registo DS acima no seu registador de domínios para o DNSSEC entrar em vigor."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC'in etkili olması için yukarıdaki DS kaydını alan adı kayıt kuruluşunuza ekleyin."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "還需把上面的 DS 記錄新增到你的網域註冊商處，DNSSEC 才會真正生效。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "還需把上面的 DS 記錄加到你的域名註冊商處，DNSSEC 才會真正生效。"
+          }
+        }
+      }
+    },
+    "为 DNS 应答加签，防止解析结果被篡改。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توقيع استجابات DNS لمنع التلاعب بنتائج التحليل."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signiert DNS-Antworten, damit sie nicht manipuliert werden können."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signs DNS responses so answers cannot be tampered with."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Firma las respuestas DNS para que no puedan alterarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signe les réponses DNS afin qu'elles ne puissent pas être falsifiées."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 応答に署名し、解決結果の改ざんを防ぎます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 응답에 서명해 결과가 변조되지 않도록 합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assina as respostas de DNS para que não possam ser adulteradas."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assina as respostas de DNS para que não possam ser adulteradas."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS yanıtlarını imzalayarak sonuçların değiştirilmesini önler."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為 DNS 回應加簽，防止解析結果被竄改。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為 DNS 回應加簽，防止解析結果被篡改。"
+          }
+        }
+      }
+    },
+    "展平所有 CNAME": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تسطيح جميع سجلات CNAME"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle CNAMEs auflösen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flatten All CNAMEs"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplanar todos los CNAME"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplatir tous les CNAME"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての CNAME をフラット化"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 CNAME 평탄화"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Achatar todos os CNAMEs"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplanar todos os CNAME"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm CNAME'leri düzleştir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展平所有 CNAME"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展平所有 CNAME"
+          }
+        }
+      }
+    },
+    "多提供商 DNS": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS متعدد المزودين"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Multi-Provider-DNS"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Multi-provider DNS"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS de varios proveedores"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS multifournisseur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マルチプロバイダー DNS"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다중 공급자 DNS"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS de vários provedores"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS de vários fornecedores"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çok sağlayıcılı DNS"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多供應商 DNS"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多供應商 DNS"
+          }
+        }
+      }
+    },
+    "高级名称服务器": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خوادم أسماء متقدمة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erweiterte Nameserver"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced Nameservers"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidores de nombres avanzados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serveurs de noms avancés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高度なネームサーバー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고급 네임서버"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidores de nomes avançados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidores de nomes avançados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelişmiş ad sunucuları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進階名稱伺服器"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進階名稱伺服器"
+          }
+        }
+      }
+    },
+    "域名模式": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع النطاق"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain-Modus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain Mode"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo del dominio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode du domaine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメインモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 모드"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo do domínio"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo do domínio"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı modu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域模式"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名模式"
+          }
+        }
+      }
+    },
+    "NS 记录 TTL": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مدة بقاء سجل NS"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TTL des NS-Eintrags"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NS Record TTL"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TTL del registro NS"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TTL de l'enregistrement NS"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NS レコードの TTL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NS 레코드 TTL"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TTL do registro NS"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TTL do registo NS"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NS kaydı TTL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NS 記錄 TTL"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NS 記錄 TTL"
+          }
+        }
+      }
+    },
+    "解析（%@）": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحليل (%@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auflösung (%@)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolution (%@)"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolución (%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résolution (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前解決（%@）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해석(%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolução (%@)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolução (%@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çözümleme (%@)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解析（%@）"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解析（%@）"
+          }
+        }
+      }
+    },
+    "展平 CNAME 会把 CNAME 解析成最终 IP 返回。多提供商 DNS 允许与其他 DNS 服务商共存。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعمل التسطيح على تحليل سجلات CNAME إلى عنوان IP النهائي قبل الرد. ويتيح DNS متعدد المزودين التعايش مع مزودي DNS آخرين."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Auflösen ersetzt CNAMEs vor der Antwort durch die finale IP. Multi-Provider-DNS erlaubt den Betrieb neben anderen DNS-Anbietern."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flattening resolves CNAMEs to their final IP before answering. Multi-provider DNS lets Cloudflare coexist with other DNS providers."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El aplanamiento resuelve los CNAME a su IP final antes de responder. El DNS de varios proveedores permite convivir con otros proveedores de DNS."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aplatissement résout les CNAME vers l'IP finale avant de répondre. Le DNS multifournisseur permet de coexister avec d'autres fournisseurs DNS."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フラット化すると CNAME を最終的な IP に解決して応答します。マルチプロバイダー DNS は他の DNS 事業者との併用を可能にします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "평탄화하면 CNAME을 최종 IP로 해석해 응답합니다. 다중 공급자 DNS는 다른 DNS 공급자와 공존할 수 있게 합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O achatamento resolve os CNAMEs até o IP final antes de responder. O DNS de vários provedores permite conviver com outros provedores de DNS."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O aplanamento resolve os CNAME até ao IP final antes de responder. O DNS de vários fornecedores permite coexistir com outros fornecedores de DNS."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Düzleştirme, yanıt vermeden önce CNAME'leri nihai IP'ye çözümler. Çok sağlayıcılı DNS, diğer DNS sağlayıcılarıyla birlikte çalışmayı sağlar."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展平 CNAME 會把 CNAME 解析成最終 IP 回傳。多供應商 DNS 允許與其他 DNS 服務商共存。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展平 CNAME 會把 CNAME 解析成最終 IP 返回。多供應商 DNS 允許與其他 DNS 服務商共存。"
+          }
+        }
+      }
+    },
+    "当前授权仅限读取（zone-dns-settings.read）。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التفويض الحالي للقراءة فقط (zone-dns-settings.read)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die aktuelle Autorisierung ist schreibgeschützt (zone-dns-settings.read)."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current authorization is read-only (zone-dns-settings.read)."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La autorización actual es solo de lectura (zone-dns-settings.read)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation actuelle est en lecture seule (zone-dns-settings.read)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の認可は読み取りのみです（zone-dns-settings.read）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 권한은 읽기 전용입니다(zone-dns-settings.read)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é somente leitura (zone-dns-settings.read)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é apenas de leitura (zone-dns-settings.read)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut yetkilendirme salt okunurdur (zone-dns-settings.read)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（zone-dns-settings.read）。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（zone-dns-settings.read）。"
+          }
+        }
+      }
+    },
+    "仅 CDN": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CDN فقط"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur CDN"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CDN only"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo CDN"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CDN uniquement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CDN のみ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CDN 전용"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Somente CDN"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apenas CDN"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yalnızca CDN"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅 CDN"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅 CDN"
+          }
+        }
+      }
+    },
+    "待在注册商处添加 DS 记录": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "في انتظار إضافة سجل DS لدى مُسجِّل النطاق"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet auf den DS-Eintrag bei Ihrem Registrar"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for the DS record at your registrar"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta agregar el registro DS en tu registrador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente de l'enregistrement DS chez votre bureau d'enregistrement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レジストラーでの DS レコード追加待ち"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "등록기관에 DS 레코드 추가 대기 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aguardando o registro DS no seu registrador"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A aguardar o registo DS no seu registador"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıt kuruluşunda DS kaydı bekleniyor"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待在註冊商處新增 DS 記錄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待在註冊商處加入 DS 記錄"
+          }
+        }
+      }
+    },
+    "正在停用": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ التعطيل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird deaktiviert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disabling"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivation en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効化しています"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비활성화 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativando"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A desativar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devre dışı bırakılıyor"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在停用"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在停用"
+          }
+        }
+      }
+    },
+    "出错": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطأ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오류"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hata"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發生錯誤"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發生錯誤"
+          }
+        }
+      }
+    },
+    "DNSSEC、CNAME 展平与名称服务器": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC وتسطيح CNAME وخوادم الأسماء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, CNAME-Auflösung und Nameserver"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, CNAME flattening, and nameservers"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, aplanamiento de CNAME y servidores de nombres"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, aplatissement CNAME et serveurs de noms"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC、CNAME のフラット化、ネームサーバー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, CNAME 평탄화, 네임서버"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, achatamento de CNAME e servidores de nomes"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, aplanamento de CNAME e servidores de nomes"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC, CNAME düzleştirme ve ad sunucuları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC、CNAME 展平與名稱伺服器"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNSSEC、CNAME 展平與名稱伺服器"
+          }
+        }
+      }
+    },
+    "域名注册": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تسجيلات النطاقات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain-Registrierungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain Registrations"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros de dominio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrements de domaine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン登録"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 등록"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros de domínio"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registos de domínio"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alan adı kayıtları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域註冊"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名註冊"
+          }
+        }
+      }
+    },
+    "已注册域名": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النطاقات المسجّلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registrierte Domains"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registered Domains"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dominios registrados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domaines enregistrés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登録済みドメイン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "등록된 도메인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domínios registrados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domínios registados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıtlı alan adları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已註冊網域"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已註冊域名"
+          }
+        }
+      }
+    },
+    "此账号下没有在 Cloudflare 注册的域名。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد نطاقات مسجّلة لدى Cloudflare في هذا الحساب."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für dieses Konto sind keine Domains bei Cloudflare registriert."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No domains registered with Cloudflare on this account."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta cuenta no tiene dominios registrados con Cloudflare."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun domaine enregistré auprès de Cloudflare sur ce compte."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアカウントに Cloudflare で登録したドメインはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 계정에 Cloudflare로 등록한 도메인이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta conta não tem domínios registrados na Cloudflare."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta conta não tem domínios registados na Cloudflare."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu hesapta Cloudflare ile kayıtlı alan adı yok."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此帳號下沒有在 Cloudflare 註冊的網域。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此帳戶下沒有在 Cloudflare 註冊的域名。"
+          }
+        }
+      }
+    },
+    "开启自动续费即授权 Cloudflare 在到期前 30 天内扣默认支付方式。域名注册与转移锁请在 Cloudflare 控制台操作。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل التجديد التلقائي يخوّل Cloudflare بالخصم من وسيلة الدفع الافتراضية حتى 30 يومًا قبل انتهاء الصلاحية. سجِّل النطاقات وغيِّر قفل النقل من لوحة تحكم Cloudflare."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die automatische Verlängerung autorisiert Cloudflare, bis zu 30 Tage vor Ablauf Ihre Standardzahlungsmethode zu belasten. Domains registrieren und die Transfersperre ändern Sie im Cloudflare-Dashboard."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turning on auto-renew authorizes Cloudflare to charge your default payment method up to 30 days before expiry. Register domains and change the transfer lock in the Cloudflare dashboard."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar la renovación automática autoriza a Cloudflare a cobrar tu método de pago predeterminado hasta 30 días antes del vencimiento. Registra dominios y cambia el bloqueo de transferencia en el panel de Cloudflare."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer le renouvellement automatique autorise Cloudflare à débiter votre moyen de paiement par défaut jusqu'à 30 jours avant l'expiration. Enregistrez les domaines et modifiez le verrou de transfert dans le tableau de bord Cloudflare."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動更新を有効にすると、有効期限の 30 日前までに既定の支払い方法へ請求することを Cloudflare に許可します。ドメイン登録と移管ロックは Cloudflare ダッシュボードで操作してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 갱신을 켜면 만료 30일 전까지 기본 결제 수단으로 청구하도록 Cloudflare에 권한을 부여합니다. 도메인 등록과 이전 잠금은 Cloudflare 대시보드에서 하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar a renovação automática autoriza a Cloudflare a cobrar seu método de pagamento padrão até 30 dias antes do vencimento. Registre domínios e altere o bloqueio de transferência no painel da Cloudflare."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar a renovação automática autoriza a Cloudflare a cobrar o seu método de pagamento predefinido até 30 dias antes do vencimento. Registe domínios e altere o bloqueio de transferência no painel da Cloudflare."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otomatik yenilemeyi açmak, Cloudflare'e sona ermeden 30 gün öncesine kadar varsayılan ödeme yönteminizden tahsilat yetkisi verir. Alan adı kaydı ve transfer kilidi için Cloudflare panelini kullanın."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟自動續約即授權 Cloudflare 在到期前 30 天內扣預設付款方式。網域註冊與轉移鎖請在 Cloudflare 主控台操作。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟自動續費即授權 Cloudflare 在到期前 30 天內扣預設付款方式。域名註冊與轉移鎖請在 Cloudflare 控制台操作。"
+          }
+        }
+      }
+    },
+    "当前授权仅限读取（registrar-domains.read）。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التفويض الحالي للقراءة فقط (registrar-domains.read)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die aktuelle Autorisierung ist schreibgeschützt (registrar-domains.read)."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current authorization is read-only (registrar-domains.read)."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La autorización actual es solo de lectura (registrar-domains.read)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation actuelle est en lecture seule (registrar-domains.read)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の認可は読み取りのみです（registrar-domains.read）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 권한은 읽기 전용입니다(registrar-domains.read)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é somente leitura (registrar-domains.read)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é apenas de leitura (registrar-domains.read)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut yetkilendirme salt okunurdur (registrar-domains.read)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（registrar-domains.read）。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（registrar-domains.read）。"
+          }
+        }
+      }
+    },
+    "还剩 %lld 天": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بقي %lld يومًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch %lld Tage"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld days left"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faltan %lld días"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld jours restants"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残り %lld 日"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld일 남음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faltam %lld dias"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faltam %lld dias"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld gün kaldı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "還剩 %lld 天"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "還剩 %lld 天"
+          }
+        }
+      }
+    },
+    "自动续费": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التجديد التلقائي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Verlängerung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-renew"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renovación automática"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renouvellement automatique"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動更新"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 갱신"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renovação automática"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renovação automática"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otomatik yenileme"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動續約"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動續費"
+          }
+        }
+      }
+    },
+    "转移锁：已开启": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قفل النقل: مفعّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfersperre: an"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer lock: on"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueo de transferencia: activado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verrou de transfert : activé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移管ロック：オン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 잠금: 켜짐"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueio de transferência: ativado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueio de transferência: ativado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer kilidi: açık"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉移鎖：已開啟"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉移鎖：已開啟"
+          }
+        }
+      }
+    },
+    "转移锁：未开启": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قفل النقل: غير مفعّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfersperre: aus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer lock: off"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueo de transferencia: desactivado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verrou de transfert : désactivé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移管ロック：オフ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 잠금: 꺼짐"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueio de transferência: desativado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueio de transferência: desativado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer kilidi: kapalı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉移鎖：未開啟"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉移鎖：未開啟"
+          }
+        }
+      }
+    },
+    "注册中": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ التسجيل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird registriert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registering"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registrando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登録処理中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "등록 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registrando"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A registar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaydediliyor"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "註冊中"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "註冊中"
+          }
+        }
+      }
+    },
+    "赎回期": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فترة الاسترداد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rückkaufphase"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redemption period"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Periodo de redención"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Période de rachat"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "償還期間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복구 기간"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Período de resgate"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Período de resgate"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurtarma dönemi"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "贖回期"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "贖回期"
+          }
+        }
+      }
+    },
+    "查看在 Cloudflare 注册的域名与到期日；读写可改自动续费": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض النطاقات المسجّلة لدى Cloudflare وتواريخ انتهائها؛ صلاحية الكتابة تتيح تغيير التجديد التلقائي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Cloudflare registrierte Domains und deren Ablauf ansehen; mit Schreibzugriff die automatische Verlängerung ändern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View domains registered with Cloudflare and their expiry; write access can change auto-renew"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta los dominios registrados con Cloudflare y su vencimiento; con escritura puedes cambiar la renovación automática"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultez les domaines enregistrés chez Cloudflare et leur expiration ; l'accès en écriture permet de modifier le renouvellement automatique"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare で登録したドメインと有効期限を表示します。読み書きでは自動更新を変更できます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare로 등록한 도메인과 만료일을 봅니다. 쓰기 권한으로 자동 갱신을 변경할 수 있습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja os domínios registrados na Cloudflare e o vencimento; com escrita é possível alterar a renovação automática"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja os domínios registados na Cloudflare e a data de expiração; com escrita pode alterar a renovação automática"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare ile kayıtlı alan adlarını ve bitiş tarihlerini görün; yazma yetkisiyle otomatik yenilemeyi değiştirebilirsiniz"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看在 Cloudflare 註冊的網域與到期日；讀寫可改自動續約"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看在 Cloudflare 註冊的域名與到期日；讀寫可改自動續費"
+          }
+        }
+      }
+    },
+    "请求追踪": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتبّع الطلبات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfrage-Trace"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request Trace"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreo de solicitudes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traçage de requête"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエストトレース"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청 추적"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreamento de solicitação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreio de pedidos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İstek izleme"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求追蹤"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求追蹤"
+          }
+        }
+      }
+    },
+    "模拟请求": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلب محاكى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulierte Anfrage"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulated Request"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitud simulada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requête simulée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエストのシミュレーション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모의 요청"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitação simulada"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pedido simulado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benzetilmiş istek"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模擬請求"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模擬請求"
+          }
+        }
+      }
+    },
+    "开始追踪": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل التتبّع"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace ausführen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Trace"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar rastreo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer le traçage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トレースを実行"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추적 실행"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar rastreamento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar rastreio"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İzlemeyi çalıştır"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始追蹤"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始追蹤"
+          }
+        }
+      }
+    },
+    "模拟一条请求打过 Cloudflare，看它命中了哪些规则。不会真的发到源站，也不影响线上流量。需要管理员角色。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحاكي طلبًا يمر عبر Cloudflare لمعرفة القواعد التي يطابقها. لا يُرسَل شيء إلى الخادم المصدر ولا يتأثر المرور الفعلي. يتطلب دور مسؤول."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simuliert eine Anfrage durch Cloudflare, um zu sehen, welche Regeln greifen. Es wird nichts an den Origin gesendet, der Live-Traffic bleibt unberührt. Erfordert eine Administratorrolle."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulates a request through Cloudflare to see which rules it matches. Nothing is sent to your origin and live traffic is unaffected. Requires an administrator role."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simula una solicitud a través de Cloudflare para ver qué reglas coincide. No se envía nada a tu origen ni se afecta el tráfico real. Requiere un rol de administrador."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simule une requête à travers Cloudflare pour voir quelles règles s'appliquent. Rien n'est envoyé à l'origine et le trafic réel n'est pas affecté. Nécessite un rôle d'administrateur."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエストが Cloudflare を通過する様子をシミュレートし、どのルールに一致するかを確認します。オリジンには送信されず、実トラフィックにも影響しません。管理者ロールが必要です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청이 Cloudflare를 지나가는 과정을 모의 실행해 어떤 규칙에 걸리는지 확인합니다. 오리진으로 전송되지 않으며 실제 트래픽에도 영향이 없습니다. 관리자 역할이 필요합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simula uma solicitação pela Cloudflare para ver quais regras ela corresponde. Nada é enviado à origem e o tráfego real não é afetado. Requer função de administrador."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simula um pedido através da Cloudflare para ver que regras corresponde. Nada é enviado à origem e o tráfego real não é afetado. Requer função de administrador."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir isteğin Cloudflare üzerinden geçişini benzeterek hangi kurallara takıldığını gösterir. Kaynak sunucuya hiçbir şey gönderilmez ve canlı trafik etkilenmez. Yönetici rolü gerekir."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模擬一條請求打過 Cloudflare，看它命中了哪些規則。不會真的送到來源伺服器，也不影響線上流量。需要管理員角色。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模擬一條請求打過 Cloudflare，看它命中了哪些規則。不會真的發到源站，也不影響線上流量。需要管理員角色。"
+          }
+        }
+      }
+    },
+    "求值过程": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطوات التقييم"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswertungsschritte"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evaluation Steps"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasos de evaluación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étapes d'évaluation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "評価の過程"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "평가 단계"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etapas de avaliação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etapas de avaliação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Değerlendirme adımları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "求值過程"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "求值過程"
+          }
+        }
+      }
+    },
+    "没有可展示的求值步骤。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد خطوات تقييم لعرضها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auswertungsschritte vorhanden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No evaluation steps to show."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay pasos de evaluación para mostrar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune étape d'évaluation à afficher."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示できる評価ステップはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표시할 평가 단계가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma etapa de avaliação para exibir."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma etapa de avaliação para mostrar."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gösterilecek değerlendirme adımı yok."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有可顯示的求值步驟。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有可顯示的求值步驟。"
+          }
+        }
+      }
+    },
+    "命中的步骤以橙色标出，缩进表示规则集与其下规则的从属关系。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُميَّز الخطوات المطابقة باللون البرتقالي، ويوضّح التداخل أي القواعد تتبع أي مجموعة."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zutreffende Schritte sind orange markiert; die Einrückung zeigt, welche Regeln zu welchem Regelsatz gehören."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matched steps are marked in orange; indentation shows which rules belong to which ruleset."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los pasos coincidentes se marcan en naranja; la sangría muestra qué reglas pertenecen a cada conjunto."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les étapes correspondantes sont en orange ; l'indentation indique quelles règles appartiennent à quel ensemble."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致したステップはオレンジで示され、インデントはルールセットとその配下ルールの関係を表します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치한 단계는 주황색으로 표시되며, 들여쓰기는 규칙 집합과 그 하위 규칙의 관계를 나타냅니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As etapas correspondentes ficam em laranja; o recuo mostra quais regras pertencem a cada conjunto."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As etapas correspondentes ficam a laranja; a indentação mostra que regras pertencem a cada conjunto."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eşleşen adımlar turuncu ile işaretlenir; girinti hangi kuralın hangi kural kümesine ait olduğunu gösterir."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命中的步驟以橘色標出，縮排表示規則集與其下規則的從屬關係。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命中的步驟以橙色標出，縮排表示規則集與其下規則的從屬關係。"
+          }
+        }
+      }
+    },
+    "未命名步骤": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطوة بلا اسم"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbenannter Schritt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unnamed step"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paso sin nombre"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étape sans nom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前のないステップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 없는 단계"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etapa sem nome"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etapa sem nome"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adsız adım"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未命名步驟"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未命名步驟"
+          }
+        }
+      }
+    },
+    "模拟请求，查看它命中了哪些规则": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محاكاة طلب ومعرفة القواعد التي يطابقها"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Anfrage simulieren und sehen, welche Regeln greifen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulate a request and see which rules it matches"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simula una solicitud y ve qué reglas coincide"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulez une requête et voyez quelles règles s'appliquent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエストをシミュレートして一致するルールを確認します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청을 모의 실행해 어떤 규칙에 걸리는지 확인합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simule uma solicitação e veja quais regras ela corresponde"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simule um pedido e veja que regras corresponde"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir isteği benzetip hangi kurallara takıldığını görün"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模擬請求，查看它命中了哪些規則"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模擬請求，查看它命中了哪些規則"
+          }
+        }
+      }
+    },
+    "数据目录": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتالوج البيانات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenkatalog"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data Catalog"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogo de datos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catalogue de données"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データカタログ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터 카탈로그"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogo de dados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogo de dados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veri kataloğu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "資料目錄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "數據目錄"
+          }
+        }
+      }
+    },
+    "启用数据目录": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل كتالوج البيانات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenkatalog aktivieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Data Catalog"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar catálogo de datos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer le catalogue de données"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データカタログを有効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터 카탈로그 사용"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar catálogo de dados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar catálogo de dados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veri kataloğunu etkinleştir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用資料目錄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用數據目錄"
+          }
+        }
+      }
+    },
+    "启用后该桶将作为 Apache Iceberg 目录，目录操作按量计费（每月含 100 万次免费额度）。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سيعمل هذا الدلو ككتالوج Apache Iceberg. تُحتسب عمليات الكتالوج حسب الاستخدام، مع مليون عملية مجانية شهريًا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Bucket dient als Apache-Iceberg-Katalog. Katalogvorgänge werden nach Nutzung abgerechnet, 1 Million pro Monat sind frei."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The bucket will serve as an Apache Iceberg catalog. Catalog operations are billed by usage, with 1 million free per month."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El bucket funcionará como catálogo de Apache Iceberg. Las operaciones de catálogo se cobran por uso, con 1 millón gratis al mes."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le bucket servira de catalogue Apache Iceberg. Les opérations de catalogue sont facturées à l'usage, avec 1 million gratuites par mois."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバケットは Apache Iceberg カタログとして機能します。カタログ操作は従量課金で、毎月 100 万回まで無料です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 버킷이 Apache Iceberg 카탈로그로 동작합니다. 카탈로그 작업은 사용량 기준으로 과금되며 매월 100만 회는 무료입니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O bucket funcionará como catálogo Apache Iceberg. As operações de catálogo são cobradas por uso, com 1 milhão gratuitas por mês."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O bucket funcionará como catálogo Apache Iceberg. As operações de catálogo são cobradas por utilização, com 1 milhão gratuitas por mês."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kova Apache Iceberg kataloğu olarak çalışır. Katalog işlemleri kullanıma göre ücretlendirilir, ayda 1 milyon işlem ücretsizdir."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用後該儲存桶將作為 Apache Iceberg 目錄，目錄操作按量計費（每月含 100 萬次免費額度）。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用後該存儲桶將作為 Apache Iceberg 目錄，目錄操作按量計費（每月含 100 萬次免費額度）。"
+          }
+        }
+      }
+    },
+    "目录名": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم الكتالوج"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katalogname"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catalog Name"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del catálogo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom du catalogue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カタログ名"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카탈로그 이름"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do catálogo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do catálogo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katalog adı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目錄名稱"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目錄名稱"
+          }
+        }
+      }
+    },
+    "自动压实": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الدمج التلقائي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Verdichtung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Compaction"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactación automática"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactage automatique"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動コンパクション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 압축"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactação automática"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactação automática"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otomatik sıkıştırma"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動壓實"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動壓實"
+          }
+        }
+      }
+    },
+    "已开启": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفعّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "켜짐"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已開啟"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已開啟"
+          }
+        }
+      }
+    },
+    "已关闭": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير مفعّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "꺼짐"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapalı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已關閉"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已關閉"
+          }
+        }
+      }
+    },
+    "暂无命名空间": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد مساحات أسماء بعد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Namespaces"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No namespaces yet"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay espacios de nombres"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun espace de noms"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前空間はまだありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네임스페이스가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há namespaces"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há namespaces"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henüz ad alanı yok"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫無命名空間"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫無命名空間"
+          }
+        }
+      }
+    },
+    "把这个桶变成可被 Spark、Snowflake 等引擎查询的 Iceberg 数据仓库。注意：目录已启用时手动删除对象会破坏目录。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحوّل هذا الدلو إلى مستودع Iceberg يمكن الاستعلام عنه بمحركات مثل Spark وSnowflake. ملاحظة: حذف الكائنات يدويًا أثناء تفعيل الكتالوج يُفسده."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macht diesen Bucket zu einem Iceberg-Warehouse, das von Engines wie Spark und Snowflake abgefragt werden kann. Hinweis: Objekte bei aktivem Katalog manuell zu löschen beschädigt ihn."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turns this bucket into an Iceberg warehouse queryable by engines like Spark and Snowflake. Note: deleting objects manually while the catalog is on will corrupt it."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convierte este bucket en un almacén Iceberg consultable por motores como Spark y Snowflake. Nota: eliminar objetos manualmente con el catálogo activo lo dañará."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transforme ce bucket en entrepôt Iceberg interrogeable par des moteurs comme Spark et Snowflake. Remarque : supprimer des objets manuellement avec le catalogue actif l'endommage."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバケットを Spark や Snowflake などのエンジンから照会できる Iceberg データウェアハウスにします。注意：カタログ有効中にオブジェクトを手動削除するとカタログが壊れます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 버킷을 Spark, Snowflake 같은 엔진으로 질의할 수 있는 Iceberg 데이터 웨어하우스로 만듭니다. 참고: 카탈로그가 켜진 상태에서 객체를 수동 삭제하면 카탈로그가 손상됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transforma este bucket em um data warehouse Iceberg consultável por mecanismos como Spark e Snowflake. Atenção: excluir objetos manualmente com o catálogo ativo o corrompe."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transforma este bucket num data warehouse Iceberg consultável por motores como o Spark e o Snowflake. Atenção: eliminar objetos manualmente com o catálogo ativo corrompe-o."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kovayı Spark ve Snowflake gibi motorlarla sorgulanabilen bir Iceberg veri ambarına dönüştürür. Not: katalog açıkken nesneleri elle silmek kataloğu bozar."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把這個儲存桶變成可被 Spark、Snowflake 等引擎查詢的 Iceberg 資料倉儲。注意：目錄已啟用時手動刪除物件會破壞目錄。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把這個存儲桶變成可被 Spark、Snowflake 等引擎查詢的 Iceberg 數據倉庫。注意：目錄已啟用時手動刪除對象會破壞目錄。"
+          }
+        }
+      }
+    },
+    "R2 数据目录": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتالوج بيانات R2"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2-Datenkatalog"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 Data Catalog"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogo de datos R2"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catalogue de données R2"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 データカタログ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 데이터 카탈로그"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogo de dados do R2"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogo de dados do R2"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 veri kataloğu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 資料目錄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 數據目錄"
+          }
+        }
+      }
+    },
+    "把 R2 桶启用为 Iceberg 数据仓库": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل دلو R2 كمستودع Iceberg"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen R2-Bucket als Iceberg-Warehouse aktivieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable an R2 bucket as an Iceberg warehouse"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa un bucket de R2 como almacén Iceberg"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer un bucket R2 comme entrepôt Iceberg"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 バケットを Iceberg データウェアハウスとして有効にします"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 버킷을 Iceberg 웨어하우스로 사용합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative um bucket do R2 como data warehouse Iceberg"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative um bucket do R2 como data warehouse Iceberg"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir R2 kovasını Iceberg ambarı olarak etkinleştirin"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把 R2 儲存桶啟用為 Iceberg 資料倉儲"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把 R2 存儲桶啟用為 Iceberg 數據倉庫"
+          }
+        }
+      }
+    },
+    "构建记录（%@）": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجل عمليات البناء (%@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build-Verlauf (%@)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build history (%@)"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial de compilaciones (%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique des builds (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルド履歴（%@）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드 기록(%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico de compilações (%@)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico de compilações (%@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derleme geçmişi (%@)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建置記錄（%@）"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構建記錄（%@）"
+          }
+        }
+      }
+    },
+    "这个 Worker 还没有构建记录。接上 Git 仓库后，每次推送都会在这里出现。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد عمليات بناء لهذا الـ Worker بعد. اربط مستودع Git وستظهر كل عملية دفع هنا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für diesen Worker gibt es noch keine Builds. Verbinden Sie ein Git-Repository, dann erscheint hier jeder Push."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No builds for this Worker yet. Connect a Git repository and every push will show up here."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este Worker aún no tiene compilaciones. Conecta un repositorio Git y cada push aparecerá aquí."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun build pour ce Worker. Connectez un dépôt Git et chaque push apparaîtra ici."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Worker にはまだビルドがありません。Git リポジトリを接続すると、プッシュのたびにここに表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 Worker에는 아직 빌드가 없습니다. Git 저장소를 연결하면 푸시할 때마다 여기에 표시됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este Worker ainda não tem compilações. Conecte um repositório Git e cada push aparecerá aqui."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este Worker ainda não tem compilações. Ligue um repositório Git e cada push aparecerá aqui."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu Worker için henüz derleme yok. Bir Git deposu bağlayın, her gönderim burada görünsün."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這個 Worker 還沒有建置記錄。接上 Git 儲存庫後，每次推送都會在這裡出現。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這個 Worker 還沒有構建記錄。接上 Git 倉庫後，每次推送都會在這裡出現。"
+          }
+        }
+      }
+    },
+    "点按查看构建日志。进行中的构建可左滑取消。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط لعرض سجلات البناء. اسحب لليسار عملية بناء جارية لإلغائها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippen für Build-Logs. Laufende Builds durch Wischen nach links abbrechen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view build logs. Swipe left on a running build to cancel it."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca para ver los registros. Desliza a la izquierda una compilación en curso para cancelarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez pour voir les journaux. Balayez vers la gauche un build en cours pour l'annuler."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップでビルドログを表示します。実行中のビルドは左スワイプでキャンセルできます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭하면 빌드 로그를 봅니다. 진행 중인 빌드는 왼쪽으로 밀어 취소할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para ver os logs. Deslize à esquerda em uma compilação em andamento para cancelá-la."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para ver os registos. Deslize para a esquerda numa compilação em curso para a cancelar."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Günlükleri görmek için dokunun. Süren bir derlemeyi iptal etmek için sola kaydırın."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點按查看建置記錄檔。進行中的建置可左滑取消。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點按查看構建日誌。進行中的構建可左滑取消。"
+          }
+        }
+      }
+    },
+    "构建日志": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجلات البناء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build-Logs"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build Logs"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros de compilación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journaux de build"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルドログ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드 로그"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs de compilação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registos de compilação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derleme günlükleri"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建置記錄檔"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構建日誌"
+          }
+        }
+      }
+    },
+    "没有日志输出。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يوجد إخراج سجل."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Log-Ausgabe."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No log output."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin salida de registro."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune sortie de journal."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログ出力はありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 출력이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem saída de log."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem saída de registo."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Günlük çıktısı yok."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有記錄檔輸出。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有日誌輸出。"
+          }
+        }
+      }
+    },
+    "构建中": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ البناء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird erstellt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルド中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilando"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A compilar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derleniyor"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建置中"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構建中"
+          }
+        }
+      }
+    },
+    "已跳过": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متخطّاة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersprungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skipped"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "건너뜀"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorada"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorada"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atlandı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已略過"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已略過"
+          }
+        }
+      }
+    },
+    "Workers 构建": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمليات بناء Workers"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers Builds"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers Builds"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilaciones de Workers"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Builds Workers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers ビルド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 빌드"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilações do Workers"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilações do Workers"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers derlemeleri"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 建置"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 構建"
+          }
+        }
+      }
+    },
+    "查看 CI 构建记录与日志；读写可取消构建": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض سجل وسجلات بناء CI؛ صلاحية الكتابة تتيح إلغاء عمليات البناء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CI-Build-Verlauf und Logs ansehen; mit Schreibzugriff Builds abbrechen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View CI build history and logs; write access can cancel builds"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta el historial y los registros de compilación de CI; con escritura puedes cancelar compilaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultez l'historique et les journaux de build CI ; l'accès en écriture permet d'annuler des builds"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CI のビルド履歴とログを表示します。読み書きではビルドをキャンセルできます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CI 빌드 기록과 로그를 봅니다. 쓰기 권한으로 빌드를 취소할 수 있습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja o histórico e os logs de compilação da CI; com escrita é possível cancelar compilações"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja o histórico e os registos de compilação da CI; com escrita pode cancelar compilações"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CI derleme geçmişini ve günlüklerini görün; yazma yetkisiyle derlemeleri iptal edin"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看 CI 建置記錄與記錄檔；讀寫可取消建置"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看 CI 構建記錄與日誌；讀寫可取消構建"
+          }
+        }
+      }
+    },
+    "源站异常时通知我": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أبلغني عند تعطّل الخادم المصدر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigen, wenn der Origin ausfällt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notify me when the origin goes down"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisarme cuando el origen falle"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "M'avertir en cas de panne de l'origine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オリジンに異常があれば通知"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오리진에 문제가 생기면 알리기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisar quando a origem falhar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisar quando a origem falhar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak sunucu düşünce bildir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來源伺服器異常時通知我"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "源站異常時通知我"
+          }
+        }
+      }
+    },
+    "由 Cloudflare 在源站状态变化时直接推送，App 不需要开着。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترسل Cloudflare التنبيه عند تغيّر حالة الخادم المصدر. لا حاجة لإبقاء التطبيق مفتوحًا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare sendet die Benachrichtigung bei Statusänderung des Origins. Die App muss nicht geöffnet sein."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare pushes the alert when origin status changes. The app does not need to be open."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare envía la alerta cuando cambia el estado del origen. No necesitas tener la app abierta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare envoie l'alerte lorsque l'état de l'origine change. L'app n'a pas besoin d'être ouverte."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オリジンの状態が変わると Cloudflare が直接通知します。アプリを開いておく必要はありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오리진 상태가 바뀌면 Cloudflare가 직접 알림을 보냅니다. 앱을 켜 둘 필요가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare envia o alerta quando o status da origem muda. Não é preciso manter o app aberto."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare envia o alerta quando o estado da origem muda. Não é preciso manter a app aberta."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak sunucunun durumu değiştiğinde bildirimi Cloudflare gönderir. Uygulamanın açık olması gerekmez."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 在來源伺服器狀態變化時直接推送，App 不需要開著。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 在源站狀態變化時直接推送，App 不需要開著。"
+          }
+        }
+      }
+    },
+    "OC：源站健康检查": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: فحص سلامة الخادم المصدر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: Origin-Integritätsprüfung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: Origin health check"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: Comprobación de estado del origen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC : contrôle d'intégrité de l'origine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC：オリジンのヘルスチェック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: 오리진 상태 확인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: Verificação de integridade da origem"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: Verificação de estado da origem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC: Kaynak sunucu sağlık denetimi"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC：來源伺服器健康檢查"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OC：源站健康檢查"
+          }
+        }
+      }
+    },
+    "构建失败时通知我": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أبلغني عند فشل عملية بناء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigen, wenn ein Build fehlschlägt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notify me when a build fails"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisarme cuando falle una compilación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "M'avertir en cas d'échec d'un build"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルド失敗時に通知"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드가 실패하면 알리기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisar quando uma compilação falhar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisar quando uma compilação falhar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir derleme başarısız olunca bildir"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建置失敗時通知我"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構建失敗時通知我"
+          }
+        }
+      }
+    },
+    "Cloudflare 没有为 Workers 构建提供告警，这里靠 App 在后台刷新时自行比对。时机由系统调度，可能延迟。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توفّر Cloudflare نوع تنبيه لعمليات بناء Workers، لذا يتحقق التطبيق أثناء التحديث في الخلفية. يحدد النظام التوقيت وقد يتأخر."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare bietet keinen Alarmtyp für Workers Builds, daher prüft die App beim Hintergrund-Refresh selbst. Der Zeitpunkt liegt beim System und kann sich verzögern."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare has no alert type for Workers Builds, so the app checks during background refresh. Timing is up to the system and may be delayed."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare no tiene alertas para las compilaciones de Workers, así que la app las revisa en la actualización en segundo plano. El momento lo decide el sistema y puede retrasarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare ne propose pas d'alerte pour les builds Workers ; l'app vérifie donc lors de l'actualisation en arrière-plan. Le moment dépend du système et peut être retardé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare には Workers ビルド向けのアラートがないため、アプリがバックグラウンド更新時に自分で確認します。タイミングはシステム次第で、遅れることがあります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare에는 Workers 빌드용 알림 유형이 없어, 앱이 백그라운드 새로 고침 때 직접 확인합니다. 시점은 시스템이 정하며 지연될 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare não tem alertas para compilações do Workers, então o app verifica na atualização em segundo plano. O momento depende do sistema e pode atrasar."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare não tem alertas para compilações do Workers, por isso a app verifica na atualização em segundo plano. O momento depende do sistema e pode atrasar."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare, Workers derlemeleri için bir uyarı türü sunmuyor; bu yüzden uygulama arka plan yenilemesinde kendisi denetler. Zamanlamayı sistem belirler ve gecikebilir."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare 沒有為 Workers 建置提供警示，這裡靠 App 在背景重新整理時自行比對。時機由系統排程，可能延遲。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare 沒有為 Workers 構建提供警示，這裡靠 App 在背景重新整理時自行比對。時機由系統調度，可能延遲。"
+          }
+        }
+      }
+    },
+    "构建失败": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل البناء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build failed"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilación fallida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du build"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルド失敗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드 실패"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilação falhou"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compilação falhou"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derleme başarısız"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建置失敗"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構建失敗"
+          }
+        }
+      }
+    },
+    "%@ 的最新一次构建失败了": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشلت آخر عملية بناء لـ %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der letzte Build von %@ ist fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The latest build of %@ failed"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La compilación más reciente de %@ falló"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le dernier build de %@ a échoué"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の最新のビルドが失敗しました"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 최신 빌드가 실패했습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A compilação mais recente de %@ falhou"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A compilação mais recente de %@ falhou"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ için son derleme başarısız oldu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的最新一次建置失敗了"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的最新一次構建失敗了"
+          }
+        }
+      }
+    },
+    "%lld 个 Worker 的最新构建失败了：%@": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشلت آخر عمليات البناء لـ %lld من Workers: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei %lld Workers ist der letzte Build fehlgeschlagen: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest builds failed for %lld Workers: %@"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las compilaciones más recientes fallaron en %lld Workers: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le dernier build a échoué pour %lld Workers : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個の Worker で最新ビルドが失敗しました：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 Worker의 최신 빌드가 실패했습니다: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As compilações mais recentes falharam em %lld Workers: %@"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As compilações mais recentes falharam em %lld Workers: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Worker için son derleme başarısız oldu: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個 Worker 的最新建置失敗了：%@"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個 Worker 的最新構建失敗了：%@"
+          }
+        }
+      }
+    },
+    "托管头": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الترويسات المُدارة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwaltete Header"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Managed Headers"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encabezados administrados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En-têtes gérés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マネージドヘッダー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "관리형 헤더"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cabeçalhos gerenciados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cabeçalhos geridos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yönetilen üst bilgiler"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "託管標頭"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "託管標頭"
+          }
+        }
+      }
+    },
+    "此域名没有可用的托管头。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد ترويسات مُدارة متاحة لهذا النطاق."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für diese Domain sind keine verwalteten Header verfügbar."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No managed headers available for this domain."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay encabezados administrados disponibles para este dominio."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun en-tête géré disponible pour ce domaine."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このドメインで利用できるマネージドヘッダーはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 도메인에 사용할 수 있는 관리형 헤더가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum cabeçalho gerenciado disponível para este domínio."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum cabeçalho gerido disponível para este domínio."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu alan adı için kullanılabilir yönetilen üst bilgi yok."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此網域沒有可用的託管標頭。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此域名沒有可用的託管標頭。"
+          }
+        }
+      }
+    },
+    "与 %@ 互斥": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتعارض مع %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht zusammen mit %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conflicts with %@"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incompatible con %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incompatible avec %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ と併用できません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@와(과) 함께 쓸 수 없음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incompatível com %@"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incompatível com %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ile birlikte kullanılamaz"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "與 %@ 互斥"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "與 %@ 互斥"
+          }
+        }
+      }
+    },
+    "由 Cloudflare 维护的头部改写，开关即生效，无需自己写 Transform 规则。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة كتابة للترويسات تتولاها Cloudflare. يكفي تفعيلها دون الحاجة إلى قاعدة Transform."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von Cloudflare gepflegte Header-Anpassungen. Einschalten genügt – keine Transform-Regel nötig."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Header rewrites maintained by Cloudflare. Toggle and they take effect — no Transform rule needed."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescrituras de encabezados mantenidas por Cloudflare. Actívalas y surten efecto, sin reglas de Transform."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réécritures d’en-têtes maintenues par Cloudflare. Activez-les et elles s’appliquent, sans règle Transform."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare が管理するヘッダー改変です。切り替えるだけで有効になり、Transform ルールは不要です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare가 관리하는 헤더 재작성입니다. 켜기만 하면 적용되며 Transform 규칙이 필요 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescritas de cabeçalho mantidas pela Cloudflare. Ative e já valem, sem regras de Transform."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescritas de cabeçalho mantidas pela Cloudflare. Ative e ficam em vigor, sem regras de Transform."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare tarafından bakımı yapılan üst bilgi yeniden yazımları. Açmanız yeterli, Transform kuralı gerekmez."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 維護的標頭改寫，開關即生效，無需自己寫 Transform 規則。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 維護的標頭改寫，開關即生效，無需自己寫 Transform 規則。"
+          }
+        }
+      }
+    },
+    "当前授权仅限读取（managed-headers.read）。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التفويض الحالي للقراءة فقط (managed-headers.read)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die aktuelle Autorisierung ist schreibgeschützt (managed-headers.read)."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current authorization is read-only (managed-headers.read)."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La autorización actual es solo de lectura (managed-headers.read)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’autorisation actuelle est en lecture seule (managed-headers.read)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の認可は読み取りのみです（managed-headers.read）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 권한은 읽기 전용입니다(managed-headers.read)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é somente leitura (managed-headers.read)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A autorização atual é apenas de leitura (managed-headers.read)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut yetkilendirme salt okunurdur (managed-headers.read)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（managed-headers.read）。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權僅限讀取（managed-headers.read）。"
+          }
+        }
+      }
+    },
+    "Cloudflare 维护的请求/响应头改写开关": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح إعادة كتابة ترويسات الطلب/الاستجابة التي تتولاها Cloudflare"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von Cloudflare gepflegte Schalter für Request-/Response-Header"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare-maintained request/response header rewrites"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescrituras de encabezados de solicitud/respuesta mantenidas por Cloudflare"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réécritures d’en-têtes de requête/réponse maintenues par Cloudflare"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare が管理するリクエスト/レスポンスヘッダーの改変スイッチ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare가 관리하는 요청/응답 헤더 재작성 스위치"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescritas de cabeçalhos de solicitação/resposta mantidas pela Cloudflare"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescritas de cabeçalhos de pedido/resposta mantidas pela Cloudflare"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare tarafından yönetilen istek/yanıt üst bilgisi anahtarları"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare 維護的請求/回應標頭改寫開關"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare 維護的請求/回應標頭改寫開關"
+          }
+        }
+      }
+    },
+    "已抑制地址": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "العناوين المحظورة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterdrückte Adressen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suppressed Addresses"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direcciones suprimidas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adresses supprimées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抑制中のアドレス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "차단된 주소"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endereços suprimidos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endereços suprimidos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bastırılan adresler"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已抑制地址"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已抑制地址"
+          }
+        }
+      }
+    },
+    "没有被抑制的地址。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد عناوين محظورة."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine unterdrückten Adressen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No suppressed addresses."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay direcciones suprimidas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune adresse supprimée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抑制中のアドレスはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "차단된 주소가 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum endereço suprimido."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum endereço suprimido."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bastırılan adres yok."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有被抑制的地址。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有被抑制的地址。"
+          }
+        }
+      }
+    },
+    "这些地址退信或投诉过，Cloudflare 已停止向其转发。左滑可解除。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ارتدّت هذه العناوين أو وردت بشأنها شكاوى، فأوقفت Cloudflare إعادة التوجيه إليها. اسحب لليسار للإلغاء."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Adressen haben Bounces oder Beschwerden ausgelöst, daher stellt Cloudflare die Weiterleitung ein. Zum Aufheben nach links wischen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These addresses bounced or complained, so Cloudflare stopped forwarding to them. Swipe left to lift."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estas direcciones rebotaron o se quejaron, así que Cloudflare dejó de reenviarles. Desliza a la izquierda para levantar la supresión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ces adresses ont rebondi ou signalé du spam ; Cloudflare a cessé d’y transférer. Balayez vers la gauche pour lever la suppression."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらのアドレスはバウンスまたは苦情があったため、Cloudflare は転送を停止しています。左スワイプで解除できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 주소들은 반송되거나 신고되어 Cloudflare가 전달을 중단했습니다. 왼쪽으로 밀면 해제됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esses endereços tiveram devoluções ou reclamações, então a Cloudflare parou de encaminhar. Deslize à esquerda para remover."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estes endereços tiveram devoluções ou reclamações, por isso a Cloudflare deixou de reencaminhar. Deslize para a esquerda para remover."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu adresler geri döndü veya şikâyet aldı; Cloudflare iletmeyi durdurdu. Kaldırmak için sola kaydırın."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這些地址退信或投訴過，Cloudflare 已停止向其轉寄。左滑可解除。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這些地址退信或投訴過，Cloudflare 已停止向其轉發。左滑可解除。"
+          }
+        }
+      }
+    },
+    "永久": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دائم"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dauerhaft"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanent"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無期限"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영구"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kalıcı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久"
+          }
+        }
+      }
+    },
+    "硬退信": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ارتداد دائم"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hard Bounce"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hard bounce"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rebote duro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rebond définitif"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ハードバウンス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "하드 바운스"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devolução permanente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devolução permanente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kalıcı geri dönüş"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "硬退信"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "硬退信"
+          }
+        }
+      }
+    },
+    "软退信": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ارتداد مؤقت"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soft Bounce"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soft bounce"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rebote suave"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rebond temporaire"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソフトバウンス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소프트 바운스"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devolução temporária"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devolução temporária"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçici geri dönüş"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軟退信"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軟退信"
+          }
+        }
+      }
+    },
+    "投诉": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شكوى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschwerde"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Complaint"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queja"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plainte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "苦情"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신고"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reclamação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reclamação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şikâyet"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "投訴"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "投訴"
+          }
+        }
+      }
+    },
+    "手动添加": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أُضيف يدويًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuell hinzugefügt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added manually"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregado manualmente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouté manuellement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動で追加"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수동 추가"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionado manualmente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionado manualmente"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elle eklendi"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動新增"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動加入"
+          }
+        }
+      }
+    },
+    "URL 扫描": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فحص الرابط"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL-Scan"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL Scan"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneo de URL"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse d'URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL スキャン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 검사"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificação de URL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análise de URL"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL taraması"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 掃描"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 掃描"
+          }
+        }
+      }
+    },
+    "扫描链接": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فحص رابط"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link scannen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan a link"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanear un enlace"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyser un lien"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクをスキャン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "링크 검사"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar um link"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analisar uma ligação"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir bağlantıyı tara"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描連結"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描連結"
+          }
+        }
+      }
+    },
+    "开始扫描": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بدء الفحص"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan starten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Scan"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar escaneo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer l'analyse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキャン開始"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검사 시작"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar verificação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar análise"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taramayı başlat"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始掃描"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始掃描"
+          }
+        }
+      }
+    },
+    "扫描中…": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ الفحص…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird gescannt …"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanning…"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキャン中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검사 중…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando…"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A analisar…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taranıyor…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描中…"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描中…"
+          }
+        }
+      }
+    },
+    "由 Cloudflare 打开该链接并生成安全报告，通常需要几十秒。扫描记录会保存在 Cloudflare 的扫描库中。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفتح Cloudflare الرابط وتُنشئ تقرير أمان، عادةً خلال أقل من دقيقة. يُحفَظ الفحص في مكتبة الفحص العامة لدى Cloudflare."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare öffnet den Link und erstellt einen Sicherheitsbericht, meist in unter einer Minute. Der Scan wird in Cloudflares öffentlicher Scan-Bibliothek gespeichert."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare opens the link and produces a security report, usually within a minute. The scan is stored in Cloudflare's public scan library."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare abre el enlace y genera un informe de seguridad, normalmente en menos de un minuto. El escaneo se guarda en la biblioteca pública de Cloudflare."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare ouvre le lien et produit un rapport de sécurité, généralement en moins d'une minute. L'analyse est conservée dans la bibliothèque publique de Cloudflare."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare がリンクを開いてセキュリティレポートを作成します。通常は数十秒かかります。スキャン記録は Cloudflare のスキャンライブラリに保存されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare가 링크를 열어 보안 보고서를 만듭니다. 보통 1분 이내이며, 검사 기록은 Cloudflare의 공개 검사 라이브러리에 저장됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare abre o link e gera um relatório de segurança, normalmente em menos de um minuto. A verificação fica na biblioteca pública da Cloudflare."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare abre a ligação e gera um relatório de segurança, normalmente em menos de um minuto. A análise fica na biblioteca pública da Cloudflare."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare bağlantıyı açıp bir güvenlik raporu üretir, genellikle bir dakikadan kısa sürer. Tarama, Cloudflare'in genel tarama kitaplığında saklanır."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 開啟該連結並產生安全報告，通常需要數十秒。掃描記錄會保存在 Cloudflare 的掃描庫中。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 開啟該連結並生成安全報告，通常需要幾十秒。掃描記錄會保存在 Cloudflare 的掃描庫中。"
+          }
+        }
+      }
+    },
+    "判定": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحكم"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bewertung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verdict"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veredicto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verdict"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "判定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "판정"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veredito"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veredicto"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "判定"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "判定"
+          }
+        }
+      }
+    },
+    "判定为恶意": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُصنَّف كضار"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als bösartig eingestuft"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flagged as malicious"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcado como malicioso"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signalé comme malveillant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "悪意ありと判定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "악성으로 판정"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sinalizado como malicioso"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assinalado como malicioso"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kötü amaçlı olarak işaretlendi"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "判定為惡意"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "判定為惡意"
+          }
+        }
+      }
+    },
+    "未发现恶意特征": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يُعثر على مؤشرات ضارة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine bösartigen Signale gefunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No malicious signals found"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron señales maliciosas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun signal malveillant détecté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "悪意のある兆候は見つかりませんでした"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "악성 징후 없음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum sinal malicioso encontrado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum sinal malicioso encontrado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kötü amaçlı işaret bulunamadı"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未發現惡意特徵"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未發現惡意特徵"
+          }
+        }
+      }
+    },
+    "分类": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفئات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorien"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorías"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catégories"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カテゴリ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "분류"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorias"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorias"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategoriler"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分類"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分類"
+          }
+        }
+      }
+    },
+    "页面": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصفحة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seite"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ページ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "페이지"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sayfa"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "頁面"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "頁面"
+          }
+        }
+      }
+    },
+    "服务器": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخادم"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serveur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーバー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서버"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidor"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidor"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sunucu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "伺服器"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "伺服器"
+          }
+        }
+      }
+    },
+    "提交成功但没拿到扫描 ID。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم الإرسال، لكن لم يُعَد معرّف الفحص."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übermittelt, aber es wurde keine Scan-ID zurückgegeben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitted, but no scan ID was returned."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se envió, pero no se devolvió un ID de escaneo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyé, mais aucun identifiant d'analyse n'a été renvoyé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信できましたが、スキャン ID が返りませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제출했지만 검사 ID를 받지 못했습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado, mas nenhum ID de verificação foi retornado."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado, mas não foi devolvido nenhum ID de análise."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gönderildi ancak tarama kimliği döndürülmedi."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交成功但沒拿到掃描 ID。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交成功但沒拿到掃描 ID。"
+          }
+        }
+      }
+    },
+    "扫描仍在进行，请稍后用同一个链接再查一次。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يزال الفحص جاريًا. أعد المحاولة بالرابط نفسه بعد قليل."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan läuft noch. Versuchen Sie es gleich mit demselben Link erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Still scanning. Try the same link again in a moment."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún se está escaneando. Vuelve a intentarlo con el mismo enlace en un momento."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse toujours en cours. Réessayez le même lien dans un instant."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだスキャン中です。しばらくしてから同じリンクでもう一度お試しください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 검사 중입니다. 잠시 후 같은 링크로 다시 시도하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda verificando. Tente o mesmo link novamente em instantes."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda a analisar. Tente a mesma ligação novamente daqui a pouco."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarama sürüyor. Birazdan aynı bağlantıyla tekrar deneyin."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描仍在進行，請稍後用同一個連結再查一次。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描仍在進行，請稍後用同一個連結再查一次。"
+          }
+        }
+      }
+    },
+    "提交链接做安全扫描并查看报告": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إرسال رابط لفحص أمني وعرض التقرير"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen Link zum Sicherheitsscan einreichen und den Bericht ansehen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submit a link for a security scan and view the report"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía un enlace para escanearlo y ver el informe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soumettez un lien pour une analyse de sécurité et consultez le rapport"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクを送信してセキュリティスキャンを実行し、レポートを表示します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "링크를 제출해 보안 검사를 하고 보고서를 봅니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envie um link para verificação de segurança e veja o relatório"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envie uma ligação para análise de segurança e veja o relatório"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güvenlik taraması için bir bağlantı gönderin ve raporu görün"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交連結做安全掃描並查看報告"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交連結做安全掃描並查看報告"
+          }
+        }
+      }
+    },
+    "变更历史": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجل التغييرات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungsverlauf"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change History"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial de cambios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique des modifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更履歴"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경 기록"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico de alterações"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico de alterações"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Değişiklik geçmişi"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "變更歷史"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "變更歷史"
+          }
+        }
+      }
+    },
+    "这条记录没有携带足够信息来定位资源，因此查不到它的变更历史。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يحمل هذا السجل معلومات كافية لتحديد المورد، لذا تعذّر جلب سجل التغييرات."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Eintrag enthält nicht genug Informationen, um die Ressource zu identifizieren; es konnte kein Verlauf abgerufen werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This entry doesn't carry enough information to identify the resource, so no history could be retrieved."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta entrada no tiene información suficiente para identificar el recurso, así que no se pudo obtener el historial."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette entrée ne contient pas assez d'informations pour identifier la ressource ; aucun historique n'a pu être récupéré."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエントリにはリソースを特定できる情報が含まれていないため、変更履歴を取得できません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 항목에는 리소스를 식별할 정보가 충분하지 않아 변경 기록을 가져올 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta entrada não traz informações suficientes para identificar o recurso, então não foi possível obter o histórico."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta entrada não traz informação suficiente para identificar o recurso, pelo que não foi possível obter o histórico."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kayıt, kaynağı tanımlamaya yetecek bilgi taşımıyor; bu nedenle geçmiş alınamadı."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這筆記錄沒有攜帶足夠資訊來定位資源，因此查不到它的變更歷史。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這條記錄沒有攜帶足夠資訊來定位資源，因此查不到它的變更歷史。"
+          }
+        }
+      }
+    },
+    "没有查到这个资源的其它变更。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يُعثر على تغييرات أخرى لهذا المورد."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine weiteren Änderungen für diese Ressource gefunden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No other changes found for this resource."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron otros cambios para este recurso."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune autre modification trouvée pour cette ressource."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリソースの他の変更は見つかりませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 리소스의 다른 변경 사항을 찾지 못했습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma outra alteração encontrada para este recurso."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foram encontradas outras alterações para este recurso."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kaynak için başka değişiklik bulunamadı."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有查到這個資源的其它變更。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有查到這個資源的其它變更。"
+          }
+        }
+      }
+    },
+    "这条记录没有资源地址，只能按其它字段近似匹配，列表里可能混入无关变更。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يحتوي هذا السجل على معرّف المورد، لذا المطابقة تقريبية وقد تظهر تغييرات غير ذات صلة."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Eintrag hat keine Ressourcen-URI, daher ist die Zuordnung ungefähr – es können unpassende Änderungen erscheinen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This entry has no resource URI, so matching is approximate — unrelated changes may appear in the list."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta entrada no tiene URI del recurso, por lo que la coincidencia es aproximada; pueden aparecer cambios no relacionados."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette entrée n'a pas d'URI de ressource ; la correspondance est approximative et des modifications sans rapport peuvent apparaître."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエントリにはリソース URI がないため、他のフィールドによる近似一致になります。無関係な変更が混ざる場合があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 항목에는 리소스 URI가 없어 다른 필드로 근사 매칭합니다. 관련 없는 변경이 섞일 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta entrada não tem URI do recurso, então a correspondência é aproximada — alterações não relacionadas podem aparecer."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta entrada não tem URI do recurso, pelo que a correspondência é aproximada — podem aparecer alterações não relacionadas."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kayıtta kaynak URI'si yok; eşleştirme yaklaşıktır ve ilgisiz değişiklikler görünebilir."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這筆記錄沒有資源位址，只能按其它欄位近似比對，列表裡可能混入無關變更。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這條記錄沒有資源位址，只能按其它欄位近似比對，列表裡可能混入無關變更。"
+          }
+        }
+      }
+    },
+    "同一资源在所选时间窗内的全部变更，最新在上。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كل تغييرات هذا المورد ضمن النطاق الزمني المحدد، الأحدث أولًا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Änderungen an dieser Ressource im gewählten Zeitfenster, neueste zuerst."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All changes to this resource within the selected time window, newest first."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos los cambios de este recurso en el periodo seleccionado, del más reciente al más antiguo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les modifications de cette ressource dans la fenêtre choisie, les plus récentes en premier."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した期間内のこのリソースのすべての変更（新しい順）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 기간 내 이 리소스의 모든 변경 사항입니다. 최신순입니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas as alterações deste recurso no período selecionado, da mais recente para a mais antiga."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas as alterações deste recurso no período selecionado, da mais recente para a mais antiga."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçili zaman aralığındaki bu kaynağa ait tüm değişiklikler, en yenisi üstte."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同一資源在所選時間窗內的全部變更，最新在上。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同一資源在所選時間窗內的全部變更，最新在上。"
+          }
+        }
+      }
+    },
+    "内存用量（24 小时）": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدام الذاكرة (24 ساعة)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichernutzung (24 Stunden)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memory usage (24 hours)"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso de memoria (24 horas)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation mémoire (24 heures)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メモリ使用量（24 時間）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모리 사용량(24시간)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso de memória (24 horas)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilização de memória (24 horas)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bellek kullanımı (24 saat)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記憶體用量（24 小時）"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記憶體用量（24 小時）"
+          }
+        }
+      }
+    },
+    "V8 isolate 的内存，不是单个对象的。一个 isolate 可能同时承载同类的多个对象与外围 Worker 代码，每个 isolate 上限 128 MB。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذه ذاكرة عزلة V8 وليست لكل كائن. يمكن للعزلة الواحدة استضافة عدة كائنات من الفئة نفسها إضافةً إلى كود الـ Worker، بحد أقصى 128 ميغابايت."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dies ist V8-Isolate-Speicher, nicht pro Objekt. Ein Isolate kann mehrere Objekte derselben Klasse plus den Worker-Code beherbergen; das Limit liegt bei 128 MB."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is V8 isolate memory, not per-object. One isolate can host several objects of the same class plus the surrounding Worker code, and each isolate is capped at 128 MB."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es memoria del isolate de V8, no por objeto. Un isolate puede alojar varios objetos de la misma clase más el código del Worker, con un límite de 128 MB."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il s'agit de la mémoire de l'isolate V8, pas par objet. Un isolate peut héberger plusieurs objets de la même classe et le code du Worker, avec une limite de 128 Mo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これは V8 アイソレートのメモリで、オブジェクト単位ではありません。1 つのアイソレートは同じクラスの複数オブジェクトと周辺の Worker コードを同時に保持でき、上限は 128 MB です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "V8 아이솔레이트의 메모리이며 객체별이 아닙니다. 한 아이솔레이트는 같은 클래스의 여러 객체와 주변 Worker 코드를 함께 담을 수 있고, 상한은 128MB입니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "É memória do isolate do V8, não por objeto. Um isolate pode hospedar vários objetos da mesma classe e o código do Worker, com limite de 128 MB."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "É memória do isolate do V8, não por objeto. Um isolate pode alojar vários objetos da mesma classe e o código do Worker, com limite de 128 MB."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu, V8 yalıtımının belleğidir; nesne başına değildir. Bir yalıtım, aynı sınıftan birden çok nesneyi ve çevredeki Worker kodunu barındırabilir; sınır 128 MB'tır."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "V8 isolate 的記憶體，不是單個物件的。一個 isolate 可能同時承載同類的多個物件與外圍 Worker 程式碼，每個 isolate 上限 128 MB。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "V8 isolate 的記憶體，不是單個對象的。一個 isolate 可能同時承載同類的多個對象與外圍 Worker 程式碼，每個 isolate 上限 128 MB。"
+          }
+        }
+      }
+    },
+    "查询串": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستعلام"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Query"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Query"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requête"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クエリ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쿼리"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorgu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查詢字串"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查詢字串"
+          }
+        }
+      }
+    },
+    "国家": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البلد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Land"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Country"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "País"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pays"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "국가"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "País"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "País"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ülke"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "國家"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "國家"
+          }
+        }
+      }
+    },
+    "已验证机器人": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روبوت مُوثَّق"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifizierter Bot"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verified bot"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot verificado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Robot vérifié"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証済みボット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검증된 봇"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot verificado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot verificado"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doğrulanmış bot"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已驗證機器人"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已驗證機械人"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/AuditLogModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/AuditLogModels.swift
@@ -83,6 +83,14 @@ nonisolated struct AuditLogResource: Codable, Sendable {
 /// 从根上绕开它与通用 ResultInfo(count: Int) 的类型冲突。
 nonisolated struct AuditResultInfo: Codable, Sendable {
     let cursor: String?
+    /// 仅资源变更历史返回：exact / approximate / unavailable。
+    /// approximate 表示没拿到资源 URI、靠其它字段近似匹配，结果可能混入无关条目——必须告诉用户。
+    let historyStatus: String?
+
+    enum CodingKeys: String, CodingKey {
+        case cursor
+        case historyStatus = "history_status"
+    }
 }
 
 /// 审计日志分页响应信封（合成 Codable；errors 设为可选以容忍 null/缺省）。

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/BotManagementModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/BotManagementModels.swift
@@ -1,0 +1,93 @@
+//
+//  BotManagementModels.swift
+//  Orange Cloud
+//
+//  Zone 级机器人管控配置（GET/PUT /zones/{id}/bot_management）。
+//
+//  接口只有一个，但响应 result 是四种套餐形态的 oneOf
+//  （Bot Fight Mode / SBFM Definitely / SBFM Likely / BM Enterprise）。
+//  四者都 allOf 引用同一个 base_config，本文件只建模 base_config 里与
+//  AI / 爬虫相关的字段，其余套餐专属字段（sbfm_* / fight_mode 等）一律不碰——
+//  因此全部字段可选，任何套餐的响应都能安全解码。
+//
+//  写入用 PUT 但是**合并语义**：官方文档的示例就是只发要改的字段
+//  （如 {"fight_mode": false}），base_config 无 required 字段。
+//  所以这里每次只发一个字段，既不会覆盖别的设置，也不会把 GET 回来的
+//  只读字段（using_latest_model / stale_zone_configuration）回写过去。
+//
+
+import Foundation
+
+nonisolated struct BotManagementConfig: Codable, Sendable {
+    /// 拦截 AI 抓取与爬虫：block（全站）/ only_on_ad_pages（仅带广告页）/ disabled（放行）
+    let aiBotsProtection:      String?
+    /// 用链接迷宫惩罚 AI 爬虫（AI Labyrinth）：enabled / disabled
+    let crawlerProtection:     String?
+    /// 拦内容机器人（低 bot score，排除已验证安全类别）：block / disabled
+    let contentBotsProtection: String?
+    /// Robots 访问控制许可证变体：off / policy_only
+    let cfRobotsVariant:       String?
+    /// 启用 Cloudflare 托管 robots.txt（会前置到既有 robots.txt 之前）
+    let isRobotsTxtManaged:    Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case aiBotsProtection      = "ai_bots_protection"
+        case crawlerProtection     = "crawler_protection"
+        case contentBotsProtection = "content_bots_protection"
+        case cfRobotsVariant       = "cf_robots_variant"
+        case isRobotsTxtManaged    = "is_robots_txt_managed"
+    }
+}
+
+/// AI 爬虫处置档位。三档取值直接对应 ai_bots_protection 的枚举。
+nonisolated enum AIBotsProtection: String, CaseIterable, Identifiable, Sendable {
+    case disabled
+    case onlyOnAdPages = "only_on_ad_pages"
+    case block
+
+    var id: String { rawValue }
+
+    /// 未知取值（CF 日后加档）按放行显示，不猜测语义
+    init(apiValue: String?) {
+        self = AIBotsProtection(rawValue: apiValue ?? "") ?? .disabled
+    }
+
+    var label: String {
+        switch self {
+        case .disabled:      String(localized: "放行")
+        case .onlyOnAdPages: String(localized: "仅拦广告页")
+        case .block:         String(localized: "全站拦截")
+        }
+    }
+}
+
+// MARK: - 写入体（每次只发一个字段，见文件头说明）
+
+nonisolated struct BotManagementUpdate<Value: Codable & Sendable>: Codable, Sendable {
+    let key:   BotManagementField
+    let value: Value
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: BotManagementField.self)
+        try container.encode(value, forKey: key)
+    }
+
+    init(key: BotManagementField, value: Value) {
+        self.key = key
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: [], debugDescription: "BotManagementUpdate 只用于编码")
+        )
+    }
+}
+
+nonisolated enum BotManagementField: String, CodingKey, Sendable {
+    case aiBotsProtection      = "ai_bots_protection"
+    case crawlerProtection     = "crawler_protection"
+    case contentBotsProtection = "content_bots_protection"
+    case cfRobotsVariant       = "cf_robots_variant"
+    case isRobotsTxtManaged    = "is_robots_txt_managed"
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/CacheRuleModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/CacheRuleModels.swift
@@ -187,3 +187,27 @@ nonisolated struct CacheRuleToggle: Codable, Sendable {
 nonisolated struct CacheEntrypointUpdate: Codable, Sendable {
     let rules: [CacheRuleCreate]
 }
+
+// MARK: - 表达式常用字段
+
+/// 缓存规则表达式的常用字段，供编辑器点按插入。
+/// 含 2026-07-16 起缓存规则新支持的 bot management 分数与 ASN 匹配字段。
+nonisolated struct CacheRuleField: Identifiable, Sendable {
+    let label: String
+    let token: String
+
+    var id: String { token }
+
+    static let common: [CacheRuleField] = [
+        .init(label: "路径",     token: "http.request.uri.path"),
+        .init(label: "主机",     token: "http.host"),
+        .init(label: "查询串",   token: "http.request.uri.query"),
+        .init(label: "方法",     token: "http.request.method"),
+        .init(label: "Cookie",  token: "http.cookie"),
+        .init(label: "国家",     token: "ip.src.country"),
+        // 2026-07-16 新增：缓存规则现在也能按 bot 分数与来源 ASN 匹配
+        .init(label: "Bot 分数", token: "cf.bot_management.score"),
+        .init(label: "已验证机器人", token: "cf.bot_management.verified_bot"),
+        .init(label: "ASN",     token: "ip.src.asnum"),
+    ]
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/DNSSettingsModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/DNSSettingsModels.swift
@@ -1,0 +1,134 @@
+//
+//  DNSSettingsModels.swift
+//  Orange Cloud
+//
+//  Zone 级 DNS 设置（/zones/{id}/dns_settings）与 DNSSEC（/zones/{id}/dnssec）。
+//
+//  注意历史弃用，别用错端点：
+//  · zone settings 里的 cname_flattening（2025-06-08 弃用）已迁到这里的 flatten_all_cnames
+//  · 账户设置的 default_nameservers / use_account_custom_ns_by_default（2025-03-14 弃用）同样迁来
+//  · 2024-09-13 起独立 DNS 设置端点合并为统一的 DNS Settings API
+//  · foundation_dns 布尔字段（2026-07-27 弃用，**sunset 2026-11-23**）已由
+//    nameservers.type = "cloudflare.advanced" 取代 —— 本文件只用后者，不建模前者
+//
+
+import Foundation
+
+// MARK: - DNS 设置
+
+nonisolated struct ZoneDNSSettings: Codable, Sendable {
+    /// 展平 zone 内全部 CNAME（顶点 CNAME 因 DNS 限制始终展平）
+    let flattenAllCnames:   Bool?
+    /// 多提供商 DNS：存在非 Cloudflare NS 记录时仍激活该 zone
+    let multiProvider:      Bool?
+    let secondaryOverrides: Bool?
+    /// NS 记录 TTL，30–86400 秒
+    let nsTtl:              Double?
+    /// standard / cdn_only / dns_only
+    let zoneMode:           String?
+    let nameservers:        ZoneNameservers?
+
+    enum CodingKeys: String, CodingKey {
+        case nameservers
+        case flattenAllCnames   = "flatten_all_cnames"
+        case multiProvider      = "multi_provider"
+        case secondaryOverrides = "secondary_overrides"
+        case nsTtl              = "ns_ttl"
+        case zoneMode           = "zone_mode"
+    }
+}
+
+nonisolated struct ZoneNameservers: Codable, Sendable {
+    /// cloudflare.standard / cloudflare.advanced / custom.account / custom.tenant / custom.zone
+    let type:  String?
+    /// 名称服务器集编号，1–5
+    let nsSet: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case nsSet = "ns_set"
+    }
+}
+
+/// PATCH 体：只带要改的字段（接口为合并语义）
+nonisolated struct ZoneDNSSettingsUpdate: Codable, Sendable {
+    var flattenAllCnames:   Bool?
+    var multiProvider:      Bool?
+    var secondaryOverrides: Bool?
+    var nsTtl:              Double?
+    var zoneMode:           String?
+    var nameservers:        ZoneNameserversUpdate?
+
+    enum CodingKeys: String, CodingKey {
+        case nameservers
+        case flattenAllCnames   = "flatten_all_cnames"
+        case multiProvider      = "multi_provider"
+        case secondaryOverrides = "secondary_overrides"
+        case nsTtl              = "ns_ttl"
+        case zoneMode           = "zone_mode"
+    }
+}
+
+nonisolated struct ZoneNameserversUpdate: Codable, Sendable {
+    let type: String
+}
+
+nonisolated enum ZoneMode: String, CaseIterable, Identifiable, Sendable {
+    case standard, cdnOnly = "cdn_only", dnsOnly = "dns_only"
+
+    var id: String { rawValue }
+
+    init(apiValue: String?) {
+        self = ZoneMode(rawValue: apiValue ?? "") ?? .standard
+    }
+
+    var label: String {
+        switch self {
+        case .standard: String(localized: "标准")
+        case .cdnOnly:  String(localized: "仅 CDN")
+        case .dnsOnly:  String(localized: "仅 DNS")
+        }
+    }
+}
+
+// MARK: - DNSSEC
+
+nonisolated struct ZoneDNSSEC: Codable, Sendable {
+    /// active / pending / disabled / pending-disabled / error
+    let status:          String?
+    /// 完整 DS 记录——用户要把它粘到域名注册商处，DNSSEC 才真正生效
+    let ds:              String?
+    let digest:          String?
+    let digestType:      String?
+    let digestAlgorithm: String?
+    let algorithm:       String?
+    let keyTag:          Double?
+    let flags:           Double?
+    let publicKey:       String?
+    let modifiedOn:      String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, ds, digest, algorithm, flags
+        case digestType      = "digest_type"
+        case digestAlgorithm = "digest_algorithm"
+        case keyTag          = "key_tag"
+        case publicKey       = "public_key"
+        case modifiedOn      = "modified_on"
+    }
+
+    var isEnabled: Bool { status == "active" || status == "pending" }
+
+    var statusText: String {
+        switch status {
+        case "active":           String(localized: "已启用")
+        case "pending":          String(localized: "待在注册商处添加 DS 记录")
+        case "pending-disabled": String(localized: "正在停用")
+        case "error":            String(localized: "出错")
+        default:                 String(localized: "未启用")
+        }
+    }
+}
+
+nonisolated struct ZoneDNSSECUpdate: Codable, Sendable {
+    let status: String
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/DurableObjectModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/DurableObjectModels.swift
@@ -1,0 +1,85 @@
+
+// MARK: - 内存用量（GraphQL durableObjectsPeriodicGroups）
+
+/// DO 的 V8 isolate 内存分位数（字节）。
+///
+/// 注意口径：**按 isolate 计，不是按单个 Durable Object**。一个 isolate 可能同时承载
+/// 同类的多个 DO 与外围 Worker 代码，图上永远是整个 isolate 的内存。
+/// 每个 isolate 受 128 MB 限制。
+nonisolated struct DurableObjectMemory: Sendable {
+    let p50:  Double
+    let p90:  Double
+    let p99:  Double
+    let p999: Double
+
+    /// 128 MB isolate 上限，用于算占比
+    static let isolateLimitBytes: Double = 128 * 1024 * 1024
+
+    var p99Ratio: Double { min(p99 / Self.isolateLimitBytes, 1) }
+}
+
+// GraphQL 解码结构
+
+nonisolated struct DOMemoryData: Codable, Sendable {
+    let viewer: DOMemoryViewer
+}
+
+nonisolated struct DOMemoryViewer: Codable, Sendable {
+    let accounts: [DOMemoryAccount]
+}
+
+nonisolated struct DOMemoryAccount: Codable, Sendable {
+    let periodic: [DOMemoryGroup]?
+
+    enum CodingKeys: String, CodingKey {
+        case periodic = "durableObjectsPeriodicGroups"
+    }
+}
+
+nonisolated struct DOMemoryGroup: Codable, Sendable {
+    let quantiles: DOMemoryQuantiles?
+}
+
+nonisolated struct DOMemoryQuantiles: Codable, Sendable {
+    let p50:  Double?
+    let p90:  Double?
+    let p99:  Double?
+    let p999: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case p50  = "memoryUsageBytesP50"
+        case p90  = "memoryUsageBytesP90"
+        case p99  = "memoryUsageBytesP99"
+        case p999 = "memoryUsageBytesP999"
+    }
+}
+
+nonisolated enum DOMemoryQuery {
+    /// 按 namespace 聚合的内存分位数。scriptName 维度用来过滤到具体 namespace。
+    static let text = """
+    query DOMemory($accountTag: String!, $namespaceId: String!, $since: Time!, $until: Time!) {
+      viewer {
+        accounts(filter: { accountTag: $accountTag }) {
+          durableObjectsPeriodicGroups(
+            limit: 1
+            filter: { datetime_geq: $since, datetime_leq: $until, namespaceId: $namespaceId }
+          ) {
+            quantiles {
+              memoryUsageBytesP50
+              memoryUsageBytesP90
+              memoryUsageBytesP99
+              memoryUsageBytesP999
+            }
+          }
+        }
+      }
+    }
+    """
+}
+
+nonisolated struct DOMemoryVariables: Codable, Sendable {
+    let accountTag:  String
+    let namespaceId: String
+    let since:       String
+    let until:       String
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/EmailRoutingModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/EmailRoutingModels.swift
@@ -98,3 +98,41 @@ nonisolated struct EmailDestinationAddress: Codable, Sendable, Identifiable {
 nonisolated struct EmailDestinationCreate: Codable, Sendable {
     let email: String
 }
+
+// MARK: - 抑制列表（Suppression）
+
+/// 被抑制的收件地址：投递硬退信等原因后，Cloudflare 不再向其转发。
+/// GET/POST /zones/{zone_id}/email/routing/suppression
+///
+/// 与「路由规则」是两回事：规则决定往哪转，抑制决定不往哪转——
+/// 用户常见的困惑「规则明明配了却收不到」多半就是命中了这里。
+nonisolated struct EmailSuppression: Codable, Identifiable, Hashable, Sendable {
+    let id:        String
+    let email:     String?
+    /// hard_bounce 等
+    let reason:    String?
+    let createdAt: String?
+    /// 到期后自动解除；null 表示永久
+    let expiresAt: String?
+    let zones:     [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, email, reason, zones
+        case createdAt = "created_at"
+        case expiresAt = "expires_at"
+    }
+
+    var reasonText: String {
+        switch reason {
+        case "hard_bounce": String(localized: "硬退信")
+        case "soft_bounce": String(localized: "软退信")
+        case "complaint":   String(localized: "投诉")
+        case "manual":      String(localized: "手动添加")
+        default:            reason ?? String(localized: "未知")
+        }
+    }
+}
+
+nonisolated struct EmailSuppressionCreate: Codable, Sendable {
+    let email: String
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/HealthCheckModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/HealthCheckModels.swift
@@ -1,0 +1,77 @@
+//
+//  HealthCheckModels.swift
+//  Orange Cloud
+//
+//  独立健康检查（Standalone Health Checks）。/zones/{zone_id}/healthchecks
+//
+//  与负载均衡的 monitor 是两回事：LB monitor 只在负载均衡语境里生效，
+//  这里是独立监控单个 IP / 主机名，单源站也能用。别把两者混进同一个页面。
+//
+//  套餐：免费版不可用（0 个），Pro 10 / Business 50 / Enterprise 1000。
+//
+
+import Foundation
+
+nonisolated struct HealthCheck: Codable, Identifiable, Hashable, Sendable {
+    let id:            String
+    let name:          String
+    /// 被监控的源站主机名或 IP
+    let address:       String?
+    let description:   String?
+    /// HTTP / HTTPS / TCP
+    let type:          String?
+    /// healthy / unhealthy / unknown / suspended
+    let status:        String?
+    /// status 为 unhealthy 时的失败原因
+    let failureReason: String?
+    /// 暂停后不再向源站发送检查
+    let suspended:     Bool?
+    /// 检查间隔（秒）
+    let interval:      Int?
+    let timeout:       Int?
+    let retries:       Int?
+    let consecutiveFails:     Int?
+    let consecutiveSuccesses: Int?
+    /// 发起检查的区域；nil 表示由 Cloudflare 自选
+    let checkRegions:  [String]?
+    let createdOn:     String?
+    let modifiedOn:    String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, address, description, type, status, suspended, interval, timeout, retries
+        case failureReason         = "failure_reason"
+        case consecutiveFails      = "consecutive_fails"
+        case consecutiveSuccesses  = "consecutive_successes"
+        case checkRegions          = "check_regions"
+        case createdOn             = "created_on"
+        case modifiedOn            = "modified_on"
+    }
+
+    /// 暂停优先于 status——暂停时 CF 不再探测，status 会停在最后一次结果上，直接显示会误导。
+    var displayStatus: HealthCheckStatus {
+        if suspended == true { return .suspended }
+        switch status {
+        case "healthy":   return .healthy
+        case "unhealthy": return .unhealthy
+        default:          return .unknown
+        }
+    }
+}
+
+nonisolated enum HealthCheckStatus: Sendable {
+    case healthy, unhealthy, suspended, unknown
+
+    var label: String {
+        switch self {
+        case .healthy:   String(localized: "正常")
+        case .unhealthy: String(localized: "异常")
+        case .suspended: String(localized: "已暂停")
+        case .unknown:   String(localized: "未知")
+        }
+    }
+}
+
+/// PATCH 体：只发要改的字段（暂停 / 恢复）
+nonisolated struct HealthCheckSuspendUpdate: Codable, Sendable {
+    let suspended: Bool
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/ManagedHeaderModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/ManagedHeaderModels.swift
@@ -1,0 +1,60 @@
+//
+//  ManagedHeaderModels.swift
+//  Orange Cloud
+//
+//  托管请求/响应头（Managed Transforms）。GET/PATCH /zones/{zone_id}/managed_headers
+//
+//  由 Cloudflare 维护的一组开关式头部改写（如 add_security_headers、
+//  add_bot_protection_headers、add_true_client_ip_headers），无需自己写 Transform 规则。
+//
+//  PATCH 是**分区合并**：两个数组都可选，只更新给出的那一节；但给出的那一节内
+//  会按 id 匹配更新，所以只发要改的那一条即可。
+//
+
+import Foundation
+
+nonisolated struct ManagedTransforms: Codable, Sendable {
+    let managedRequestHeaders:  [ManagedTransform]?
+    let managedResponseHeaders: [ManagedTransform]?
+
+    enum CodingKeys: String, CodingKey {
+        case managedRequestHeaders  = "managed_request_headers"
+        case managedResponseHeaders = "managed_response_headers"
+    }
+}
+
+nonisolated struct ManagedTransform: Codable, Identifiable, Hashable, Sendable {
+    let id:      String
+    let enabled: Bool?
+    /// 与之冲突的其它托管头（只读）。开启前应提示用户会互斥。
+    let conflictsWith: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, enabled
+        case conflictsWith = "conflicts_with"
+    }
+
+    /// 接口给的是 add_security_headers 这类蛇形 id，直接展示不友好
+    var displayName: String {
+        id.replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+}
+
+/// PATCH 体：只带要改的那一节
+nonisolated struct ManagedTransformsPatch: Codable, Sendable {
+    var managedRequestHeaders:  [ManagedTransformToggle]?
+    var managedResponseHeaders: [ManagedTransformToggle]?
+
+    enum CodingKeys: String, CodingKey {
+        case managedRequestHeaders  = "managed_request_headers"
+        case managedResponseHeaders = "managed_response_headers"
+    }
+}
+
+nonisolated struct ManagedTransformToggle: Codable, Sendable {
+    let id:      String
+    let enabled: Bool
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/PermissionModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/PermissionModels.swift
@@ -133,13 +133,96 @@ extension FeaturePermission {
             isRequired: false
         ),
         .init(
+            id: "managed_headers",
+            title: String(localized: "托管头"),
+            description: String(localized: "Cloudflare 维护的请求/响应头改写开关"),
+            icon: "list.bullet.rectangle.portrait",
+            readScopes: ["managed-headers.read"],
+            editScopes: ["managed-headers.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "workers_builds",
+            title: String(localized: "Workers 构建"),
+            description: String(localized: "查看 CI 构建记录与日志；读写可取消构建"),
+            icon: "hammer.circle",
+            readScopes: ["workers-ci.read"],
+            editScopes: ["workers-ci.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "r2_catalog",
+            title: String(localized: "R2 数据目录"),
+            description: String(localized: "把 R2 桶启用为 Iceberg 数据仓库"),
+            icon: "tablecells",
+            readScopes: ["r2-catalog.read"],
+            editScopes: ["r2-catalog.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "url_scanner",
+            title: String(localized: "URL 扫描"),
+            description: String(localized: "提交链接做安全扫描并查看报告"),
+            icon: "magnifyingglass.circle",
+            readScopes: ["url-scanner.read"],
+            editScopes: ["url-scanner.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "request_tracer",
+            title: String(localized: "请求追踪"),
+            description: String(localized: "模拟请求，查看它命中了哪些规则"),
+            icon: "point.topleft.down.curvedto.point.bottomright.up",
+            readScopes: ["request-tracer.read"],
+            editScopes: [],
+            isRequired: false
+        ),
+        .init(
+            id: "registrar",
+            title: String(localized: "域名注册"),
+            description: String(localized: "查看在 Cloudflare 注册的域名与到期日；读写可改自动续费"),
+            icon: "checkmark.seal",
+            readScopes: ["registrar-domains.read"],
+            editScopes: ["registrar-domains.admin"],
+            isRequired: false
+        ),
+        .init(
+            id: "dns_settings",
+            title: String(localized: "DNS 设置"),
+            description: String(localized: "DNSSEC、CNAME 展平与名称服务器"),
+            icon: "gearshape.2",
+            readScopes: ["zone-dns-settings.read"],
+            editScopes: ["zone-dns-settings.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "health_checks",
+            title: String(localized: "健康检查"),
+            description: String(localized: "监控源站是否在线；读写可暂停与删除"),
+            icon: "waveform.path.ecg",
+            readScopes: ["healthcheck.read"],
+            editScopes: ["healthcheck.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "bot_management",
+            title: String(localized: "AI 与机器人"),
+            description: String(localized: "管控 AI 爬虫、内容机器人与 robots.txt"),
+            icon: "ant",
+            readScopes: ["bot-management.read"],
+            editScopes: ["bot-management.write"],
+            isRequired: false
+        ),
+        .init(
             id: "email_routing",
             title: "Email Routing",
             description: String(localized: "查看与管理邮件路由规则与目的地址"),
             icon: "envelope",
             // rules 是域名级，addresses 是账号级——两组 scope 都要才能完整使用
-            readScopes: ["email-routing-rule.read", "email-routing-address.read"],
-            editScopes: ["email-routing-rule.write", "email-routing-address.write"],
+            readScopes: ["email-routing-rule.read", "email-routing-address.read",
+                         "email-routing-suppression.read"],
+            editScopes: ["email-routing-rule.write", "email-routing-address.write",
+                         "email-routing-suppression.write"],
             isRequired: false
         ),
         .init(

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/R2CatalogModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/R2CatalogModels.swift
@@ -1,0 +1,83 @@
+//
+//  R2CatalogModels.swift
+//  Orange Cloud
+//
+//  R2 Data Catalog —— 把 R2 桶启用为 Apache Iceberg 目录。
+//  /accounts/{account_id}/r2-catalog[/{bucket_name}]
+//
+//  2026-08-03 起计费（$9/百万次目录操作，每月含 100 万次免费；压实另计），
+//  UI 上要让用户知道启用是有成本的动作。
+//
+
+import Foundation
+
+nonisolated struct R2Catalog: Codable, Sendable {
+    let id:                String?
+    /// 所属桶名
+    let bucket:            String?
+    /// 完整目录名，形如 account123_analytics-bucket
+    let name:              String?
+    /// active / …
+    let status:            String?
+    /// present 表示已存过访问凭据
+    let credentialStatus:  String?
+    let maintenanceConfig: R2CatalogMaintenance?
+
+    enum CodingKeys: String, CodingKey {
+        case id, bucket, name, status
+        case credentialStatus  = "credential_status"
+        case maintenanceConfig = "maintenance_config"
+    }
+
+    var isActive: Bool { status == "active" }
+}
+
+nonisolated struct R2CatalogMaintenance: Codable, Sendable {
+    let compaction:         R2CatalogCompaction?
+    let snapshotExpiration: R2CatalogSnapshotExpiration?
+
+    enum CodingKeys: String, CodingKey {
+        case compaction
+        case snapshotExpiration = "snapshot_expiration"
+    }
+}
+
+nonisolated struct R2CatalogCompaction: Codable, Sendable {
+    let state:        String?
+    /// 接口返回的是字符串数字（如 "128"）
+    let targetSizeMb: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case targetSizeMb = "target_size_mb"
+    }
+}
+
+nonisolated struct R2CatalogSnapshotExpiration: Codable, Sendable {
+    let state:              String?
+    let maxSnapshotAge:     String?
+    let minSnapshotsToKeep: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case maxSnapshotAge     = "max_snapshot_age"
+        case minSnapshotsToKeep = "min_snapshots_to_keep"
+    }
+}
+
+/// 命名空间列表的 result 外壳
+nonisolated struct R2CatalogNamespaceList: Codable, Sendable {
+    let namespaces: [R2CatalogNamespace]?
+}
+
+nonisolated struct R2CatalogNamespace: Codable, Identifiable, Hashable, Sendable {
+    /// Iceberg 命名空间是分段的，接口以数组返回
+    let name: [String]?
+
+    var id: String { displayName }
+
+    /// 嵌套命名空间用 · 连接展示
+    var displayName: String {
+        (name ?? []).joined(separator: " · ")
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/RegistrarModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/RegistrarModels.swift
@@ -1,0 +1,88 @@
+//
+//  RegistrarModels.swift
+//  Orange Cloud
+//
+//  Cloudflare Registrar —— 在 Cloudflare 注册的域名：到期日 / 自动续费 / 转移锁。
+//
+//  ⚠️ 必须用新版 API。旧的 /accounts/{id}/registrar/domains 系列于 2026-06-29 弃用、
+//  **2026-09-27 停用**；新版在 /accounts/{id}/registrar/registrations 下。
+//
+//  两个由接口决定的边界，UI 必须如实反映：
+//  · PATCH **只支持 auto_renew**（规范原文：currently supports updating auto_renew only），
+//    转移锁 locked 是只读的 —— 不做成开关
+//  · PATCH 返回的是**异步 workflow 状态**而非更新后的注册对象，故写入后需回读列表
+//
+
+import Foundation
+
+nonisolated struct DomainRegistration: Codable, Identifiable, Hashable, Sendable {
+    let domainName:  String
+    /// 到期时间。registration_pending 期间可能为 null
+    let expiresAt:   String?
+    let createdAt:   String?
+    /// 自动续费：开启即授权 Cloudflare 在到期前 30 天内扣默认支付方式
+    let autoRenew:   Bool?
+    /// 是否锁定转移。**只读**，新版 API 不支持经此端点修改
+    let locked:      Bool?
+    /// false / redaction
+    let privacyMode: String?
+    /// active / registration_pending / expired / suspended / redemption_period
+    let status:      String?
+
+    var id: String { domainName }
+
+    enum CodingKeys: String, CodingKey {
+        case locked, status
+        case domainName  = "domain_name"
+        case expiresAt   = "expires_at"
+        case createdAt   = "created_at"
+        case autoRenew   = "auto_renew"
+        case privacyMode = "privacy_mode"
+    }
+
+    var statusText: String {
+        switch status {
+        case "active":               String(localized: "正常")
+        case "registration_pending": String(localized: "注册中")
+        case "expired":              String(localized: "已过期")
+        case "suspended":            String(localized: "已暂停")
+        case "redemption_period":    String(localized: "赎回期")
+        default:                     status ?? String(localized: "未知")
+        }
+    }
+
+    var expiryDate: Date? {
+        guard let expiresAt else { return nil }
+        return ISO8601DateFormatter.registrarParser.date(from: expiresAt)
+    }
+
+    /// 距到期天数；负数表示已过期
+    var daysUntilExpiry: Int? {
+        guard let expiryDate else { return nil }
+        return Calendar.current.dateComponents([.day], from: Date(), to: expiryDate).day
+    }
+
+    /// 30 天内到期且未开自动续费——需要用户尽快处理
+    var needsAttention: Bool {
+        guard let days = daysUntilExpiry else { return false }
+        return days <= 30 && autoRenew != true
+    }
+}
+
+/// PATCH 体。接口目前只认 auto_renew。
+nonisolated struct RegistrationUpdate: Codable, Sendable {
+    let autoRenew: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case autoRenew = "auto_renew"
+    }
+}
+
+nonisolated extension ISO8601DateFormatter {
+    /// Registrar 的时间戳带小数秒，默认解析器接不住
+    static let registrarParser: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/RequestTracerModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/RequestTracerModels.swift
@@ -1,0 +1,84 @@
+//
+//  RequestTracerModels.swift
+//  Orange Cloud
+//
+//  Cloudflare Trace —— 模拟一个请求打过 Cloudflare，看它走了哪些规则、被谁拦的。
+//  POST /accounts/{account_id}/request-tracer/trace
+//
+//  本质是「模拟」而非真实流量回放，文案上别让用户误解。
+//  全套餐可用，但要求 Administrator / Super Administrator 角色。
+//
+
+import Foundation
+
+nonisolated struct TraceRequest: Codable, Sendable {
+    let method:   String
+    let url:      String
+    let protocolVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case method, url
+        case protocolVersion = "protocol"
+    }
+}
+
+nonisolated struct TraceResult: Codable, Sendable {
+    let statusCode: Int?
+    let trace:      [TraceStep]?
+
+    enum CodingKeys: String, CodingKey {
+        case trace
+        case statusCode = "status_code"
+    }
+}
+
+/// 单个求值步骤。**是递归结构**：ruleset 步骤的 trace 里装着它的各条 rule。
+nonisolated struct TraceStep: Codable, Hashable, Sendable, Identifiable {
+    /// rule / ruleset / …
+    let type:       String?
+    let stepName:   String?
+    /// 命中时执行的动作（type 为 rule 时）
+    let action:     String?
+    let description: String?
+    /// 匹配表达式（type 为 rule 时）
+    let expression: String?
+    /// ruleset 的种类（zone / managed 等）
+    let kind:       String?
+    let name:       String?
+    /// 该步骤是否真的影响了请求——UI 的重点就是把 true 的挑出来
+    let matched:    Bool?
+    let trace:      [TraceStep]?
+
+    var id: String {
+        // 同一层可能有同名步骤，拼上表达式与子树规模降低碰撞
+        "\(stepName ?? "")|\(name ?? "")|\(expression ?? "")|\(trace?.count ?? 0)"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type, action, description, expression, kind, name, matched, trace
+        case stepName = "step_name"
+    }
+
+    /// 展示名：ruleset 用 name，rule 用 description，都没有才退回 step_name
+    var title: String {
+        if let name, !name.isEmpty { return name }
+        if let description, !description.isEmpty { return description }
+        return stepName ?? String(localized: "未命名步骤")
+    }
+}
+
+/// 把递归树摊平成带层级的行，便于用 List 直接渲染
+nonisolated struct FlatTraceStep: Identifiable {
+    let step:  TraceStep
+    let depth: Int
+    var id: String { "\(depth)-\(step.id)" }
+}
+
+nonisolated extension Array where Element == TraceStep {
+    /// 深度优先摊平；depth 用于缩进
+    func flattened(depth: Int = 0) -> [FlatTraceStep] {
+        flatMap { step -> [FlatTraceStep] in
+            [FlatTraceStep(step: step, depth: depth)] + (step.trace ?? []).flattened(depth: depth + 1)
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/TunnelModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/TunnelModels.swift
@@ -3,7 +3,13 @@
 //  Orange Cloud
 //
 //  Cloudflare Tunnel（cfd_tunnel）。GET /accounts/{id}/cfd_tunnel
-//  列表响应已内嵌活跃连接，无需单独拉取。
+//
+//  ⚠️ 活跃连接的取数方式已变更（CF 2026-07-09 公告）：
+//  list/get 响应内嵌的 connections 数组将于 **2026-10-05** 移除，
+//  改由专用端点 GET /cfd_tunnel/{id}/connections 提供。
+//  该端点返回的是 **Client 数组**（每个 client 内嵌 conns），与旧的扁平数组结构不同，
+//  故新增 TunnelClient 建模并用 flattenedConnections 摊平回 TunnelConnection。
+//  Tunnel.connections 仅作过渡期占位（字段消失后恒为 nil），勿再作为唯一数据源。
 //
 
 import Foundation
@@ -16,6 +22,8 @@ nonisolated struct Tunnel: Codable, Identifiable, Hashable, Sendable {
     let connsActiveAt: String?
     let tunType:       String?            // "cfd_tunnel" | "warp_connector" ...
     let remoteConfig:  Bool?
+    /// 过渡期字段：CF 将于 2026-10-05 从 list/get 响应移除。
+    /// 只用来在详情页首帧占位，真实数据以 TunnelService.connections(...) 为准。
     let connections:   [TunnelConnection]?
 
     enum CodingKeys: String, CodingKey {
@@ -43,13 +51,55 @@ nonisolated struct TunnelConnection: Codable, Hashable, Sendable {
     let originIp:      String?
     let openedAt:      String?
     let clientVersion: String?
+    /// 仅专用端点返回；旧的内嵌数组没有这两个字段。
+    let clientId:      String?
+    let uuid:          String?
 
     enum CodingKeys: String, CodingKey {
-        case id
+        case id, uuid
         case coloName      = "colo_name"
         case originIp      = "origin_ip"
         case openedAt      = "opened_at"
         case clientVersion = "client_version"
+        case clientId      = "client_id"
+    }
+}
+
+/// GET /accounts/{id}/cfd_tunnel/{id}/connections 的 result 元素。
+/// 一个 client 即一个 cloudflared 进程，其 conns 是它维持的各条连接。
+nonisolated struct TunnelClient: Codable, Hashable, Sendable {
+    let id:            String?
+    let arch:          String?
+    let version:       String?
+    let runAt:         String?
+    let configVersion: Int?
+    let features:      [String]?
+    let conns:         [TunnelConnection]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, arch, version, features, conns
+        case runAt         = "run_at"
+        case configVersion = "config_version"
+    }
+}
+
+extension Array where Element == TunnelClient {
+    /// 摊平成 UI 直接消费的连接列表。
+    /// client_version 在 conns 里可能缺省，回退用 client 自身的 version 补齐。
+    var flattenedConnections: [TunnelConnection] {
+        flatMap { client in
+            (client.conns ?? []).map { conn in
+                TunnelConnection(
+                    id:            conn.id,
+                    coloName:      conn.coloName,
+                    originIp:      conn.originIp,
+                    openedAt:      conn.openedAt,
+                    clientVersion: conn.clientVersion ?? client.version,
+                    clientId:      conn.clientId ?? client.id,
+                    uuid:          conn.uuid
+                )
+            }
+        }
     }
 }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/URLScannerModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/URLScannerModels.swift
@@ -1,0 +1,84 @@
+//
+//  URLScannerModels.swift
+//  Orange Cloud
+//
+//  Cloudflare URL Scanner（v2）。提交 URL 做安全扫描并看报告。
+//  POST /accounts/{account_id}/urlscanner/v2/scan
+//  GET  /accounts/{account_id}/urlscanner/v2/result/{scan_id}
+//  GET  /accounts/{account_id}/urlscanner/v2/screenshots/{scan_id}.png
+//
+//  ⚠️ 只用 v2，不要用 v1（v1 是旧版，字段与路径都不同）。
+//  扫描是异步的：提交后返回 uuid，结果要轮询，未就绪时 result 返回 404/202。
+//
+
+import Foundation
+
+nonisolated struct URLScanSubmit: Codable, Sendable {
+    let url: String
+}
+
+/// 提交成功后的回执
+nonisolated struct URLScanAccepted: Codable, Sendable {
+    let uuid:    String?
+    let api:     String?
+    let message: String?
+    let result:  String?
+}
+
+/// 扫描报告。字段很多，这里只取移动端会展示的那部分。
+nonisolated struct URLScanResult: Codable, Sendable {
+    let task:     URLScanTask?
+    let page:     URLScanPage?
+    let verdicts: URLScanVerdicts?
+    let stats:    URLScanStats?
+}
+
+nonisolated struct URLScanTask: Codable, Sendable {
+    let uuid:      String?
+    let url:       String?
+    let effectiveUrl: String?
+    let status:    String?
+    let time:      String?
+
+    enum CodingKeys: String, CodingKey {
+        case uuid, url, status, time
+        case effectiveUrl = "effectiveUrl"
+    }
+}
+
+nonisolated struct URLScanPage: Codable, Sendable {
+    let url:     String?
+    let domain:  String?
+    let ip:      String?
+    let country: String?
+    let asn:     String?
+    let asnname: String?
+    let server:  String?
+    let statusCode: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case url, domain, ip, country, asn, asnname, server
+        case statusCode = "statusCode"
+    }
+}
+
+nonisolated struct URLScanVerdicts: Codable, Sendable {
+    let overall: URLScanVerdict?
+}
+
+nonisolated struct URLScanVerdict: Codable, Sendable {
+    let malicious:  Bool?
+    let categories: [URLScanCategory]?
+    let phishing:   [String]?
+}
+
+nonisolated struct URLScanCategory: Codable, Sendable {
+    let id:   Int?
+    let name: String?
+}
+
+nonisolated struct URLScanStats: Codable, Sendable {
+    let uniqCountries: Int?
+    let dataLength:    Int?
+    let requests:      Int?
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerBuildModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerBuildModels.swift
@@ -1,0 +1,105 @@
+//
+//  WorkerBuildModels.swift
+//  Orange Cloud
+//
+//  Workers Builds —— Worker 的 CI 构建记录。
+//  GET /accounts/{account_id}/builds/workers/{external_script_id}/builds
+//  GET /accounts/{account_id}/builds/builds/{build_uuid}/logs
+//
+//  注意 status 与 outcome 是两个维度：status 只到 stopped 为止（queued/initializing/
+//  running/stopped），成功还是失败要看 build_outcome。UI 必须合起来判断，
+//  只看 status 会把「失败」显示成「已结束」。
+//
+
+import Foundation
+
+nonisolated struct WorkerBuild: Codable, Identifiable, Hashable, Sendable {
+    let buildUuid:  String
+    /// queued / initializing / running / stopped
+    let status:     String?
+    /// success / fail / skipped / cancelled / terminated（仅 stopped 后有值）
+    let buildOutcome: String?
+    let createdOn:  String?
+    let modifiedOn: String?
+    let buildTriggerMetadata: BuildTriggerMetadata?
+
+    var id: String { buildUuid }
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case buildUuid            = "build_uuid"
+        case buildOutcome         = "build_outcome"
+        case createdOn            = "created_on"
+        case modifiedOn           = "modified_on"
+        case buildTriggerMetadata = "build_trigger_metadata"
+    }
+
+    /// 把 status + outcome 合成用户能看懂的一个状态
+    var displayState: BuildDisplayState {
+        if status != "stopped" {
+            switch status {
+            case "queued":       return .queued
+            case "initializing": return .running
+            case "running":      return .running
+            default:             return .unknown
+            }
+        }
+        switch buildOutcome {
+        case "success":                 return .success
+        case "fail", "terminated":      return .failed
+        case "cancelled":               return .cancelled
+        case "skipped":                 return .skipped
+        default:                        return .unknown
+        }
+    }
+}
+
+nonisolated enum BuildDisplayState: Sendable {
+    case queued, running, success, failed, cancelled, skipped, unknown
+
+    var label: String {
+        switch self {
+        case .queued:    String(localized: "排队中")
+        case .running:   String(localized: "构建中")
+        case .success:   String(localized: "成功")
+        case .failed:    String(localized: "失败")
+        case .cancelled: String(localized: "已取消")
+        case .skipped:   String(localized: "已跳过")
+        case .unknown:   String(localized: "未知")
+        }
+    }
+
+    var isRunning: Bool { self == .queued || self == .running }
+}
+
+nonisolated struct BuildTriggerMetadata: Codable, Hashable, Sendable {
+    let author:       String?
+    let branch:       String?
+    let commitHash:   String?
+    let buildCommand: String?
+    let buildTriggerSource: String?
+
+    enum CodingKeys: String, CodingKey {
+        case author, branch
+        case commitHash         = "commit_hash"
+        case buildCommand       = "build_command"
+        case buildTriggerSource = "build_trigger_source"
+    }
+
+    /// commit 只取前 7 位，和 git 短哈希习惯一致
+    var shortCommit: String? {
+        guard let commitHash, commitHash.count >= 7 else { return commitHash }
+        return String(commitHash.prefix(7))
+    }
+}
+
+/// 构建日志：接口是游标分页的行数组
+nonisolated struct BuildLogsPage: Codable, Sendable {
+    let lines:  [BuildLogLine]?
+    let cursor: String?
+}
+
+nonisolated struct BuildLogLine: Codable, Hashable, Sendable {
+    let line: String?
+    let ts:   String?
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/AuditLogService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/AuditLogService.swift
@@ -42,4 +42,40 @@ struct AuditLogService {
         }
         return page
     }
+    // MARK: - 资源变更历史（2026-07-27 上线）
+
+    /// 某条审计日志所对应资源的完整变更序列。
+    ///
+    /// 接口先用 id + action_time 定位源日志、从中推出资源标识，再回查同一资源的其它日志，
+    /// 所以 **action_time 必须传**（用于收窄查找窗口），否则定位不到。
+    ///
+    /// result_info.history_status 表示识别质量，要如实透传给用户：
+    /// · exact —— 用资源 URI 精确识别
+    /// · approximate —— 没有资源 URI，靠其它字段近似匹配，可能混入无关条目
+    /// · unavailable —— 源日志信息不足，返回空列表（不是「没有变更」）
+    func resourceHistory(
+        accountId: String,
+        entryId: String,
+        actionTime: Date,
+        since: Date,
+        before: Date,
+        limit: Int = 50
+    ) async throws -> AuditLogPage {
+        let query: [URLQueryItem] = [
+            .init(name: "action_time", value: actionTime.ISO8601Format()),
+            .init(name: "since",       value: since.ISO8601Format()),
+            .init(name: "before",      value: before.ISO8601Format()),
+            .init(name: "limit",       value: String(limit)),
+            .init(name: "direction",   value: "desc"),
+        ]
+        let page: AuditLogPage = try await client.get(
+            "accounts/\(accountId)/logs/audit/\(entryId)/history",
+            queryItems: query
+        )
+        guard page.success else {
+            throw page.toAPIError()
+        }
+        return page
+    }
+
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/BotManagementService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/BotManagementService.swift
@@ -1,0 +1,45 @@
+//
+//  BotManagementService.swift
+//  Orange Cloud
+//
+//  Zone 机器人管控（bot-management.read / .write）。
+//  GET/PUT /zones/{zone_id}/bot_management —— 全套餐可用（含免费版）。
+//
+
+import Foundation
+
+struct BotManagementService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 读当前配置。响应 result 是四种套餐形态之一，本模型只取共有的 base_config 字段。
+    func config(zoneId: String) async throws -> BotManagementConfig {
+        let response: CFAPIResponse<BotManagementConfig> = try await client.get(
+            "zones/\(zoneId)/bot_management"
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 写单个字段（PUT 为合并语义，只发要改的那个），返回生效后的完整配置。
+    func update<Value: Codable & Sendable>(
+        zoneId: String,
+        field: BotManagementField,
+        value: Value
+    ) async throws -> BotManagementConfig {
+        let response: CFAPIResponse<BotManagementConfig> = try await client.put(
+            "zones/\(zoneId)/bot_management",
+            body: BotManagementUpdate(key: field, value: value)
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/DNSSettingsService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/DNSSettingsService.swift
@@ -1,0 +1,64 @@
+//
+//  DNSSettingsService.swift
+//  Orange Cloud
+//
+//  Zone DNS 设置（zone-dns-settings.read/.write）与 DNSSEC（dns.read/.write）。
+//
+
+import Foundation
+
+struct DNSSettingsService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    // MARK: - DNS 设置
+
+    func settings(zoneId: String) async throws -> ZoneDNSSettings {
+        let response: CFAPIResponse<ZoneDNSSettings> = try await client.get(
+            "zones/\(zoneId)/dns_settings"
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 合并语义：只发 update 里非 nil 的字段
+    func updateSettings(zoneId: String, update: ZoneDNSSettingsUpdate) async throws -> ZoneDNSSettings {
+        let response: CFAPIResponse<ZoneDNSSettings> = try await client.patch(
+            "zones/\(zoneId)/dns_settings",
+            body: update
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    // MARK: - DNSSEC
+
+    func dnssec(zoneId: String) async throws -> ZoneDNSSEC {
+        let response: CFAPIResponse<ZoneDNSSEC> = try await client.get("zones/\(zoneId)/dnssec")
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 启用传 "active"，停用传 "disabled"。
+    /// 启用后状态先是 pending——必须由用户去注册商处添加 DS 记录才会转 active。
+    func setDNSSEC(zoneId: String, enabled: Bool) async throws -> ZoneDNSSEC {
+        let response: CFAPIResponse<ZoneDNSSEC> = try await client.patch(
+            "zones/\(zoneId)/dnssec",
+            body: ZoneDNSSECUpdate(status: enabled ? "active" : "disabled")
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/DurableObjectService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/DurableObjectService.swift
@@ -36,4 +36,30 @@ struct DurableObjectService {
         let next = response.resultInfo?.cursor
         return (response.result ?? [], (next?.isEmpty == false) ? next : nil)
     }
+    // MARK: - 内存用量（GraphQL）
+
+    /// 某 namespace 过去 24h 的 isolate 内存分位数。
+    ///
+    /// 走账户级 GraphQL —— 免费账号常被 authz 挡（与账号用量同一条链路），
+    /// 故调用方应把失败当成「不可用」静默处理，不要弹错。
+    func memoryUsage(accountId: String, namespaceId: String) async throws -> DurableObjectMemory? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let now = Date()
+        let data: DOMemoryData = try await client.graphQL(
+            query: DOMemoryQuery.text,
+            variables: DOMemoryVariables(
+                accountTag: accountId,
+                namespaceId: namespaceId,
+                since: formatter.string(from: now.addingTimeInterval(-86400)),
+                until: formatter.string(from: now)
+            )
+        )
+        guard let q = data.viewer.accounts.first?.periodic?.first?.quantiles,
+              let p50 = q.p50, let p90 = q.p90, let p99 = q.p99, let p999 = q.p999 else {
+            return nil
+        }
+        return DurableObjectMemory(p50: p50, p90: p90, p99: p99, p999: p999)
+    }
+
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/EmailRoutingService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/EmailRoutingService.swift
@@ -111,4 +111,35 @@ struct EmailRoutingService {
     func deleteAddress(accountId: String, addressId: String) async throws {
         try await client.delete("accounts/\(accountId)/email/routing/addresses/\(addressId)")
     }
+
+    // MARK: - 抑制列表（email-routing-suppression.read / .write）
+
+    /// 被抑制的收件地址。响应信封含 success/errors，与常规一致（另有 page/per_page 平级字段，忽略即可）。
+    func suppressions(zoneId: String) async throws -> [EmailSuppression] {
+        let response: CFAPIResponseArray<EmailSuppression> = try await client.get(
+            "zones/\(zoneId)/email/routing/suppression",
+            queryItems: [URLQueryItem(name: "per_page", value: "100")]
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return response.result ?? []
+    }
+
+    /// 手动抑制一个地址（此后不再向它转发）
+    func addSuppression(zoneId: String, email: String) async throws {
+        let response: CFAPIResponse<EmailSuppression> = try await client.post(
+            "zones/\(zoneId)/email/routing/suppression",
+            body: EmailSuppressionCreate(email: email)
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+    }
+
+    /// 解除抑制
+    func deleteSuppression(zoneId: String, id: String) async throws {
+        try await client.delete("zones/\(zoneId)/email/routing/suppression/\(id)")
+    }
+
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/HealthCheckService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/HealthCheckService.swift
@@ -1,0 +1,56 @@
+//
+//  HealthCheckService.swift
+//  Orange Cloud
+//
+//  独立健康检查（healthcheck.read / .write）。免费版不可用。
+//
+
+import Foundation
+
+struct HealthCheckService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 该 Zone 的全部健康检查（页码分页）
+    func list(zoneId: String) async throws -> [HealthCheck] {
+        var checks: [HealthCheck] = []
+        var page = 1
+        while true {
+            let response: CFAPIResponseArray<HealthCheck> = try await client.get(
+                "zones/\(zoneId)/healthchecks",
+                queryItems: [
+                    URLQueryItem(name: "page",     value: String(page)),
+                    URLQueryItem(name: "per_page", value: "50"),
+                ]
+            )
+            guard response.success else {
+                throw response.toAPIError()
+            }
+            checks.append(contentsOf: response.result ?? [])
+            let totalPages = response.resultInfo?.totalPages ?? 1
+            guard page < totalPages else { break }
+            page += 1
+        }
+        return checks
+    }
+
+    /// 暂停 / 恢复。暂停后 CF 不再向源站发送检查。
+    func setSuspended(zoneId: String, checkId: String, suspended: Bool) async throws -> HealthCheck {
+        let response: CFAPIResponse<HealthCheck> = try await client.patch(
+            "zones/\(zoneId)/healthchecks/\(checkId)",
+            body: HealthCheckSuspendUpdate(suspended: suspended)
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    func delete(zoneId: String, checkId: String) async throws {
+        try await client.delete("zones/\(zoneId)/healthchecks/\(checkId)")
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/ManagedHeaderService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/ManagedHeaderService.swift
@@ -1,0 +1,47 @@
+//
+//  ManagedHeaderService.swift
+//  Orange Cloud
+//
+//  托管请求/响应头（managed-headers.read / .write）。
+//
+
+import Foundation
+
+struct ManagedHeaderService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    func transforms(zoneId: String) async throws -> ManagedTransforms {
+        let response: CFAPIResponse<ManagedTransforms> = try await client.get(
+            "zones/\(zoneId)/managed_headers"
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 开关单条。isRequest 决定改哪一节——两节的 id 空间是独立的。
+    func setEnabled(
+        zoneId: String,
+        id: String,
+        enabled: Bool,
+        isRequest: Bool
+    ) async throws -> ManagedTransforms {
+        let toggle = ManagedTransformToggle(id: id, enabled: enabled)
+        let body = isRequest
+            ? ManagedTransformsPatch(managedRequestHeaders: [toggle], managedResponseHeaders: nil)
+            : ManagedTransformsPatch(managedRequestHeaders: nil, managedResponseHeaders: [toggle])
+        let response: CFAPIResponse<ManagedTransforms> = try await client.patch(
+            "zones/\(zoneId)/managed_headers", body: body
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/R2CatalogService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/R2CatalogService.swift
@@ -1,0 +1,69 @@
+//
+//  R2CatalogService.swift
+//  Orange Cloud
+//
+//  R2 Data Catalog（r2-catalog.read / .write）。
+//
+
+import Foundation
+
+struct R2CatalogService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 单桶的目录详情。未启用时接口 404，按「未启用」处理而非报错。
+    func catalog(accountId: String, bucketName: String) async throws -> R2Catalog? {
+        do {
+            let response: CFAPIResponse<R2Catalog> = try await client.get(
+                "accounts/\(accountId)/r2-catalog/\(bucketName)"
+            )
+            guard response.success else {
+                throw response.toAPIError()
+            }
+            return response.result
+        } catch APIError.notFound {
+            return nil
+        }
+    }
+
+    /// 启用为 Iceberg 目录。**这是计费动作**（$9/百万次目录操作），调用方需先确认。
+    func enable(accountId: String, bucketName: String) async throws -> R2Catalog? {
+        let response: CFAPIResponse<R2Catalog> = try await client.post(
+            "accounts/\(accountId)/r2-catalog/\(bucketName)/enable",
+            body: EmptyBody()
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return response.result
+    }
+
+    /// 停用目录。数据保留，只是不再作为 Iceberg 目录对外提供。
+    func disable(accountId: String, bucketName: String) async throws {
+        let response: CFAPIResponse<R2Catalog> = try await client.post(
+            "accounts/\(accountId)/r2-catalog/\(bucketName)/disable",
+            body: EmptyBody()
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+    }
+
+    func namespaces(accountId: String, bucketName: String) async throws -> [R2CatalogNamespace] {
+        let response: CFAPIResponse<R2CatalogNamespaceList> = try await client.get(
+            "accounts/\(accountId)/r2-catalog/\(bucketName)/namespaces",
+            queryItems: [URLQueryItem(name: "page_size", value: "100")]
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return response.result?.namespaces ?? []
+    }
+}
+
+/// enable / disable 是无体 POST，但 CFAPIClient.post 要求 Encodable body
+nonisolated struct EmptyBody: Codable, Sendable {}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/RegistrarService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/RegistrarService.swift
@@ -1,0 +1,59 @@
+//
+//  RegistrarService.swift
+//  Orange Cloud
+//
+//  Cloudflare Registrar（registrar-domains.read / .admin）。
+//  用新版 /registrar/registrations —— 旧的 /registrar/domains 于 2026-09-27 停用。
+//
+
+import Foundation
+
+struct RegistrarService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 账号下已注册域名。该端点是**游标分页**（不是页码），cursor 为空串即到底。
+    func registrations(accountId: String) async throws -> [DomainRegistration] {
+        var all: [DomainRegistration] = []
+        var cursor: String?
+        // 兜底上限，防止服务端游标异常导致死循环
+        for _ in 0..<20 {
+            var items = [URLQueryItem(name: "per_page", value: "50")]
+            if let cursor, !cursor.isEmpty {
+                items.append(URLQueryItem(name: "cursor", value: cursor))
+            }
+            let response: CFAPIResponseArray<DomainRegistration> = try await client.get(
+                "accounts/\(accountId)/registrar/registrations",
+                queryItems: items
+            )
+            guard response.success else {
+                throw response.toAPIError()
+            }
+            all.append(contentsOf: response.result ?? [])
+            cursor = response.resultInfo?.cursor
+            guard let cursor, !cursor.isEmpty else { break }
+        }
+        return all
+    }
+
+    /// 设置自动续费。返回的是异步 workflow 状态，调用方成功后应回读列表。
+    func setAutoRenew(accountId: String, domainName: String, enabled: Bool) async throws {
+        let response: CFAPIResponse<RegistrarWorkflowStatus> = try await client.patch(
+            "accounts/\(accountId)/registrar/registrations/\(domainName)",
+            body: RegistrationUpdate(autoRenew: enabled)
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+    }
+}
+
+/// PATCH 的异步 workflow 结果，只取判定是否完成所需的字段
+nonisolated struct RegistrarWorkflowStatus: Codable, Sendable {
+    let completed: Bool?
+    let state:     String?
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/RequestTracerService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/RequestTracerService.swift
@@ -1,0 +1,34 @@
+//
+//  RequestTracerService.swift
+//  Orange Cloud
+//
+//  Cloudflare Trace（request-tracer.read）。全套餐可用，
+//  但**要求 Administrator / Super Administrator 角色**——非管理员成员会失败。
+//
+
+import Foundation
+
+struct RequestTracerService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    func trace(
+        accountId: String,
+        method: String,
+        url: String,
+        protocolVersion: String = "HTTP/1.1"
+    ) async throws -> TraceResult {
+        let response: CFAPIResponse<TraceResult> = try await client.post(
+            "accounts/\(accountId)/request-tracer/trace",
+            body: TraceRequest(method: method, url: url, protocolVersion: protocolVersion)
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/TunnelService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/TunnelService.swift
@@ -62,6 +62,22 @@ struct TunnelService {
         return token
     }
 
+    // MARK: - 活跃连接
+
+    /// 隧道的活跃连接。
+    ///
+    /// 专用端点，取代 list/get 响应里内嵌的 connections 数组（CF 将于 2026-10-05 移除该字段）。
+    /// result 是 Client 数组（一个 cloudflared 进程一项），此处摊平为连接列表供 UI 直接消费。
+    func connections(accountId: String, tunnelId: String) async throws -> [TunnelConnection] {
+        let response: CFAPIResponseArray<TunnelClient> = try await client.get(
+            "accounts/\(accountId)/cfd_tunnel/\(tunnelId)/connections"
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return (response.result ?? []).flattenedConnections
+    }
+
     /// 清理失活连接（删除隧道前先调用；活跃的 cloudflared 仍会重连）
     func deleteConnections(accountId: String, tunnelId: String) async throws {
         try await client.delete("accounts/\(accountId)/cfd_tunnel/\(tunnelId)/connections")

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/URLScannerService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/URLScannerService.swift
@@ -1,0 +1,50 @@
+//
+//  URLScannerService.swift
+//  Orange Cloud
+//
+//  URL Scanner v2（url-scanner.read / .write）。
+//
+
+import Foundation
+
+struct URLScannerService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 提交扫描。异步任务，返回 uuid 后需轮询结果。
+    func submit(accountId: String, url: String) async throws -> String? {
+        let response: CFAPIResponse<URLScanAccepted> = try await client.post(
+            "accounts/\(accountId)/urlscanner/v2/scan",
+            body: URLScanSubmit(url: url)
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        // 不同版本回执里 uuid 可能落在 uuid 或 result 字段
+        return response.result?.uuid ?? response.result?.result
+    }
+
+    /// 取扫描报告。未就绪时接口 404，此处返回 nil 交由调用方继续轮询。
+    func result(accountId: String, scanId: String) async throws -> URLScanResult? {
+        do {
+            let response: CFAPIResponse<URLScanResult> = try await client.get(
+                "accounts/\(accountId)/urlscanner/v2/result/\(scanId)"
+            )
+            guard response.success else {
+                throw response.toAPIError()
+            }
+            return response.result
+        } catch APIError.notFound {
+            return nil
+        }
+    }
+
+    /// 截图 URL（PNG）。直接交给 AsyncImage 加载，鉴权头由 client 统一带。
+    func screenshotPath(accountId: String, scanId: String) -> String {
+        "accounts/\(accountId)/urlscanner/v2/screenshots/\(scanId).png"
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerBuildService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerBuildService.swift
@@ -1,0 +1,54 @@
+//
+//  WorkerBuildService.swift
+//  Orange Cloud
+//
+//  Workers Builds（workers-ci.read / .write）。
+//
+
+import Foundation
+
+struct WorkerBuildService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 某个 Worker 的构建记录。未接 CI 的 Worker 会 404，按「没有构建」处理。
+    func builds(accountId: String, scriptId: String) async throws -> [WorkerBuild] {
+        do {
+            let response: CFAPIResponseArray<WorkerBuild> = try await client.get(
+                "accounts/\(accountId)/builds/workers/\(scriptId)/builds",
+                queryItems: [URLQueryItem(name: "per_page", value: "20")]
+            )
+            guard response.success else {
+                throw response.toAPIError()
+            }
+            return response.result ?? []
+        } catch APIError.notFound {
+            return []
+        }
+    }
+
+    func logs(accountId: String, buildUuid: String) async throws -> [BuildLogLine] {
+        let response: CFAPIResponse<BuildLogsPage> = try await client.get(
+            "accounts/\(accountId)/builds/builds/\(buildUuid)/logs"
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return response.result?.lines ?? []
+    }
+
+    /// 取消进行中的构建（workers-ci.write）
+    func cancel(accountId: String, buildUuid: String) async throws {
+        let response: CFAPIResponse<WorkerBuild> = try await client.put(
+            "accounts/\(accountId)/builds/builds/\(buildUuid)/cancel",
+            body: EmptyBody()
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/AuditLogViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/AuditLogViewModel.swift
@@ -74,4 +74,32 @@ final class AuditLogViewModel {
         }
         isLoadingMore = false
     }
+    // MARK: - 资源变更历史
+
+    private(set) var history: [IdentifiedAuditEntry] = []
+    /// exact / approximate / unavailable，用于给用户交代结果可信度
+    private(set) var historyStatus: String?
+    var isLoadingHistory = false
+
+    /// 拉某条日志所对应资源的变更序列。
+    /// 时间窗沿用列表的 since/before —— 接口要靠 action_time 定位源日志，窗口不一致会找不到。
+    func loadHistory(for entry: AuditLogEntry) async {
+        guard let entryId = entry.id, let actionTime = entry.timestamp,
+              let since, let before, !isLoadingHistory else { return }
+        isLoadingHistory = true
+        history = []
+        historyStatus = nil
+        do {
+            let page = try await service.resourceHistory(
+                accountId: accountId, entryId: entryId, actionTime: actionTime,
+                since: since, before: before
+            )
+            history = (page.result ?? []).map { IdentifiedAuditEntry(entry: $0) }
+            historyStatus = page.resultInfo?.historyStatus
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoadingHistory = false
+    }
+
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DNSSettingsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DNSSettingsViewModel.swift
@@ -1,0 +1,93 @@
+//
+//  DNSSettingsViewModel.swift
+//  Orange Cloud
+//
+//  Zone DNS 设置 + DNSSEC。两条链路权限不同（zone-dns-settings.* / dns.*），
+//  任一读失败不连累另一条。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class DNSSettingsViewModel {
+
+    private(set) var settings: ZoneDNSSettings?
+    private(set) var dnssec: ZoneDNSSEC?
+    var isLoading = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false
+
+    private let service: DNSSettingsService
+    private let zoneId: String
+
+    init(service: DNSSettingsService, zoneId: String) {
+        self.service = service
+        self.zoneId = zoneId
+    }
+
+    var settingsLoaded: Bool { settings != nil }
+    var dnssecLoaded: Bool { dnssec != nil }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        // 两条链路各自独立：DNSSEC 无权限时不该让 DNS 设置也不显示
+        async let settingsTask = service.settings(zoneId: zoneId)
+        async let dnssecTask = service.dnssec(zoneId: zoneId)
+        settings = try? await settingsTask
+        dnssec = try? await dnssecTask
+        isLoading = false
+    }
+
+    private func apply(_ update: ZoneDNSSettingsUpdate) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            settings = try await service.updateSettings(zoneId: zoneId, update: update)
+            didMutate.toggle()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+
+    func setFlattenAllCnames(_ on: Bool) async {
+        await apply(ZoneDNSSettingsUpdate(flattenAllCnames: on))
+    }
+
+    func setMultiProvider(_ on: Bool) async {
+        await apply(ZoneDNSSettingsUpdate(multiProvider: on))
+    }
+
+    func setSecondaryOverrides(_ on: Bool) async {
+        await apply(ZoneDNSSettingsUpdate(secondaryOverrides: on))
+    }
+
+    func setZoneMode(_ mode: ZoneMode) async {
+        await apply(ZoneDNSSettingsUpdate(zoneMode: mode.rawValue))
+    }
+
+    /// 高级名称服务器：用 nameservers.type 而非已弃用的 foundation_dns
+    func setAdvancedNameservers(_ on: Bool) async {
+        await apply(ZoneDNSSettingsUpdate(
+            nameservers: ZoneNameserversUpdate(type: on ? "cloudflare.advanced" : "cloudflare.standard")
+        ))
+    }
+
+    func setDNSSEC(_ on: Bool) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            dnssec = try await service.setDNSSEC(zoneId: zoneId, enabled: on)
+            didMutate.toggle()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DeveloperPlatformViewModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DeveloperPlatformViewModels.swift
@@ -364,11 +364,22 @@ final class DurableObjectInstancesViewModel {
     let accountId: String?
     let namespaceId: String
 
+    // MARK: 内存用量（账户级 GraphQL，免费账号常被 authz 挡）
+
+    private(set) var memory: DurableObjectMemory?
+
     init(service: DurableObjectService, accountId: String?, namespaceId: String) {
         self.service = service
         self.accountId = accountId
         self.namespaceId = namespaceId
     }
+
+    /// 拿不到就静默——与账号用量同一条 authz 链路，弹错只会打扰用户
+    func loadMemory() async {
+        guard let accountId else { return }
+        memory = try? await service.memoryUsage(accountId: accountId, namespaceId: namespaceId)
+    }
+
 
     func load() async {
         guard let accountId, !isLoading else { return }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/EmailRoutingViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/EmailRoutingViewModel.swift
@@ -15,6 +15,9 @@ final class EmailRoutingViewModel {
     private(set) var settings:  EmailRoutingSettings?
     private(set) var rules:     [EmailRoutingRule] = []
     private(set) var addresses: [EmailDestinationAddress] = []
+    /// 抑制列表：独立 scope，读不到不连累主加载
+    private(set) var suppressions: [EmailSuppression] = []
+    private(set) var suppressionsAvailable = false
     var isLoading = false
     var isMutating = false
     var error: String?
@@ -49,6 +52,11 @@ final class EmailRoutingViewModel {
         // 地址是账号级、独立 scope，单独容错不连累主加载
         if let accountId {
             addresses = (try? await service.addresses(accountId: accountId)) ?? addresses
+        }
+        // 抑制列表同理：email-routing-suppression.read 未授权时静默跳过
+        if let list = try? await service.suppressions(zoneId: zoneId) {
+            suppressions = list
+            suppressionsAvailable = true
         }
         isLoading = false
     }
@@ -128,4 +136,13 @@ final class EmailRoutingViewModel {
         }
         isMutating = false
     }
+
+    /// 解除抑制。成功后本地移除，不必整页重载。
+    func removeSuppression(_ item: EmailSuppression) async {
+        await mutate {
+            try await service.deleteSuppression(zoneId: zoneId, id: item.id)
+        }
+        suppressions.removeAll { $0.id == item.id }
+    }
+
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/HealthCheckAlertViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/HealthCheckAlertViewModel.swift
@@ -1,0 +1,99 @@
+//
+//  HealthCheckAlertViewModel.swift
+//  Orange Cloud
+//
+//  「源站异常时通知我」——把 CF 原生的 health_check_status_notification 告警
+//  一键接到推送端点上。
+//
+//  为什么不像构建那样走后台轮询：健康检查在 Cloudflare 侧**有原生告警类型**，
+//  服务端直接投递 webhook，App 关着也能收到，比客户端比对可靠得多。
+//  通用告警页（CFAlertingView）本来就能开这一项，但混在 69 个告警类型里没人找得到，
+//  所以在健康检查页给一个直达开关。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class HealthCheckAlertViewModel {
+
+    /// CF 的健康检查状态告警类型
+    static let alertType = "health_check_status_notification"
+
+    private(set) var isEnabled = false
+    private(set) var isAvailable = false
+    var isLoading = false
+    var isMutating = false
+    var error: String?
+
+    private let service: AlertingService
+    private let accountId: String
+    private var policyId: String?
+    private var webhookId: String?
+
+    init(service: AlertingService, accountId: String) {
+        self.service = service
+        self.accountId = accountId
+    }
+
+    /// 端点没注册（用户还没开通推送中心）时整个开关不显示
+    var pushEndpoint: String? { PushConfig.endpointURL }
+
+    private var webhookURL: String? {
+        pushEndpoint.map { "\($0)/cf" }
+    }
+
+    func load() async {
+        guard pushEndpoint != nil else { return }
+        isLoading = true
+        error = nil
+        // 该账号是否支持这个告警类型（免费套餐可能没有）
+        if let groups = try? await service.availableAlerts(accountId: accountId) {
+            isAvailable = groups.values.flatMap { $0 }.contains { $0.type == Self.alertType }
+        }
+        if let policies = try? await service.policies(accountId: accountId) {
+            let existing = policies.first { $0.alertType == Self.alertType }
+            policyId = existing?.id
+            isEnabled = existing != nil
+        }
+        if let hooks = try? await service.webhooks(accountId: accountId), let url = webhookURL {
+            webhookId = hooks.first { $0.url == url }?.id
+        }
+        isLoading = false
+    }
+
+    func setEnabled(_ on: Bool) async {
+        guard !isMutating, let url = webhookURL else { return }
+        isMutating = true
+        error = nil
+        do {
+            if on {
+                // 复用已有的推送 webhook，没有才建——避免每开一项告警就多一个目标
+                let hookId: String
+                if let webhookId {
+                    hookId = webhookId
+                } else {
+                    hookId = try await service.createWebhook(
+                        accountId: accountId, name: "Orange Cloud Push", url: url
+                    )
+                    webhookId = hookId
+                }
+                policyId = try await service.createPolicy(
+                    accountId: accountId,
+                    name: String(localized: "OC：源站健康检查"),
+                    alertType: Self.alertType,
+                    webhookId: hookId
+                )
+                isEnabled = true
+            } else if let policyId {
+                try await service.deletePolicy(accountId: accountId, id: policyId)
+                self.policyId = nil
+                isEnabled = false
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/HealthCheckViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/HealthCheckViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  HealthCheckViewModel.swift
+//  Orange Cloud
+//
+//  独立健康检查列表：查看源站状态 + 暂停/恢复 + 删除。
+//  新建检查字段较多（协议、区域、重试、超时、HTTP 配置），属桌面场景，暂不在移动端提供。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class HealthCheckViewModel {
+
+    private(set) var checks: [HealthCheck] = []
+    var isLoading = false
+    var loaded = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false
+
+    private let service: HealthCheckService
+    let zoneId: String
+
+    init(service: HealthCheckService, zoneId: String) {
+        self.service = service
+        self.zoneId = zoneId
+    }
+
+    /// 异常的排在前面——进页第一眼就该看到出问题的源站
+    private func sorted(_ items: [HealthCheck]) -> [HealthCheck] {
+        items.sorted { lhs, rhs in
+            func rank(_ c: HealthCheck) -> Int {
+                switch c.displayStatus {
+                case .unhealthy: 0
+                case .unknown:   1
+                case .healthy:   2
+                case .suspended: 3
+                }
+            }
+            let (l, r) = (rank(lhs), rank(rhs))
+            return l == r ? lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending : l < r
+        }
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        do {
+            checks = sorted(try await service.list(zoneId: zoneId))
+            loaded = true
+        } catch is CancellationError {
+        } catch let urlError as URLError where urlError.code == .cancelled {
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func setSuspended(_ check: HealthCheck, suspended: Bool) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            let updated = try await service.setSuspended(
+                zoneId: zoneId, checkId: check.id, suspended: suspended
+            )
+            if let index = checks.firstIndex(where: { $0.id == check.id }) {
+                checks[index] = updated
+                checks = sorted(checks)
+            }
+            didMutate.toggle()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+
+    @discardableResult
+    func delete(_ check: HealthCheck) async -> Bool {
+        guard !isMutating else { return false }
+        isMutating = true
+        error = nil
+        defer { isMutating = false }
+        do {
+            try await service.delete(zoneId: zoneId, checkId: check.id)
+            checks.removeAll { $0.id == check.id }
+            didMutate.toggle()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ManagedHeadersViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ManagedHeadersViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  ManagedHeadersViewModel.swift
+//  Orange Cloud
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class ManagedHeadersViewModel {
+
+    private(set) var requestHeaders: [ManagedTransform] = []
+    private(set) var responseHeaders: [ManagedTransform] = []
+    var isLoading = false
+    var loaded = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false
+
+    private let service: ManagedHeaderService
+    private let zoneId: String
+
+    init(service: ManagedHeaderService, zoneId: String) {
+        self.service = service
+        self.zoneId = zoneId
+    }
+
+    private func apply(_ transforms: ManagedTransforms) {
+        // 接口不保证顺序，按 id 排一下，避免每次刷新行位置跳动
+        requestHeaders = (transforms.managedRequestHeaders ?? []).sorted { $0.id < $1.id }
+        responseHeaders = (transforms.managedResponseHeaders ?? []).sorted { $0.id < $1.id }
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        do {
+            apply(try await service.transforms(zoneId: zoneId))
+            loaded = true
+        } catch is CancellationError {
+        } catch let urlError as URLError where urlError.code == .cancelled {
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func setEnabled(_ item: ManagedTransform, enabled: Bool, isRequest: Bool) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            apply(try await service.setEnabled(
+                zoneId: zoneId, id: item.id, enabled: enabled, isRequest: isRequest
+            ))
+            didMutate.toggle()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/R2CatalogViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/R2CatalogViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  R2CatalogViewModel.swift
+//  Orange Cloud
+//
+//  R2 桶的 Iceberg 数据目录：启用状态、维护配置、命名空间。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class R2CatalogViewModel {
+
+    private(set) var catalog: R2Catalog?
+    private(set) var namespaces: [R2CatalogNamespace] = []
+    var isLoading = false
+    var loaded = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false
+
+    private let service: R2CatalogService
+    private let accountId: String
+    private let bucketName: String
+
+    init(service: R2CatalogService, accountId: String, bucketName: String) {
+        self.service = service
+        self.accountId = accountId
+        self.bucketName = bucketName
+    }
+
+    var isEnabled: Bool { catalog?.isActive == true }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        do {
+            catalog = try await service.catalog(accountId: accountId, bucketName: bucketName)
+            // 命名空间只在已启用时才有意义；失败不连累目录状态显示
+            namespaces = isEnabled
+                ? ((try? await service.namespaces(accountId: accountId, bucketName: bucketName)) ?? [])
+                : []
+            loaded = true
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func setEnabled(_ on: Bool) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            if on {
+                catalog = try await service.enable(accountId: accountId, bucketName: bucketName)
+            } else {
+                try await service.disable(accountId: accountId, bucketName: bucketName)
+            }
+            didMutate.toggle()
+            await load()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/RegistrarViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/RegistrarViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  RegistrarViewModel.swift
+//  Orange Cloud
+//
+//  在 Cloudflare 注册的域名。只读 + 自动续费开关——
+//  转移锁在新版 API 里是只读的，域名注册是花钱操作、移动端不做。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class RegistrarViewModel {
+
+    private(set) var registrations: [DomainRegistration] = []
+    var isLoading = false
+    var loaded = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false
+
+    private let service: RegistrarService
+    private let accountId: String
+
+    init(service: RegistrarService, accountId: String) {
+        self.service = service
+        self.accountId = accountId
+    }
+
+    /// 快到期又没开自动续费的排最前，其余按到期日升序
+    private func sorted(_ items: [DomainRegistration]) -> [DomainRegistration] {
+        items.sorted { lhs, rhs in
+            if lhs.needsAttention != rhs.needsAttention { return lhs.needsAttention }
+            switch (lhs.expiryDate, rhs.expiryDate) {
+            case let (l?, r?): return l < r
+            case (nil, _?):    return false
+            case (_?, nil):    return true
+            default:           return lhs.domainName < rhs.domainName
+            }
+        }
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        do {
+            registrations = sorted(try await service.registrations(accountId: accountId))
+            loaded = true
+        } catch is CancellationError {
+        } catch let urlError as URLError where urlError.code == .cancelled {
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    /// 接口是异步 workflow，返回后回读列表拿真实状态
+    func setAutoRenew(_ registration: DomainRegistration, enabled: Bool) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            try await service.setAutoRenew(
+                accountId: accountId, domainName: registration.domainName, enabled: enabled
+            )
+            didMutate.toggle()
+            await load()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/RequestTracerViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/RequestTracerViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  RequestTracerViewModel.swift
+//  Orange Cloud
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class RequestTracerViewModel {
+
+    var urlText = ""
+    var method = "GET"
+    private(set) var result: TraceResult?
+    private(set) var flatSteps: [FlatTraceStep] = []
+    var isTracing = false
+    var error: String?
+    var didTrace = false
+
+    static let methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
+
+    private let service: RequestTracerService
+    private let accountId: String
+
+    init(service: RequestTracerService, accountId: String) {
+        self.service = service
+        self.accountId = accountId
+    }
+
+    /// 只做最基本的形态校验，具体是否可达交给接口判断
+    var canTrace: Bool {
+        let trimmed = urlText.trimmingCharacters(in: .whitespaces)
+        return !trimmed.isEmpty && trimmed.contains("://") && !isTracing
+    }
+
+    func run() async {
+        guard canTrace else { return }
+        isTracing = true
+        error = nil
+        do {
+            let traceResult = try await service.trace(
+                accountId: accountId,
+                method: method,
+                url: urlText.trimmingCharacters(in: .whitespaces)
+            )
+            result = traceResult
+            flatSteps = (traceResult.trace ?? []).flattened()
+            didTrace.toggle()
+        } catch {
+            self.error = error.localizedDescription
+            result = nil
+            flatSteps = []
+        }
+        isTracing = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SessionStore.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SessionStore.swift
@@ -26,6 +26,16 @@ final class SessionStore {
     let wafService:        WAFService
     let snippetService:    SnippetService
     let zoneSettingsService: ZoneSettingsService
+    let botManagementService:      BotManagementService
+    let healthCheckService:        HealthCheckService
+    let dnsSettingsService:        DNSSettingsService
+    let registrarService:          RegistrarService
+    let requestTracerService:      RequestTracerService
+    let r2CatalogService:          R2CatalogService
+    let workerBuildService:        WorkerBuildService
+    let alertingService:           AlertingService
+    let managedHeaderService:      ManagedHeaderService
+    let urlScannerService:         URLScannerService
     let sslCertificateService:     SSLCertificateService
     let transformRuleService:      TransformRuleService
     let firewallAccessRuleService: FirewallAccessRuleService
@@ -81,6 +91,16 @@ final class SessionStore {
         self.wafService        = WAFService(client: client)
         self.snippetService    = SnippetService(client: client)
         self.zoneSettingsService = ZoneSettingsService(client: client)
+        self.botManagementService      = BotManagementService(client: client)
+        self.healthCheckService        = HealthCheckService(client: client)
+        self.dnsSettingsService        = DNSSettingsService(client: client)
+        self.registrarService          = RegistrarService(client: client)
+        self.requestTracerService      = RequestTracerService(client: client)
+        self.r2CatalogService          = R2CatalogService(client: client)
+        self.workerBuildService        = WorkerBuildService(client: client)
+        self.alertingService           = AlertingService(client: client)
+        self.managedHeaderService      = ManagedHeaderService(client: client)
+        self.urlScannerService         = URLScannerService(client: client)
         self.sslCertificateService     = SSLCertificateService(client: client)
         self.transformRuleService      = TransformRuleService(client: client)
         self.firewallAccessRuleService = FirewallAccessRuleService(client: client)

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/TunnelWAFViewModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/TunnelWAFViewModels.swift
@@ -72,8 +72,12 @@ final class TunnelDetailViewModel {
 
     var token: String?
     var config: TunnelConfig?
+    /// 活跃连接。首帧用列表响应内嵌的数组占位，随后由专用端点覆盖
+    /// （内嵌字段 CF 将于 2026-10-05 移除，届时占位恒为空、完全依赖端点）。
+    var connections: [TunnelConnection]
     var isLoadingToken = false
     var isLoadingConfig = false
+    var isLoadingConnections = false
     var configLoaded = false
     var isSaving = false
     var error: String?
@@ -89,6 +93,7 @@ final class TunnelDetailViewModel {
 
     init(tunnel: Tunnel, accountId: String, session: SessionStore, canWriteDNS: Bool) {
         self.tunnel = tunnel
+        self.connections = tunnel.connections ?? []
         self.accountId = accountId
         self.tunnelService = session.tunnelService
         self.dnsService = session.dnsService
@@ -145,6 +150,18 @@ final class TunnelDetailViewModel {
     }
 
     /// 清理失活连接（危险区）。活跃的 cloudflared 会自动重连。
+    /// 拉取活跃连接。失败不弹错误框——详情页其余内容仍可用，保留占位数据即可。
+    func loadConnections() async {
+        guard !isLoadingConnections else { return }
+        isLoadingConnections = true
+        defer { isLoadingConnections = false }
+        do {
+            connections = try await tunnelService.connections(accountId: accountId, tunnelId: tunnel.id)
+        } catch {
+            AppLog.network.info("tunnel connections fetch failed for tunnel=\(self.tunnel.id); keeping placeholder")
+        }
+    }
+
     func cleanupConnections() async {
         guard !isSaving else { return }
         isSaving = true
@@ -152,6 +169,8 @@ final class TunnelDetailViewModel {
         defer { isSaving = false }
         do {
             try await tunnelService.deleteConnections(accountId: accountId, tunnelId: tunnel.id)
+            // 清理后立刻回读，避免列表还显示已被移除的失活连接
+            await loadConnections()
         } catch {
             self.error = error.localizedDescription
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/URLScannerViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/URLScannerViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  URLScannerViewModel.swift
+//  Orange Cloud
+//
+//  扫描是异步的：提交 → 轮询结果。轮询有上限，避免无限转圈。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class URLScannerViewModel {
+
+    var urlText = ""
+    private(set) var result: URLScanResult?
+    private(set) var scanId: String?
+    var isScanning = false
+    var error: String?
+    var didFinish = false
+
+    private let service: URLScannerService
+    private let accountId: String
+
+    /// 轮询上限：2 秒一次、最多 30 次（约 1 分钟）。超时按「还没出结果」处理而非报错。
+    private let maxPolls = 30
+    private let pollInterval: UInt64 = 2_000_000_000
+
+    init(service: URLScannerService, accountId: String) {
+        self.service = service
+        self.accountId = accountId
+    }
+
+    var canScan: Bool {
+        let trimmed = urlText.trimmingCharacters(in: .whitespaces)
+        return !trimmed.isEmpty && trimmed.contains(".") && !isScanning
+    }
+
+    func screenshotPath() -> String? {
+        scanId.map { service.screenshotPath(accountId: accountId, scanId: $0) }
+    }
+
+    func scan() async {
+        guard canScan else { return }
+        isScanning = true
+        error = nil
+        result = nil
+        scanId = nil
+        do {
+            var target = urlText.trimmingCharacters(in: .whitespaces)
+            // 用户多半只输域名，补上协议再提交
+            if !target.contains("://") { target = "https://\(target)" }
+            guard let id = try await service.submit(accountId: accountId, url: target) else {
+                error = String(localized: "提交成功但没拿到扫描 ID。")
+                isScanning = false
+                return
+            }
+            scanId = id
+            for _ in 0..<maxPolls {
+                try? await Task.sleep(nanoseconds: pollInterval)
+                if Task.isCancelled { break }
+                if let report = try await service.result(accountId: accountId, scanId: id) {
+                    result = report
+                    didFinish.toggle()
+                    break
+                }
+            }
+            if result == nil {
+                error = String(localized: "扫描仍在进行，请稍后用同一个链接再查一次。")
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isScanning = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerBuildViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerBuildViewModel.swift
@@ -1,0 +1,73 @@
+//
+//  WorkerBuildViewModel.swift
+//  Orange Cloud
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class WorkerBuildViewModel {
+
+    private(set) var builds: [WorkerBuild] = []
+    private(set) var logs: [BuildLogLine] = []
+    private(set) var logsBuildUuid: String?
+    var isLoading = false
+    var loaded = false
+    var isLoadingLogs = false
+    var isMutating = false
+    var error: String?
+    var didMutate = false
+
+    private let service: WorkerBuildService
+    private let accountId: String
+    private let scriptId: String
+
+    init(service: WorkerBuildService, accountId: String, scriptId: String) {
+        self.service = service
+        self.accountId = accountId
+        self.scriptId = scriptId
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        do {
+            builds = try await service.builds(accountId: accountId, scriptId: scriptId)
+            loaded = true
+        } catch is CancellationError {
+        } catch let urlError as URLError where urlError.code == .cancelled {
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func loadLogs(for build: WorkerBuild) async {
+        guard !isLoadingLogs else { return }
+        isLoadingLogs = true
+        logsBuildUuid = build.buildUuid
+        logs = []
+        do {
+            logs = try await service.logs(accountId: accountId, buildUuid: build.buildUuid)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoadingLogs = false
+    }
+
+    func cancel(_ build: WorkerBuild) async {
+        guard !isMutating else { return }
+        isMutating = true
+        error = nil
+        do {
+            try await service.cancel(accountId: accountId, buildUuid: build.buildUuid)
+            didMutate.toggle()
+            await load()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isMutating = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZoneActionsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/ZoneActionsViewModel.swift
@@ -2,7 +2,8 @@
 //  ZoneActionsViewModel.swift
 //  Orange Cloud
 //
-//  Zone 详情页「操作」区：Under Attack / 开发模式 / 暂停 Cloudflare 开关 + 缓存清理。
+//  Zone 详情页「操作」区：Under Attack / 开发模式 / 暂停 Cloudflare 开关 + 缓存清理，
+//  以及「AI 内容控制」区：AI 训练重定向 / 面向 Agent 的 Markdown。
 //
 //  注意暂停态与另两个开关的数据源不同：Under Attack / 开发模式读写 zone settings
 //  （zone-settings.read/.write），暂停读写 zone 本身（zone.read / zone.write），
@@ -22,8 +23,35 @@ final class ZoneActionsViewModel {
     /// 是否暂停 Cloudflare 代理。初值取自本地缓存，进页后再用 API 校准。
     private(set) var paused: Bool
 
+    // MARK: AI 内容控制（Pro/Business 起；免费套餐读取即失败，整卡隐藏）
+
+    /// Redirects for AI Training —— 把 AI 训练类爬虫重定向走
+    private(set) var aiTrainingRedirect = false
+    /// Markdown for Agents —— 按 Accept: text/markdown 把 HTML 转 Markdown 供 agent 消费
+    private(set) var markdownForAgents = false
+    /// 两项中至少一项读到了，才认为该 Zone 支持这组设置
+    private(set) var aiSettingsAvailable = false
+
+    // MARK: 机器人管控（bot-management.read/.write，全套餐可用）
+
+    /// AI 爬虫处置：全站拦 / 仅广告页 / 放行
+    private(set) var aiBotsProtection: AIBotsProtection = .disabled
+    /// 链接迷宫（AI Labyrinth）
+    private(set) var crawlerProtection = false
+    /// 拦内容机器人
+    private(set) var contentBotsProtection = false
+    /// Robots 访问控制许可证
+    private(set) var robotsLicense = false
+    /// 托管 robots.txt
+    private(set) var managedRobotsTxt = false
+    private(set) var botConfigLoaded = false
+
     var isTogglingUnderAttack = false
     var isTogglingDevMode = false
+    var isTogglingAITrainingRedirect = false
+    var isTogglingMarkdownForAgents = false
+    /// 机器人管控五项共用一个忙态：同一个端点，串行改更安全
+    var isUpdatingBotConfig = false
     var isTogglingPause = false
     var isPurging = false
     var didPurge = false       // sensoryFeedback / 提示触发器
@@ -31,11 +59,19 @@ final class ZoneActionsViewModel {
 
     private let service: ZoneSettingsService
     private let zoneService: ZoneService
+    private let botService: BotManagementService
     private let zoneId: String
 
-    init(service: ZoneSettingsService, zoneService: ZoneService, zoneId: String, paused: Bool = false) {
+    init(
+        service: ZoneSettingsService,
+        zoneService: ZoneService,
+        botService: BotManagementService,
+        zoneId: String,
+        paused: Bool = false
+    ) {
         self.service = service
         self.zoneService = zoneService
+        self.botService = botService
         self.zoneId = zoneId
         self.paused = paused
     }
@@ -49,6 +85,104 @@ final class ZoneActionsViewModel {
         underAttack = security == "under_attack"
         devMode = dev == "on"
         settingsLoaded = true
+    }
+
+    /// 读 AI 内容控制两项。免费套餐不支持这两个 setting，读取会失败——
+    /// 此时 aiSettingsAvailable 保持 false，调用方整卡隐藏，不给用户一个永远打不开的锁。
+    func loadAISettings() async {
+        guard !aiSettingsAvailable else { return }
+        async let redirectTask = service.getSetting(zoneId: zoneId, setting: "redirects_for_ai_training")
+        async let converterTask = service.getSetting(zoneId: zoneId, setting: "content_converter")
+        let redirect = try? await redirectTask
+        let converter = try? await converterTask
+        guard redirect != nil || converter != nil else { return }
+        aiTrainingRedirect = redirect == "on"
+        markdownForAgents = converter == "on"
+        aiSettingsAvailable = true
+    }
+
+    /// 读机器人管控配置。四种套餐形态共用 base_config，任何套餐都能读到。
+    func loadBotConfig() async {
+        guard !botConfigLoaded else { return }
+        guard let config = try? await botService.config(zoneId: zoneId) else { return }
+        apply(config)
+        botConfigLoaded = true
+    }
+
+    private func apply(_ config: BotManagementConfig) {
+        aiBotsProtection      = AIBotsProtection(apiValue: config.aiBotsProtection)
+        crawlerProtection     = config.crawlerProtection == "enabled"
+        contentBotsProtection = config.contentBotsProtection == "block"
+        robotsLicense         = config.cfRobotsVariant == "policy_only"
+        managedRobotsTxt      = config.isRobotsTxtManaged == true
+    }
+
+    /// 写单个字段。PUT 是合并语义，只发改动的那一个，不会动 sbfm_* 等套餐专属配置。
+    private func updateBot<Value: Codable & Sendable>(
+        _ field: BotManagementField,
+        _ value: Value
+    ) async {
+        guard !isUpdatingBotConfig else { return }
+        isUpdatingBotConfig = true
+        error = nil
+        do {
+            apply(try await botService.update(zoneId: zoneId, field: field, value: value))
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isUpdatingBotConfig = false
+    }
+
+    func setAIBotsProtection(_ mode: AIBotsProtection) async {
+        await updateBot(.aiBotsProtection, mode.rawValue)
+    }
+
+    func setCrawlerProtection(_ on: Bool) async {
+        await updateBot(.crawlerProtection, on ? "enabled" : "disabled")
+    }
+
+    func setContentBotsProtection(_ on: Bool) async {
+        await updateBot(.contentBotsProtection, on ? "block" : "disabled")
+    }
+
+    func setRobotsLicense(_ on: Bool) async {
+        await updateBot(.cfRobotsVariant, on ? "policy_only" : "off")
+    }
+
+    func setManagedRobotsTxt(_ on: Bool) async {
+        await updateBot(.isRobotsTxtManaged, on)
+    }
+
+    func setAITrainingRedirect(_ on: Bool) async {
+        guard !isTogglingAITrainingRedirect else { return }
+        isTogglingAITrainingRedirect = true
+        error = nil
+        do {
+            let value = try await service.setSetting(
+                zoneId: zoneId, setting: "redirects_for_ai_training",
+                value: on ? "on" : "off"
+            )
+            aiTrainingRedirect = value == "on"
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isTogglingAITrainingRedirect = false
+    }
+
+    func setMarkdownForAgents(_ on: Bool) async {
+        guard !isTogglingMarkdownForAgents else { return }
+        isTogglingMarkdownForAgents = true
+        error = nil
+        do {
+            let value = try await service.setSetting(
+                zoneId: zoneId, setting: "content_converter",
+                value: on ? "on" : "off"
+            )
+            markdownForAgents = value == "on"
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isTogglingMarkdownForAgents = false
     }
 
     func setUnderAttack(_ on: Bool) async {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -55,6 +55,12 @@ struct DashboardView: View {
                 // 逐级 push 才在 iOS 17.0 正常（同 DeveloperHubView 的 DevHubRoute 做法）
                 .navigationDestination(for: DashboardRoute.self) { route in
                     switch route {
+                    case .registrar:
+                        RegistrarView(session: session)
+                    case .urlScanner:
+                        URLScannerView(session: session)
+                    case .requestTracer:
+                        RequestTracerView(session: session)
                     case .tunnels:
                         TunnelListView(session: session)
                     case .tunnelConnect(let tunnel):
@@ -1361,6 +1367,33 @@ private struct DashboardHomeView: View {
         VStack(spacing: 10) {
             // Tunnel 列表点行还要继续 push 详情/连接页：必须走值式 + 栈根 navdest，
             // eager NavigationLink(destination:) 的目的页内部再 push 在 iOS 17.0 会卡死。
+            PermissionGatedValueLink(
+                label: String(localized: "URL 扫描"),
+                systemImage: "magnifyingglass.circle",
+                requiredScope: "url-scanner.read",
+                tint: .cyan,
+                showsChevron: true,
+                value: DashboardRoute.urlScanner
+            )
+
+            PermissionGatedValueLink(
+                label: String(localized: "请求追踪"),
+                systemImage: "point.topleft.down.curvedto.point.bottomright.up",
+                requiredScope: "request-tracer.read",
+                tint: .indigo,
+                showsChevron: true,
+                value: DashboardRoute.requestTracer
+            )
+
+            PermissionGatedValueLink(
+                label: String(localized: "域名注册"),
+                systemImage: "checkmark.seal",
+                requiredScope: "registrar-domains.read",
+                tint: .orange,
+                showsChevron: true,
+                value: DashboardRoute.registrar
+            )
+
             ProGatedValueLink(
                 label: "Cloudflare Tunnel",
                 systemImage: "arrow.triangle.2.circlepath",
@@ -1417,6 +1450,9 @@ private struct DashboardHomeView: View {
 /// 概览页玻璃岛入口路由（走栈根 navdest，同 DevHubRoute）。本岛为非 List 容器，
 /// eager `NavigationLink(destination:)` 在 iOS 17.0 点击即冻结（叶子目的页也一样），一律值式。
 enum DashboardRoute: Hashable {
+    case registrar
+    case urlScanner
+    case requestTracer
     case tunnels
     case tunnelConnect(Tunnel)
     case accessApps

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/RegistrarView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/RegistrarView.swift
@@ -1,0 +1,107 @@
+//
+//  RegistrarView.swift
+//  Orange Cloud
+//
+//  在 Cloudflare 注册的域名：到期日、自动续费、转移锁。
+//
+
+import SwiftUI
+
+struct RegistrarView: View {
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: RegistrarViewModel
+
+    init(session: SessionStore) {
+        _viewModel = State(initialValue: RegistrarViewModel(
+            service: session.registrarService,
+            accountId: session.selectedAccount?.id ?? ""
+        ))
+    }
+
+    private var canAdmin: Bool { auth.hasScope("registrar-domains.admin") }
+
+    var body: some View {
+        List {
+            Section {
+                if viewModel.isLoading && !viewModel.loaded {
+                    ProgressView().frame(maxWidth: .infinity).padding(.vertical, 8)
+                } else if viewModel.registrations.isEmpty {
+                    Text("此账号下没有在 Cloudflare 注册的域名。")
+                        .font(.footnote).foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.registrations) { registration in
+                        registrationRow(registration)
+                    }
+                }
+            } header: {
+                Text("已注册域名")
+            } footer: {
+                Text(canAdmin
+                     ? String(localized: "开启自动续费即授权 Cloudflare 在到期前 30 天内扣默认支付方式。域名注册与转移锁请在 Cloudflare 控制台操作。")
+                     : String(localized: "当前授权仅限读取（registrar-domains.read）。"))
+            }
+            .glassRow()
+        }
+        .daybreakList()
+        .navigationTitle("域名注册")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+        .refreshable { await viewModel.load() }
+        .sensoryFeedback(.success, trigger: viewModel.didMutate)
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    private func registrationRow(_ registration: DomainRegistration) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(registration.domainName)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+                Spacer()
+                Text(registration.statusText)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(registration.status == "active" ? Color.secondary : Color.orange)
+            }
+
+            if let expiry = registration.expiryDate {
+                HStack(spacing: 6) {
+                    Text("到期")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(expiry, format: .dateTime.year().month().day())
+                        .font(.caption)
+                        .foregroundStyle(registration.needsAttention ? Color.orange : Color.secondary)
+                    if let days = registration.daysUntilExpiry, days <= 30 {
+                        Text(days >= 0
+                             ? String(localized: "还剩 \(days) 天")
+                             : String(localized: "已过期"))
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+
+            Toggle("自动续费", isOn: Binding(
+                get: { registration.autoRenew ?? false },
+                set: { on in Task { await viewModel.setAutoRenew(registration, enabled: on) } }
+            ))
+            .font(.caption)
+            .disabled(!canAdmin || viewModel.isMutating)
+
+            // 转移锁在新版 API 里只读，做成开关会误导用户以为能改
+            if let locked = registration.locked {
+                Text(locked ? String(localized: "转移锁：已开启") : String(localized: "转移锁：未开启"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/RequestTracerView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/RequestTracerView.swift
@@ -1,0 +1,136 @@
+//
+//  RequestTracerView.swift
+//  Orange Cloud
+//
+//  「这个请求为什么被拦了」——模拟一个请求打过 Cloudflare，看它逐步走了哪些规则。
+//
+
+import SwiftUI
+
+struct RequestTracerView: View {
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: RequestTracerViewModel
+    @FocusState private var urlFocused: Bool
+
+    init(session: SessionStore) {
+        _viewModel = State(initialValue: RequestTracerViewModel(
+            service: session.requestTracerService,
+            accountId: session.selectedAccount?.id ?? ""
+        ))
+    }
+
+    var body: some View {
+        List {
+            inputSection
+            if let result = viewModel.result {
+                resultSection(result)
+            }
+        }
+        .daybreakList()
+        .navigationTitle("请求追踪")
+        .navigationBarTitleDisplayMode(.inline)
+        .sensoryFeedback(.success, trigger: viewModel.didTrace)
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    private var inputSection: some View {
+        Section {
+            Picker("请求方法", selection: $viewModel.method) {
+                ForEach(RequestTracerViewModel.methods, id: \.self) { Text($0).tag($0) }
+            }
+
+            TextField("https://example.com/path", text: $viewModel.urlText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .focused($urlFocused)
+
+            Button {
+                urlFocused = false
+                Task { await viewModel.run() }
+            } label: {
+                HStack {
+                    if viewModel.isTracing {
+                        ProgressView().padding(.trailing, 4)
+                    }
+                    Text("开始追踪")
+                }
+            }
+            .disabled(!viewModel.canTrace)
+        } header: {
+            Text("模拟请求")
+        } footer: {
+            // 说清楚这是模拟而非真实流量，否则用户会以为在看线上请求
+            Text("模拟一条请求打过 Cloudflare，看它命中了哪些规则。不会真的发到源站，也不影响线上流量。需要管理员角色。")
+        }
+        .glassRow()
+    }
+
+    private func resultSection(_ result: TraceResult) -> some View {
+        Section {
+            if viewModel.flatSteps.isEmpty {
+                Text("没有可展示的求值步骤。")
+                    .font(.footnote).foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.flatSteps) { flat in
+                    stepRow(flat)
+                }
+            }
+        } header: {
+            HStack {
+                Text("求值过程")
+                Spacer()
+                if let code = result.statusCode {
+                    Text(verbatim: "HTTP \(code)")
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } footer: {
+            Text("命中的步骤以橙色标出，缩进表示规则集与其下规则的从属关系。")
+        }
+        .glassRow()
+    }
+
+    private func stepRow(_ flat: FlatTraceStep) -> some View {
+        let step = flat.step
+        let matched = step.matched == true
+        return VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 6) {
+                // 命中与否是这页的核心信息，用图标 + 颜色双重编码，不只靠颜色
+                Image(systemName: matched ? "checkmark.circle.fill" : "circle")
+                    .font(.caption)
+                    .foregroundStyle(matched ? Color.ocOrange : Color.secondary)
+                Text(step.title)
+                    .font(.callout.weight(matched ? .semibold : .regular))
+                    .lineLimit(2)
+                Spacer()
+                if let action = step.action, !action.isEmpty {
+                    Text(action)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(matched ? Color.ocOrange : Color.secondary)
+                }
+            }
+            if let expression = step.expression, !expression.isEmpty {
+                Text(expression)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+            if let type = step.type, !type.isEmpty {
+                Text(type)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.leading, CGFloat(flat.depth) * 14)
+        .padding(.vertical, 1)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/URLScannerView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/URLScannerView.swift
@@ -1,0 +1,117 @@
+//
+//  URLScannerView.swift
+//  Orange Cloud
+//
+//  URL 安全扫描：提交一个链接，看它的归属、状态与风险判定。
+//  注意不能放进工具箱——那里是免登录的，本功能需要账号。
+//
+
+import SwiftUI
+
+struct URLScannerView: View {
+
+    @State private var viewModel: URLScannerViewModel
+    @FocusState private var urlFocused: Bool
+
+    init(session: SessionStore) {
+        _viewModel = State(initialValue: URLScannerViewModel(
+            service: session.urlScannerService,
+            accountId: session.selectedAccount?.id ?? ""
+        ))
+    }
+
+    var body: some View {
+        List {
+            inputSection
+            if let result = viewModel.result {
+                verdictSection(result)
+                pageSection(result)
+            }
+        }
+        .daybreakList()
+        .navigationTitle("URL 扫描")
+        .navigationBarTitleDisplayMode(.inline)
+        .sensoryFeedback(.success, trigger: viewModel.didFinish)
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    private var inputSection: some View {
+        Section {
+            TextField("example.com", text: $viewModel.urlText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .focused($urlFocused)
+
+            Button {
+                urlFocused = false
+                Task { await viewModel.scan() }
+            } label: {
+                HStack {
+                    if viewModel.isScanning {
+                        ProgressView().padding(.trailing, 4)
+                    }
+                    Text(viewModel.isScanning ? String(localized: "扫描中…") : String(localized: "开始扫描"))
+                }
+            }
+            .disabled(!viewModel.canScan)
+        } header: {
+            Text("扫描链接")
+        } footer: {
+            // 扫描是异步的，且结果会进 Cloudflare 的公共扫描库，得说清楚
+            Text("由 Cloudflare 打开该链接并生成安全报告，通常需要几十秒。扫描记录会保存在 Cloudflare 的扫描库中。")
+        }
+        .glassRow()
+    }
+
+    private func verdictSection(_ result: URLScanResult) -> some View {
+        Section("判定") {
+            let malicious = result.verdicts?.overall?.malicious == true
+            HStack(spacing: 8) {
+                Image(systemName: malicious ? "exclamationmark.triangle.fill" : "checkmark.shield.fill")
+                    .foregroundStyle(malicious ? Color.red : Color.green)
+                Text(malicious ? String(localized: "判定为恶意") : String(localized: "未发现恶意特征"))
+                    .font(.callout.weight(.semibold))
+            }
+            if let categories = result.verdicts?.overall?.categories, !categories.isEmpty {
+                LabeledContent("分类", value: categories.compactMap(\.name).joined(separator: "、"))
+            }
+        }
+        .glassRow()
+    }
+
+    private func pageSection(_ result: URLScanResult) -> some View {
+        Section("页面") {
+            if let url = result.page?.url ?? result.task?.effectiveUrl {
+                LabeledContent("最终地址") {
+                    Text(url)
+                        .font(.caption.monospaced())
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                }
+            }
+            if let ip = result.page?.ip {
+                LabeledContent("IP", value: ip)
+            }
+            if let asn = result.page?.asn {
+                LabeledContent("ASN", value: [asn, result.page?.asnname].compactMap { $0 }.joined(separator: " "))
+            }
+            if let country = result.page?.country {
+                LabeledContent("国家/地区", value: country)
+            }
+            if let server = result.page?.server {
+                LabeledContent("服务器", value: server)
+            }
+            if let code = result.page?.statusCode {
+                LabeledContent("状态码", value: "\(code)")
+            }
+        }
+        .glassRow()
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/DeveloperPlatform/DurableObjectsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/DeveloperPlatform/DurableObjectsView.swift
@@ -115,6 +115,7 @@ private struct DurableObjectInstancesSheet: View {
                 )
                 vm = model
                 await model.load()
+                await model.loadMemory()
             }
         }
     }
@@ -131,6 +132,21 @@ private struct DurableObjectInstancesSheet: View {
             }
         } else {
             List {
+                // 内存按 isolate 计，不是按单个对象——口径要写清楚，否则会被误读
+                if let memory = vm.memory {
+                    Section {
+                        LabeledContent("P50", value: Int64(memory.p50).ocBytes)
+                        LabeledContent("P90", value: Int64(memory.p90).ocBytes)
+                        LabeledContent("P99", value: Int64(memory.p99).ocBytes)
+                        LabeledContent("P999", value: Int64(memory.p999).ocBytes)
+                    } header: {
+                        Text("内存用量（24 小时）")
+                    } footer: {
+                        Text("V8 isolate 的内存，不是单个对象的。一个 isolate 可能同时承载同类的多个对象与外围 Worker 代码，每个 isolate 上限 128 MB。")
+                    }
+                    .glassRow()
+                }
+
                 Section {
                     ForEach(vm.instances) { obj in
                         HStack {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Settings/AuditLogListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Settings/AuditLogListView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct AuditLogListView: View {
 
+    @State private var historyTarget: IdentifiedAuditEntry?
+
     let session: SessionStore
 
     @State private var vm: AuditLogViewModel?
@@ -49,7 +51,14 @@ struct AuditLogListView: View {
             List {
                 Section {
                     ForEach(vm.entries) { item in
-                        AuditLogRow(entry: item.entry)
+                        // 点行看该资源的完整变更序列（v2 的 history 端点）
+                        Button {
+                            historyTarget = item
+                            Task { await vm.loadHistory(for: item.entry) }
+                        } label: {
+                            AuditLogRow(entry: item.entry)
+                        }
+                        .buttonStyle(.plain)
                     }
                 } footer: {
                     Text("仅显示当前账号最近 30 天的操作记录。")
@@ -70,6 +79,12 @@ struct AuditLogListView: View {
             }
             .daybreakList()
             .refreshable { await vm.load() }
+            .sheet(item: $historyTarget) { item in
+                NavigationStack {
+                    AuditHistoryView(source: item.entry, vm: vm)
+                }
+                .presentationDetents([.medium, .large])
+            }
         }
     }
 }
@@ -141,3 +156,50 @@ private extension String {
         return t.isEmpty ? nil : t
     }
 }
+
+// MARK: - 资源变更历史
+
+private struct AuditHistoryView: View {
+
+    let source: AuditLogEntry
+    let vm: AuditLogViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Section {
+                if vm.isLoadingHistory {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else if vm.history.isEmpty {
+                    Text(vm.historyStatus == "unavailable"
+                         ? String(localized: "这条记录没有携带足够信息来定位资源，因此查不到它的变更历史。")
+                         : String(localized: "没有查到这个资源的其它变更。"))
+                        .font(.footnote).foregroundStyle(.secondary)
+                } else {
+                    ForEach(vm.history) { item in
+                        AuditLogRow(entry: item.entry)
+                    }
+                }
+            } header: {
+                Text("变更历史")
+            } footer: {
+                // 识别质量必须如实说明——approximate 时结果可能混入无关条目
+                if vm.historyStatus == "approximate" {
+                    Text("这条记录没有资源地址，只能按其它字段近似匹配，列表里可能混入无关变更。")
+                } else if !vm.history.isEmpty {
+                    Text("同一资源在所选时间窗内的全部变更，最新在上。")
+                }
+            }
+            .glassRow()
+        }
+        .daybreakList()
+        .navigationTitle(source.resource?.type ?? String(localized: "变更历史"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("完成") { dismiss() }
+            }
+        }
+    }
+}
+

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2BucketSettingsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2BucketSettingsView.swift
@@ -16,6 +16,8 @@ struct R2BucketSettingsView: View {
     @Environment(AuthManager.self) private var auth
     @Environment(EntitlementStore.self) private var entitlements
     @State private var viewModel: R2BucketSettingsViewModel
+    @State private var catalogViewModel: R2CatalogViewModel
+    @State private var showCatalogEnableConfirm = false
     @State private var showAddCors = false
     @State private var showDenied = false
 
@@ -35,6 +37,11 @@ struct R2BucketSettingsView: View {
             accountId: session.selectedAccount?.id ?? "",
             bucketName: bucket.name
         ))
+        _catalogViewModel = State(initialValue: R2CatalogViewModel(
+            service: session.r2CatalogService,
+            accountId: session.selectedAccount?.id ?? "",
+            bucketName: bucket.name
+        ))
     }
 
     var body: some View {
@@ -43,6 +50,7 @@ struct R2BucketSettingsView: View {
                 filesSection
                 managedSection
                 customDomainsSection
+                dataCatalogSection
                 corsSection
             }
             .navigationTitle("桶设置")
@@ -53,6 +61,16 @@ struct R2BucketSettingsView: View {
                 }
             }
             .task { await refreshMountState() }
+            .task { if auth.hasScope("r2-catalog.read") { await catalogViewModel.load() } }
+            .confirmationDialog(
+                "启用数据目录",
+                isPresented: $showCatalogEnableConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("启用") { Task { await catalogViewModel.setEnabled(true) } }
+            } message: {
+                Text("启用后该桶将作为 Apache Iceberg 目录，目录操作按量计费（每月含 100 万次免费额度）。")
+            }
             .sheet(isPresented: $mountPaywall) {
                 PaywallView(feature: .filesApp)
             }
@@ -209,6 +227,57 @@ struct R2BucketSettingsView: View {
     }
 
     // MARK: - CORS
+
+    /// R2 数据目录（Iceberg）。启用是计费动作，故走二次确认。
+    @ViewBuilder
+    private var dataCatalogSection: some View {
+        if auth.hasScope("r2-catalog.read") {
+            Section {
+                if catalogViewModel.isLoading && !catalogViewModel.loaded {
+                    ProgressView()
+                } else {
+                    Toggle("启用数据目录", isOn: Binding(
+                        get: { catalogViewModel.isEnabled },
+                        set: { on in
+                            if on {
+                                showCatalogEnableConfirm = true
+                            } else {
+                                Task { await catalogViewModel.setEnabled(false) }
+                            }
+                        }
+                    ))
+                    .disabled(!auth.hasScope("r2-catalog.write") || catalogViewModel.isMutating)
+
+                    if let catalog = catalogViewModel.catalog, catalogViewModel.isEnabled {
+                        if let name = catalog.name {
+                            LabeledContent("目录名") {
+                                Text(name)
+                                    .font(.caption.monospaced())
+                                    .textSelection(.enabled)
+                            }
+                        }
+                        if let compaction = catalog.maintenanceConfig?.compaction?.state {
+                            LabeledContent("自动压实", value: compaction == "enabled"
+                                           ? String(localized: "已开启") : String(localized: "已关闭"))
+                        }
+                        if catalogViewModel.namespaces.isEmpty {
+                            Text("暂无命名空间")
+                                .font(.caption).foregroundStyle(.secondary)
+                        } else {
+                            ForEach(catalogViewModel.namespaces) { namespace in
+                                Text(namespace.displayName)
+                                    .font(.caption.monospaced())
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("数据目录")
+            } footer: {
+                Text("把这个桶变成可被 Spark、Snowflake 等引擎查询的 Iceberg 数据仓库。注意：目录已启用时手动删除对象会破坏目录。")
+            }
+        }
+    }
 
     private var corsSection: some View {
         Section {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Tunnels/TunnelListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Tunnels/TunnelListView.swift
@@ -144,6 +144,8 @@ private struct TunnelRow: View {
                     Text(tunnel.statusText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    // 连接数来自列表响应内嵌的 connections，CF 将于 2026-10-05 移除该字段。
+                    // 届时此处自然隐藏，仅保留状态点——不为列表每行单发一次连接请求（N+1）。
                     if let count = tunnel.connections?.count, count > 0 {
                         Text("· \(count) 个连接")
                             .font(.caption)
@@ -220,7 +222,10 @@ struct TunnelDetailView: View {
         .daybreakList()
         .navigationTitle(tunnel.name)
         .navigationBarTitleDisplayMode(.inline)
-        .task { if isRemote { await viewModel.loadConfiguration() } }
+        .task {
+            if isRemote { await viewModel.loadConfiguration() }
+            await viewModel.loadConnections()
+        }
         .sheet(item: $hostnameEdit) { edit in
             switch edit {
             case .new:
@@ -369,8 +374,8 @@ struct TunnelDetailView: View {
 
     private var connectionsSection: some View {
         Section("活跃连接") {
-            if let connections = tunnel.connections, !connections.isEmpty {
-                ForEach(Array(connections.enumerated()), id: \.offset) { _, connection in
+            if !viewModel.connections.isEmpty {
+                ForEach(Array(viewModel.connections.enumerated()), id: \.offset) { _, connection in
                     HStack(spacing: 12) {
                         TintIcon(systemImage: "antenna.radiowaves.left.and.right", color: .green, size: 28)
                         VStack(alignment: .leading, spacing: 2) {
@@ -389,6 +394,8 @@ struct TunnelDetailView: View {
                         }
                     }
                 }
+            } else if viewModel.isLoadingConnections {
+                ProgressView()
             } else {
                 Text("没有活跃连接")
                     .foregroundStyle(.secondary)

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerBuildsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerBuildsView.swift
@@ -1,0 +1,187 @@
+//
+//  WorkerBuildsView.swift
+//  Orange Cloud
+//
+//  Worker 的 CI 构建记录：状态、分支/commit、日志、取消。
+//
+
+import SwiftUI
+
+struct WorkerBuildsView: View {
+
+    let scriptName: String
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: WorkerBuildViewModel
+    @State private var logTarget: WorkerBuild?
+    @State private var watching = false
+
+    init(scriptName: String, session: SessionStore) {
+        self.scriptName = scriptName
+        _viewModel = State(initialValue: WorkerBuildViewModel(
+            service: session.workerBuildService,
+            accountId: session.selectedAccount?.id ?? "",
+            scriptId: scriptName
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("workers-ci.write") }
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("构建失败时通知我", isOn: Binding(
+                    get: { watching },
+                    set: { on in
+                        watching = on
+                        AppNotifications.setWatchingBuilds(scriptName, on)
+                    }
+                ))
+            } footer: {
+                // 说清是尽力而为，别让用户以为是实时推送
+                Text("Cloudflare 没有为 Workers 构建提供告警，这里靠 App 在后台刷新时自行比对。时机由系统调度，可能延迟。")
+            }
+            .glassRow()
+
+            Section {
+                if viewModel.isLoading && !viewModel.loaded {
+                    ProgressView().frame(maxWidth: .infinity).padding(.vertical, 8)
+                } else if viewModel.builds.isEmpty {
+                    Text("这个 Worker 还没有构建记录。接上 Git 仓库后，每次推送都会在这里出现。")
+                        .font(.footnote).foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.builds) { build in
+                        buildRow(build)
+                            .swipeActions(edge: .trailing) {
+                                // 只有进行中的构建才谈得上取消
+                                if canWrite && build.displayState.isRunning {
+                                    Button(role: .destructive) {
+                                        Task { await viewModel.cancel(build) }
+                                    } label: {
+                                        Label("取消", systemImage: "stop.circle")
+                                    }
+                                }
+                            }
+                    }
+                }
+            } header: {
+                Text("构建记录（\(scriptName)）")
+            } footer: {
+                Text("点按查看构建日志。进行中的构建可左滑取消。")
+            }
+            .glassRow()
+        }
+        .daybreakList()
+        .navigationTitle("构建")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            watching = AppNotifications.isWatchingBuilds(scriptName)
+            await viewModel.load()
+        }
+        .refreshable { await viewModel.load() }
+        .sensoryFeedback(.success, trigger: viewModel.didMutate)
+        .sheet(item: $logTarget) { build in
+            NavigationStack {
+                BuildLogsView(build: build, viewModel: viewModel)
+            }
+        }
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    private func buildRow(_ build: WorkerBuild) -> some View {
+        Button {
+            logTarget = build
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(stateColor(build.displayState))
+                        .frame(width: 8, height: 8)
+                    Text(build.displayState.label)
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    if let created = WorkerScript.parseDate(build.createdOn) {
+                        Text(created, format: .relative(presentation: .named))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if let meta = build.buildTriggerMetadata {
+                    HStack(spacing: 6) {
+                        if let branch = meta.branch {
+                            Label(branch, systemImage: "arrow.triangle.branch")
+                                .font(.caption2)
+                        }
+                        if let commit = meta.shortCommit {
+                            Text(commit)
+                                .font(.caption2.monospaced())
+                        }
+                    }
+                    .foregroundStyle(.secondary)
+                    if let author = meta.author {
+                        Text(author)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+
+    private func stateColor(_ state: BuildDisplayState) -> Color {
+        switch state {
+        case .success:            .green
+        case .failed:             .red
+        case .queued, .running:   .orange
+        case .cancelled, .skipped, .unknown: .gray
+        }
+    }
+}
+
+// MARK: - 日志
+
+private struct BuildLogsView: View {
+
+    let build: WorkerBuild
+    let viewModel: WorkerBuildViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Section {
+                if viewModel.isLoadingLogs {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else if viewModel.logs.isEmpty {
+                    Text("没有日志输出。")
+                        .font(.footnote).foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(viewModel.logs.enumerated()), id: \.offset) { _, line in
+                        Text(line.line ?? "")
+                            .font(.caption2.monospaced())
+                            .textSelection(.enabled)
+                    }
+                }
+            } header: {
+                Text(build.displayState.label)
+            }
+            .glassRow()
+        }
+        .daybreakList()
+        .navigationTitle("构建日志")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.loadLogs(for: build) }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("完成") { dismiss() }
+            }
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
@@ -104,6 +104,15 @@ struct WorkerDetailView: View {
                 ) {
                     WorkerTriggersView(accountId: script.accountId, scriptName: script.id, session: session)
                 }
+                PermissionGatedNavigationLink(
+                    label: String(localized: "构建"),
+                    systemImage: "hammer.circle",
+                    requiredScope: "workers-ci.read",
+                    tint: .teal,
+                    showsChevron: true
+                ) {
+                    WorkerBuildsView(scriptName: script.id, session: session)
+                }
                 ProGatedNavigationLink(
                     label: String(localized: "部署历史"),
                     systemImage: "clock.arrow.circlepath",

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/CacheRuleEditorView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/CacheRuleEditorView.swift
@@ -86,6 +86,26 @@ struct CacheRuleEditorView: View {
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                         .frame(minHeight: 90)
+
+                    // 表达式是自由文本，字段全靠记——给常用字段一个点按插入。
+                    // 含 2026-07-16 起缓存规则新支持的 bot 分数与 ASN 匹配。
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 6) {
+                            ForEach(CacheRuleField.common) { field in
+                                Button {
+                                    insert(field.token)
+                                } label: {
+                                    Text(field.label)
+                                        .font(.caption2)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 4)
+                                        .background(Color.ocOrange.opacity(0.12), in: Capsule())
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
                 } header: {
                     Text("匹配表达式")
                 } footer: {
@@ -240,4 +260,15 @@ struct CacheRuleEditorView: View {
             dismiss()
         }
     }
+    /// 点按插入字段：光标概念在 TextEditor 里不好拿，直接追加到末尾并补一个空格
+    private func insert(_ token: String) {
+        if expression.isEmpty {
+            expression = token
+        } else if expression.hasSuffix(" ") {
+            expression += token
+        } else {
+            expression += " " + token
+        }
+    }
+
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/EmailRoutingView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/EmailRoutingView.swift
@@ -135,6 +135,50 @@ struct EmailRoutingView: View {
                 .glassRow()
             }
 
+            // 抑制列表：规则决定往哪转，抑制决定不往哪转——
+            // 「规则配了却收不到」多半就是命中了这里，所以要能看见
+            if vm.suppressionsAvailable {
+                Section {
+                    if vm.suppressions.isEmpty {
+                        Text("没有被抑制的地址。")
+                            .font(.footnote).foregroundStyle(.secondary)
+                    } else {
+                        ForEach(vm.suppressions) { item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.email ?? item.id)
+                                    .font(.callout)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                HStack(spacing: 6) {
+                                    Text(item.reasonText)
+                                    if let expires = WorkerScript.parseDate(item.expiresAt) {
+                                        Text(expires, format: .dateTime.year().month().day())
+                                    } else {
+                                        Text("永久")
+                                    }
+                                }
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            }
+                            .swipeActions(edge: .trailing) {
+                                if canEditRules {
+                                    Button(role: .destructive) {
+                                        Task { await vm.removeSuppression(item) }
+                                    } label: {
+                                        Label("解除", systemImage: "arrow.uturn.backward")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    Text("已抑制地址")
+                } footer: {
+                    Text("这些地址退信或投诉过，Cloudflare 已停止向其转发。左滑可解除。")
+                }
+                .glassRow()
+            }
+
             if let error = vm.error {
                 Section {
                     Text(error).font(.footnote).foregroundStyle(.red)

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/HealthCheckListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/HealthCheckListView.swift
@@ -1,0 +1,246 @@
+//
+//  HealthCheckListView.swift
+//  Orange Cloud
+//
+//  独立健康检查：源站是否在线。与负载均衡的监控器不同源，别混用。
+//
+
+import SwiftUI
+
+struct HealthCheckListView: View {
+
+    let zoneName: String
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: HealthCheckViewModel
+    @State private var checkToDelete: HealthCheck?
+    @State private var detailTarget: HealthCheck?
+    @State private var alertViewModel: HealthCheckAlertViewModel
+
+    init(zoneId: String, zoneName: String, session: SessionStore) {
+        self.zoneName = zoneName
+        _viewModel = State(initialValue: HealthCheckViewModel(
+            service: session.healthCheckService,
+            zoneId: zoneId
+        ))
+        _alertViewModel = State(initialValue: HealthCheckAlertViewModel(
+            service: session.alertingService,
+            accountId: session.selectedAccount?.id ?? ""
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("healthcheck.write") }
+
+    var body: some View {
+        List {
+            alertSection
+            checksSection
+        }
+        .daybreakList()
+        .navigationTitle("健康检查")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+        .task { if auth.hasScope("notifications.read") { await alertViewModel.load() } }
+        .refreshable { await viewModel.load() }
+        .sensoryFeedback(.success, trigger: viewModel.didMutate)
+        .sheet(item: $detailTarget) { check in
+            NavigationStack {
+                HealthCheckDetailView(check: check)
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .confirmationDialog(
+            "删除健康检查",
+            isPresented: .init(get: { checkToDelete != nil }, set: { if !$0 { checkToDelete = nil } }),
+            titleVisibility: .visible,
+            presenting: checkToDelete
+        ) { check in
+            Button("删除「\(check.name)」", role: .destructive) {
+                Task { await viewModel.delete(check) }
+            }
+        } message: { _ in
+            Text("删除后将不再监控该源站，也不会再收到相关通知。不可撤销。")
+        }
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    /// 源站异常时推送。走 CF 原生告警（health_check_status_notification），
+    /// 服务端投递 webhook —— App 关着也能收到，比客户端轮询可靠。
+    @ViewBuilder
+    private var alertSection: some View {
+        if alertViewModel.pushEndpoint != nil && alertViewModel.isAvailable {
+            Section {
+                Toggle("源站异常时通知我", isOn: Binding(
+                    get: { alertViewModel.isEnabled },
+                    set: { on in Task { await alertViewModel.setEnabled(on) } }
+                ))
+                .disabled(!auth.hasScope("notifications.write") || alertViewModel.isMutating)
+            } footer: {
+                Text("由 Cloudflare 在源站状态变化时直接推送，App 不需要开着。")
+            }
+            .glassRow()
+        }
+    }
+
+    private var checksSection: some View {
+        Section {
+            if viewModel.isLoading && !viewModel.loaded {
+                ProgressView().frame(maxWidth: .infinity).padding(.vertical, 8)
+            } else if viewModel.checks.isEmpty {
+                // 免费套餐不支持健康检查，此处同样是空列表——不臆测原因，只说事实
+                Text("此域名暂无健康检查。可在 Cloudflare 控制台创建后回到这里查看与暂停。")
+                    .font(.footnote).foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.checks) { check in
+                    checkRow(check)
+                        .swipeActions(edge: .leading) {
+                            if canWrite {
+                                Button {
+                                    Task {
+                                        await viewModel.setSuspended(check, suspended: !(check.suspended ?? false))
+                                    }
+                                } label: {
+                                    Label(check.suspended == true
+                                          ? String(localized: "恢复") : String(localized: "暂停"),
+                                          systemImage: check.suspended == true ? "play" : "pause")
+                                }
+                                .tint(.orange)
+                            }
+                        }
+                        .swipeActions(edge: .trailing) {
+                            if canWrite {
+                                Button(role: .destructive) { checkToDelete = check } label: {
+                                    Label("删除", systemImage: "trash")
+                                }
+                            }
+                        }
+                }
+            }
+        } header: {
+            Text("源站监控（\(zoneName)）")
+        } footer: {
+            Text(canWrite
+                 ? String(localized: "点按查看详情，左滑暂停或恢复，右滑删除。暂停后不再向源站发送检查。")
+                 : String(localized: "当前授权仅限读取（healthcheck.read）。"))
+        }
+        .glassRow()
+    }
+
+    private func checkRow(_ check: HealthCheck) -> some View {
+        Button {
+            detailTarget = check
+        } label: {
+            HStack(spacing: 12) {
+                TintIcon(systemImage: "waveform.path.ecg", color: statusColor(check))
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 8) {
+                        Text(check.name)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(check.displayStatus.label)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(statusColor(check))
+                    }
+                    if let address = check.address {
+                        Text(address)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    // 只在真的异常时显示原因，避免正常态也占一行
+                    if check.displayStatus == .unhealthy,
+                       let reason = check.failureReason, !reason.isEmpty {
+                        Text(reason)
+                            .font(.caption2)
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+                }
+            }
+        }
+    }
+
+    private func statusColor(_ check: HealthCheck) -> Color {
+        switch check.displayStatus {
+        case .healthy:   .green
+        case .unhealthy: .red
+        case .suspended: .gray
+        case .unknown:   .orange
+        }
+    }
+}
+
+// MARK: - 详情
+
+private struct HealthCheckDetailView: View {
+
+    let check: HealthCheck
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Section("状态") {
+                LabeledContent("当前状态", value: check.displayStatus.label)
+                if check.displayStatus == .unhealthy,
+                   let reason = check.failureReason, !reason.isEmpty {
+                    LabeledContent("失败原因", value: reason)
+                }
+                if let fails = check.consecutiveFails {
+                    LabeledContent("连续失败", value: "\(fails)")
+                }
+                if let successes = check.consecutiveSuccesses {
+                    LabeledContent("连续成功", value: "\(successes)")
+                }
+            }
+            .glassRow()
+
+            Section("配置") {
+                if let address = check.address {
+                    LabeledContent("源站") {
+                        Text(address)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                    }
+                }
+                if let type = check.type {
+                    LabeledContent("协议", value: type)
+                }
+                if let interval = check.interval {
+                    LabeledContent("检查间隔", value: String(localized: "\(interval) 秒"))
+                }
+                if let timeout = check.timeout {
+                    LabeledContent("超时", value: String(localized: "\(timeout) 秒"))
+                }
+                if let retries = check.retries {
+                    LabeledContent("重试次数", value: "\(retries)")
+                }
+                if let regions = check.checkRegions, !regions.isEmpty {
+                    LabeledContent("检查区域", value: regions.joined(separator: "、"))
+                } else {
+                    LabeledContent("检查区域", value: String(localized: "由 Cloudflare 自选"))
+                }
+                if let description = check.description, !description.isEmpty {
+                    LabeledContent("备注", value: description)
+                }
+            }
+            .glassRow()
+        }
+        .daybreakList()
+        .navigationTitle(check.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("完成") { dismiss() }
+            }
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ManagedHeadersView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ManagedHeadersView.swift
@@ -1,0 +1,89 @@
+//
+//  ManagedHeadersView.swift
+//  Orange Cloud
+//
+//  托管请求/响应头：Cloudflare 维护的一组开关式头部改写，不用自己写 Transform 规则。
+//
+
+import SwiftUI
+
+struct ManagedHeadersView: View {
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: ManagedHeadersViewModel
+
+    init(zoneId: String, session: SessionStore) {
+        _viewModel = State(initialValue: ManagedHeadersViewModel(
+            service: session.managedHeaderService, zoneId: zoneId
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("managed-headers.write") }
+
+    var body: some View {
+        List {
+            section(
+                title: String(localized: "请求头"),
+                items: viewModel.requestHeaders,
+                isRequest: true
+            )
+            section(
+                title: String(localized: "响应头"),
+                items: viewModel.responseHeaders,
+                isRequest: false
+            )
+        }
+        .daybreakList()
+        .navigationTitle("托管头")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+        .refreshable { await viewModel.load() }
+        .sensoryFeedback(.success, trigger: viewModel.didMutate)
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private func section(title: String, items: [ManagedTransform], isRequest: Bool) -> some View {
+        Section {
+            if viewModel.isLoading && !viewModel.loaded {
+                ProgressView().frame(maxWidth: .infinity).padding(.vertical, 8)
+            } else if items.isEmpty {
+                Text("此域名没有可用的托管头。")
+                    .font(.footnote).foregroundStyle(.secondary)
+            } else {
+                ForEach(items) { item in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Toggle(item.displayName, isOn: Binding(
+                            get: { item.enabled ?? false },
+                            set: { on in
+                                Task { await viewModel.setEnabled(item, enabled: on, isRequest: isRequest) }
+                            }
+                        ))
+                        .disabled(!canWrite || viewModel.isMutating)
+                        // 互斥关系由接口给出，开之前让用户知道会顶掉谁
+                        if let conflicts = item.conflictsWith, !conflicts.isEmpty {
+                            Text("与 \(conflicts.joined(separator: "、")) 互斥")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        } header: {
+            Text(title)
+        } footer: {
+            if !isRequest {
+                Text(canWrite
+                     ? String(localized: "由 Cloudflare 维护的头部改写，开关即生效，无需自己写 Transform 规则。")
+                     : String(localized: "当前授权仅限读取（managed-headers.read）。"))
+            }
+        }
+        .glassRow()
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDNSSettingsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDNSSettingsView.swift
@@ -1,0 +1,152 @@
+//
+//  ZoneDNSSettingsView.swift
+//  Orange Cloud
+//
+//  域名的 DNS 设置：DNSSEC、CNAME 展平、多提供商 DNS、NS 类型、域名模式。
+//  与 DNS 记录列表分开——那里是逐条记录，这里是 zone 级策略。
+//
+
+import SwiftUI
+
+struct ZoneDNSSettingsView: View {
+
+    let zoneName: String
+
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: DNSSettingsViewModel
+
+    init(zoneId: String, zoneName: String, session: SessionStore) {
+        self.zoneName = zoneName
+        _viewModel = State(initialValue: DNSSettingsViewModel(
+            service: session.dnsSettingsService, zoneId: zoneId
+        ))
+    }
+
+    private var canEditSettings: Bool { auth.hasScope("zone-dns-settings.write") }
+    private var canEditDNS: Bool { auth.hasScope("dns.write") }
+
+    var body: some View {
+        List {
+            if viewModel.dnssecLoaded { dnssecSection }
+            if viewModel.settingsLoaded { settingsSection }
+            if !viewModel.isLoading && !viewModel.dnssecLoaded && !viewModel.settingsLoaded {
+                Section {
+                    Text("读不到该域名的 DNS 设置。可能是权限不足，或此域名不支持这些选项。")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .glassRow()
+            }
+        }
+        .daybreakList()
+        .navigationTitle("DNS 设置")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+        .refreshable { await viewModel.load() }
+        .sensoryFeedback(.success, trigger: viewModel.didMutate)
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    // MARK: DNSSEC
+
+    @ViewBuilder
+    private var dnssecSection: some View {
+        if let dnssec = viewModel.dnssec {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { dnssec.isEnabled },
+                    set: { on in Task { await viewModel.setDNSSEC(on) } }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("DNSSEC")
+                        Text(dnssec.statusText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .disabled(!canEditDNS || viewModel.isMutating)
+
+                // DS 记录必须由用户粘到域名注册商处，DNSSEC 才真正生效——
+                // 这是最容易被忽略的一步，所以单独列出并可复制
+                if let ds = dnssec.ds, !ds.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("DS 记录")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(ds)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                        Button {
+                            UIPasteboard.general.string = ds
+                        } label: {
+                            Label("复制 DS 记录", systemImage: "doc.on.doc")
+                                .font(.caption)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            } header: {
+                Text("DNSSEC")
+            } footer: {
+                Text(dnssec.status == "pending"
+                     ? String(localized: "还需把上面的 DS 记录添加到你的域名注册商处，DNSSEC 才会真正生效。")
+                     : String(localized: "为 DNS 应答加签，防止解析结果被篡改。"))
+            }
+            .glassRow()
+        }
+    }
+
+    // MARK: DNS 设置
+
+    @ViewBuilder
+    private var settingsSection: some View {
+        if let settings = viewModel.settings {
+            Section {
+                Toggle("展平所有 CNAME", isOn: Binding(
+                    get: { settings.flattenAllCnames ?? false },
+                    set: { on in Task { await viewModel.setFlattenAllCnames(on) } }
+                ))
+                .disabled(!canEditSettings || viewModel.isMutating)
+
+                Toggle("多提供商 DNS", isOn: Binding(
+                    get: { settings.multiProvider ?? false },
+                    set: { on in Task { await viewModel.setMultiProvider(on) } }
+                ))
+                .disabled(!canEditSettings || viewModel.isMutating)
+
+                Toggle("高级名称服务器", isOn: Binding(
+                    get: { settings.nameservers?.type == "cloudflare.advanced" },
+                    set: { on in Task { await viewModel.setAdvancedNameservers(on) } }
+                ))
+                .disabled(!canEditSettings || viewModel.isMutating)
+
+                Picker("域名模式", selection: Binding(
+                    get: { ZoneMode(apiValue: settings.zoneMode) },
+                    set: { mode in Task { await viewModel.setZoneMode(mode) } }
+                )) {
+                    ForEach(ZoneMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .disabled(!canEditSettings || viewModel.isMutating)
+
+                if let ttl = settings.nsTtl {
+                    LabeledContent("NS 记录 TTL", value: String(localized: "\(Int(ttl)) 秒"))
+                }
+            } header: {
+                Text("解析（\(zoneName)）")
+            } footer: {
+                Text(canEditSettings
+                     ? String(localized: "展平 CNAME 会把 CNAME 解析成最终 IP 返回。多提供商 DNS 允许与其他 DNS 服务商共存。")
+                     : String(localized: "当前授权仅限读取（zone-dns-settings.read）。"))
+            }
+            .glassRow()
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneDetailView.swift
@@ -42,6 +42,7 @@ struct ZoneDetailView: View {
         _actionsViewModel = State(initialValue: ZoneActionsViewModel(
             service: session.zoneSettingsService,
             zoneService: session.zoneService,
+            botService: session.botManagementService,
             zoneId: zoneId,
             paused: zone.paused
         ))
@@ -56,6 +57,8 @@ struct ZoneDetailView: View {
 
     private var canReadSettings: Bool { auth.hasScope("zone-settings.read") }
     private var canEditSettings: Bool { auth.hasScope("zone-settings.write") }
+    private var canReadBots: Bool { auth.hasScope("bot-management.read") }
+    private var canEditBots: Bool { auth.hasScope("bot-management.write") }
     private var canPurge: Bool { auth.hasScope("cache.purge") }
     /// 暂停 / 恢复走 zone 本身，权限与 zone-settings 那条链路无关
     private var canEditZone: Bool { auth.hasScope("zone.write") }
@@ -117,6 +120,16 @@ struct ZoneDetailView: View {
                         DNSListView(zoneId: zone.id, zoneName: zone.name, session: session)
                     }
                     .listRowStyleValue(String(localized: "\(dnsRecordDisplayCount) 条"))
+
+                    // zone 级 DNS 策略（DNSSEC / CNAME 展平 / NS 类型），与逐条记录分开
+                    PermissionGatedValueLink(
+                        label: String(localized: "DNS 设置"),
+                        systemImage: "gearshape.2",
+                        requiredScope: "zone-dns-settings.read",
+                        tint: .indigo,
+                        showsChevron: true,
+                        value: ZoneRoute.dnsSettings(zoneId: zone.id, zoneName: zone.name)
+                    )
 
                     ProGatedNavigationLink(
                         label: String(localized: "WAF 防火墙"),
@@ -202,6 +215,16 @@ struct ZoneDetailView: View {
                         ZoneAccessRulesView(zoneId: zone.id, session: session)
                     }
 
+                    // 与负载均衡的监控器不同源：这里监控单个源站，单源站也能用
+                    PermissionGatedValueLink(
+                        label: String(localized: "健康检查"),
+                        systemImage: "waveform.path.ecg",
+                        requiredScope: "healthcheck.read",
+                        tint: .green,
+                        showsChevron: true,
+                        value: ZoneRoute.healthChecks(zoneId: zone.id, zoneName: zone.name)
+                    )
+
                     ProGatedValueLink(
                         label: String(localized: "负载均衡"),
                         systemImage: "arrow.left.arrow.right",
@@ -211,6 +234,122 @@ struct ZoneDetailView: View {
                         showsChevron: true,
                         value: ZoneRoute.loadBalancers(zoneId: zone.id, zoneName: zone.name)
                     )
+                }
+
+                // 整卡仅在读到任一组配置时出现：
+                // 机器人管控全套餐可用但需 bot-management.read；
+                // 上面两个 zone setting 是 Pro/Business 起，免费套餐读取即失败。
+                // 与其给用户一排永远打不开的锁，不如不显示。
+                if actionsViewModel.botConfigLoaded || actionsViewModel.aiSettingsAvailable {
+                    sectionCard(String(localized: "AI 内容控制")) {
+                        if actionsViewModel.botConfigLoaded {
+                            settingPickerRow(
+                                title: String(localized: "AI 爬虫"),
+                                subtitle: String(localized: "抓取内容用于训练或问答的机器人"),
+                                icon: "ant",
+                                tint: .indigo,
+                                selection: actionsViewModel.aiBotsProtection,
+                                isBusy: actionsViewModel.isUpdatingBotConfig,
+                                canEdit: canEditBots,
+                                deniedScope: "bot-management.write",
+                                requestChange: { mode in
+                                    Task { await actionsViewModel.setAIBotsProtection(mode) }
+                                }
+                            )
+
+                            settingToggleRow(
+                                title: String(localized: "链接迷宫"),
+                                subtitle: String(localized: "用无尽链接消耗违规爬虫"),
+                                icon: "arrow.triangle.turn.up.right.diamond",
+                                tint: .indigo,
+                                isOn: actionsViewModel.crawlerProtection,
+                                isBusy: actionsViewModel.isUpdatingBotConfig,
+                                canEdit: canEditBots,
+                                isLoaded: true,
+                                deniedScope: "bot-management.write",
+                                requestToggle: { on in
+                                    Task { await actionsViewModel.setCrawlerProtection(on) }
+                                }
+                            )
+
+                            settingToggleRow(
+                                title: String(localized: "拦截内容机器人"),
+                                subtitle: String(localized: "拦下低可信自动流量，已验证的机器人除外"),
+                                icon: "person.badge.shield.checkmark",
+                                tint: .indigo,
+                                isOn: actionsViewModel.contentBotsProtection,
+                                isBusy: actionsViewModel.isUpdatingBotConfig,
+                                canEdit: canEditBots,
+                                isLoaded: true,
+                                deniedScope: "bot-management.write",
+                                requestToggle: { on in
+                                    Task { await actionsViewModel.setContentBotsProtection(on) }
+                                }
+                            )
+
+                            settingToggleRow(
+                                title: String(localized: "托管 robots.txt"),
+                                subtitle: String(localized: "由 Cloudflare 维护，置于现有内容之前"),
+                                icon: "list.bullet.rectangle",
+                                tint: .teal,
+                                isOn: actionsViewModel.managedRobotsTxt,
+                                isBusy: actionsViewModel.isUpdatingBotConfig,
+                                canEdit: canEditBots,
+                                isLoaded: true,
+                                deniedScope: "bot-management.write",
+                                requestToggle: { on in
+                                    Task { await actionsViewModel.setManagedRobotsTxt(on) }
+                                }
+                            )
+
+                            settingToggleRow(
+                                title: String(localized: "内容使用声明"),
+                                subtitle: String(localized: "在 robots.txt 中声明内容的使用许可"),
+                                icon: "doc.badge.gearshape",
+                                tint: .teal,
+                                isOn: actionsViewModel.robotsLicense,
+                                isBusy: actionsViewModel.isUpdatingBotConfig,
+                                canEdit: canEditBots,
+                                isLoaded: true,
+                                deniedScope: "bot-management.write",
+                                requestToggle: { on in
+                                    Task { await actionsViewModel.setRobotsLicense(on) }
+                                }
+                            )
+                        }
+
+                        if actionsViewModel.aiSettingsAvailable {
+                            settingToggleRow(
+                                title: String(localized: "AI 训练重定向"),
+                                subtitle: String(localized: "把用于模型训练的爬虫引走"),
+                                icon: "arrow.triangle.branch",
+                                tint: .purple,
+                                isOn: actionsViewModel.aiTrainingRedirect,
+                                isBusy: actionsViewModel.isTogglingAITrainingRedirect,
+                                canEdit: canEditSettings,
+                                isLoaded: true,
+                                deniedScope: "zone-settings.write",
+                                requestToggle: { on in
+                                    Task { await actionsViewModel.setAITrainingRedirect(on) }
+                                }
+                            )
+
+                            settingToggleRow(
+                                title: String(localized: "面向 Agent 的 Markdown"),
+                                subtitle: String(localized: "按请求把页面转成 Markdown 返回"),
+                                icon: "doc.plaintext",
+                                tint: .teal,
+                                isOn: actionsViewModel.markdownForAgents,
+                                isBusy: actionsViewModel.isTogglingMarkdownForAgents,
+                                canEdit: canEditSettings,
+                                isLoaded: true,
+                                deniedScope: "zone-settings.write",
+                                requestToggle: { on in
+                                    Task { await actionsViewModel.setMarkdownForAgents(on) }
+                                }
+                            )
+                        }
+                    }
                 }
 
                 sectionCard(String(localized: "操作")) {
@@ -349,6 +488,10 @@ struct ZoneDetailView: View {
         .task {
             if canReadSettings {
                 await actionsViewModel.loadSettings()
+                await actionsViewModel.loadAISettings()
+            }
+            if canReadBots {
+                await actionsViewModel.loadBotConfig()
             }
         }
         .task {
@@ -371,6 +514,10 @@ struct ZoneDetailView: View {
             }
             if canReadSettings {
                 await actionsViewModel.loadSettings()
+                await actionsViewModel.loadAISettings()
+            }
+            if canReadBots {
+                await actionsViewModel.loadBotConfig()
             }
             await syncPausedFromAPI()
         }
@@ -462,6 +609,62 @@ struct ZoneDetailView: View {
 
     /// canEdit / isLoaded / deniedScope 由调用方给：Under Attack 与开发模式走
     /// zone-settings.*，暂停走 zone.write，两条权限链路不共用。
+    /// 三档选择行。与 settingToggleRow 同构，只是右侧从开关换成菜单；
+    /// 无写权限时显示当前档位并在点击时提示缺失 scope。
+    private func settingPickerRow(
+        title: String,
+        subtitle: String,
+        icon: String,
+        tint: Color,
+        selection: AIBotsProtection,
+        isBusy: Bool,
+        canEdit: Bool,
+        deniedScope: String,
+        requestChange: @escaping (AIBotsProtection) -> Void
+    ) -> some View {
+        HStack(spacing: 12) {
+            TintIcon(systemImage: icon, color: tint)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if isBusy {
+                ProgressView()
+            } else if canEdit {
+                Menu {
+                    ForEach(AIBotsProtection.allCases) { mode in
+                        Button {
+                            requestChange(mode)
+                        } label: {
+                            if mode == selection {
+                                Label(mode.label, systemImage: "checkmark")
+                            } else {
+                                Text(mode.label)
+                            }
+                        }
+                    }
+                } label: {
+                    Text(selection.label)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel(title)
+            } else {
+                Button {
+                    deniedScopeHint = deniedScope
+                    showActionDenied = true
+                } label: {
+                    Text(selection.label)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
     private func settingToggleRow(
         title: String,
         subtitle: String,
@@ -641,6 +844,8 @@ private extension View {
 enum ZoneRoute: Hashable {
     case rulesHub(zoneId: String, zoneName: String)
     case loadBalancers(zoneId: String, zoneName: String)
+    case healthChecks(zoneId: String, zoneName: String)
+    case dnsSettings(zoneId: String, zoneName: String)
     case snippets(zoneId: String, zoneName: String)
     case bulkRedirects
 }
@@ -654,6 +859,10 @@ extension View {
                 ZoneRulesHubView(zoneId: zoneId, zoneName: zoneName, session: session)
             case .loadBalancers(let zoneId, let zoneName):
                 LoadBalancerListView(zoneId: zoneId, zoneName: zoneName, session: session)
+            case .healthChecks(let zoneId, let zoneName):
+                HealthCheckListView(zoneId: zoneId, zoneName: zoneName, session: session)
+            case .dnsSettings(let zoneId, let zoneName):
+                ZoneDNSSettingsView(zoneId: zoneId, zoneName: zoneName, session: session)
             case .snippets(let zoneId, let zoneName):
                 SnippetsListView(zoneId: zoneId, zoneName: zoneName, session: session)
             case .bulkRedirects:

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneRulesHubView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Zones/ZoneRulesHubView.swift
@@ -89,6 +89,14 @@ struct ZoneRulesHubView: View {
 
             Section("改写与缓存") {
                 PermissionGatedNavigationLink(
+                    label: String(localized: "托管头"),
+                    systemImage: "list.bullet.rectangle.portrait",
+                    requiredScope: "managed-headers.read",
+                    tint: .teal
+                ) {
+                    ManagedHeadersView(zoneId: zoneId, session: session)
+                }
+                PermissionGatedNavigationLink(
                     label: "Transform Rules",
                     systemImage: "arrow.triangle.branch",
                     requiredScope: "zone-transform-rules.read",


### PR DESCRIPTION
iOS 2.0.0，`MARKETING_VERSION` 1.9.3 → 2.0.0、`CURRENT_PROJECT_VERSION` 38 → 39。路径只含 `apps/ios/`。

## 本版内容
- **AI 爬虫管控**（bot_management，三档）+ 两个 AI 内容开关
- **独立健康检查**，源站异常走 CF 原生告警 `health_check_status_notification`（服务端投递，App 关着也能收）
- **域名注册商**：到期日 / 自动续费 / 转移锁
- **请求追踪**（Cloudflare Trace）
- **Zone DNS 设置**：DNSSEC 与 DS 记录、CNAME 展平、域名服务器类型
- **Workers 构建记录** + 构建失败推送
- **R2 数据目录 / 托管请求头 / URL 安全扫描 / Email 抑制列表**
- 审计日志资源变更历史、缓存规则常用字段速插（含 Bot 分数与来源 ASN）、Durable Objects 内存分位数
- 修复隧道详情页不显示活跃连接（`connections` 字段弃用，改读 `Client.conns`）

## 核对
- [x] `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` 各 **12 处**（grep 计数）已同步 2.0.0 / 39
- [x] 新增文案补齐 `Localizable.xcstrings` 13 语（catalog 删除行 0）
- [x] What's New 走 changelog 单一数据源，未手改生成物
- [x] `xcodebuild -scheme "Orange Cloud"` 通过，无 `CFBundleShortVersionString … must match` warning
- [x] 路径互斥：不挟带 infra / Android

> 送审提醒：ASC 元数据与截图另走 fastlane deliver；官网翻牌依赖 ASC webhook，需在送审前先合 infra 分支。

🤖 Generated with [Claude Code](https://claude.com/claude-code)