### PR TITLE
release(ios): 2.1.0 (build 40)

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
@@ -306,6 +306,34 @@ actor CFAPIClient {
         return data
     }
 
+    /// 对 Cloudflare 系外部主机（如 R2 SQL 的 api.sql.cloudflarestorage.com）发 JSON POST，
+    /// 复用 OAuth Bearer 与临期刷新，返回 2xx 原始响应体。
+    /// 注意：这些主机不一定走 client/v4 信封，错误体也交给 mapHTTPError 尽力解析。
+    func postExternalJSON<B: Codable & Sendable>(url: URL, body: B) async throws -> Data {
+        let token = try await validAccessToken()
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            Self.logTransportError("POST", url.absoluteString, "(external) network error", error)
+            throw APIError.networkError(error)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+        guard (200...299).contains(http.statusCode) else {
+            AppLog.network.error("POST \(url.host ?? "")\(url.path) (external) -> \(http.statusCode)\(Self.cfErrorSummary(data))")
+            throw Self.mapHTTPError(status: http.statusCode, data: data)
+        }
+        return data
+    }
+
     /// multipart/form-data 表单字段写入，指定 method（Pages 创建部署：POST 一个 manifest 字段）
     func multipartFields<T: Codable & Sendable>(method: String, _ path: String, fields: [String: String]) async throws -> T {
         let boundary = "OrangeCloud-\(UUID().uuidString)"

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -913,6 +913,82 @@
         }
       }
     },
+    "R2 数据目录，直接用 SQL 查": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Query R2 Data Catalog with SQL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 資料目錄，直接用 SQL 查"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 數據目錄，直接用 SQL 查"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 データカタログを SQL で直接クエリ"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta R2 Data Catalog con SQL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 데이터 카탈로그를 SQL로 바로 조회"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte o R2 Data Catalog com SQL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte o R2 Data Catalog com SQL"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 Data Catalog direkt per SQL abfragen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrogez R2 Data Catalog en SQL"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استعلم عن كتالوج بيانات R2 مباشرة بلغة SQL"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 Veri Kataloğu'nu doğrudan SQL ile sorgulayın"
+          }
+        }
+      }
+    },
     "Rate Limiting": {
       "localizations": {
         "en": {
@@ -2125,6 +2201,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Workers ve Pages listeleri artık ada (varsayılan), oluşturma tarihine veya son güncellemeye göre sıralanabilir; seçiminiz hatırlanır."
+          }
+        }
+      }
+    },
+    "Workers 密钥，一次批量导入": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bulk-import Worker secrets"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 金鑰，一次批次匯入"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 密鑰，一次批量導入"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers のシークレットを一括インポート"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa secretos de Workers en lote"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers 시크릿을 한 번에 가져오기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importe segredos do Workers em lote"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importe segredos do Workers em lote"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worker-Secrets im Stapel importieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importez les secrets Workers en masse"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استورد أسرار Workers دفعة واحدة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workers gizli anahtarlarını toplu aktarın"
           }
         }
       }
@@ -8209,6 +8361,158 @@
         }
       }
     },
+    "桶设置的数据目录里新增 R2 SQL 查询控制台：点选表名生成查询，结果表格展示。按扫描量计费（每月 10 GB 免费），控制台内有提示。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bucket settings gain an R2 SQL console under Data Catalog: tap a table to start a query and view results in a grid. Billed by data scanned (first 10 GB per month free) — the console reminds you."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存桶設定的資料目錄裡新增 R2 SQL 查詢主控台：點選資料表名產生查詢，結果以表格呈現。按掃描量計費（每月 10 GB 免費），主控台內有提示。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存桶設定的數據目錄裡新增 R2 SQL 查詢控制台：點選表名生成查詢，結果表格展示。按掃描量計費（每月 10 GB 免費），控制台內有提示。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バケット設定のデータカタログに R2 SQL コンソールを追加。テーブル名をタップしてクエリを作り、結果をグリッドで確認できます。スキャン量課金（毎月 10 GB まで無料）で、コンソール内に注意書きがあります。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes del bucket ganan una consola R2 SQL en Data Catalog: toca una tabla para generar la consulta y ver los resultados en una tabla. Se factura por datos escaneados (10 GB gratis al mes); la consola te lo recuerda."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버킷 설정의 데이터 카탈로그에 R2 SQL 콘솔이 추가되었습니다. 테이블을 탭해 쿼리를 만들고 결과를 표로 확인하세요. 스캔한 데이터양으로 과금되며(매월 10 GB 무료) 콘솔에 안내가 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As configurações do bucket ganham um console R2 SQL no Data Catalog: toque em uma tabela para gerar a consulta e veja os resultados em grade. Cobrança por dados verificados (10 GB grátis por mês) — o console avisa."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As definições do bucket ganham uma consola R2 SQL no Data Catalog: toque numa tabela para gerar a consulta e veja os resultados em grelha. Faturação por dados analisados (10 GB grátis por mês) — a consola avisa."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Bucket-Einstellungen erhalten unter Data Catalog eine R2-SQL-Konsole: Tabelle antippen, Abfrage starten, Ergebnisse im Raster ansehen. Abgerechnet nach gescannter Datenmenge (10 GB pro Monat frei) – die Konsole erinnert daran."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les réglages du bucket gagnent une console R2 SQL sous Data Catalog : touchez une table pour lancer la requête et voir les résultats en grille. Facturation au volume scanné (10 GB gratuits par mois) — la console vous le rappelle."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا وحدة تحكم R2 SQL إلى كتالوج البيانات في إعدادات الحاوية: انقر على جدول لبدء استعلام واعرض النتائج في شبكة. تُحتسب التكلفة حسب البيانات الممسوحة (أول 10 GB شهريًا مجانًا) — وستذكّرك وحدة التحكم بذلك."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kova ayarlarındaki Veri Kataloğu'na R2 SQL konsolu eklendi: bir tabloya dokunup sorgu oluşturun, sonuçları tabloda görün. Taranan veriye göre ücretlendirilir (ayda 10 GB ücretsiz) — konsol size hatırlatır."
+          }
+        }
+      }
+    },
+    "概览页新增 Turnstile 入口：查看全部组件，新建、改域名与模式，密钥一键轮换（可留 2 小时宽限平滑过渡），sitekey 和 secret 点按即复制。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A new Turnstile entry on the overview: browse all widgets, create and edit domains and modes, rotate secrets with an optional 2-hour grace period, and tap to copy the sitekey or secret."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總覽頁新增 Turnstile 入口：檢視全部元件，新增、改網域與模式，金鑰一鍵輪替（可留 2 小時寬限平滑過渡），sitekey 和 secret 點按即複製。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概覽頁新增 Turnstile 入口：查看全部組件，新建、改域名與模式，密鑰一鍵輪換（可留 2 小時寬限平滑過渡），sitekey 和 secret 點按即複製。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要画面に Turnstile の入口を追加。全ウィジェットの一覧、作成やドメイン・モードの変更、シークレットのローテーション（2 時間の猶予つきでスムーズに移行）、sitekey と secret のタップコピーに対応しました。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva entrada de Turnstile en el resumen: explora todos los widgets, crea y edita dominios y modos, rota secretos con un periodo de gracia opcional de 2 horas y copia la sitekey o el secreto con un toque."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개요 화면에 Turnstile 입구가 생겼습니다. 전체 위젯을 둘러보고, 만들고, 도메인과 모드를 수정하고, 2시간 유예를 선택해 시크릿을 교체하고, sitekey와 secret을 탭 한 번으로 복사하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova entrada do Turnstile na visão geral: veja todos os widgets, crie e edite domínios e modos, rotacione segredos com carência opcional de 2 horas e copie a sitekey ou o segredo com um toque."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova entrada do Turnstile na vista geral: veja todos os widgets, crie e edite domínios e modos, rode segredos com tolerância opcional de 2 horas e copie a sitekey ou o segredo com um toque."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Turnstile-Einstieg in der Übersicht: alle Widgets durchsehen, Domains und Modi anlegen und ändern, Secrets mit optionaler 2-Stunden-Karenz rotieren, Sitekey und Secret per Tipp kopieren."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle entrée Turnstile sur l'aperçu : parcourez tous les widgets, créez et modifiez domaines et modes, renouvelez les secrets avec un délai de grâce optionnel de 2 h, et copiez la sitekey ou le secret d'un geste."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مدخل جديد لـ Turnstile في صفحة النظرة العامة: تصفح كل العناصر، أنشئ وعدّل النطاقات والأوضاع، ودوّر الأسرار مع مهلة اختيارية لساعتين، وانسخ sitekey أو secret بنقرة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel bakışta yeni Turnstile girişi: tüm öğelere göz atın, alan adı ve mod oluşturup düzenleyin, isteğe bağlı 2 saatlik geçiş süresiyle anahtarları değiştirin, sitekey ve secret'ı dokunarak kopyalayın."
+          }
+        }
+      }
+    },
     "概览页新增「域名注册商」：在 Cloudflare 注册的域名，到期日、自动续费与转移锁状态都列在一起，快到期的会标出来。": {
       "localizations": {
         "en": {
@@ -9881,6 +10185,82 @@
         }
       }
     },
+    "粘贴一段 JSON 就能批量写入变量或密钥：走 Cloudflare 新的批量接口，单次调用原子生效，不再逐条保存。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste a JSON object to write variables or secrets in bulk — powered by Cloudflare's new bulk endpoint, one atomic call instead of saving one by one."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "貼上一段 JSON 就能批次寫入變數或金鑰：走 Cloudflare 新的批次介面，單次呼叫原子生效，不再逐條儲存。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "貼上一段 JSON 就能批量寫入變數或密鑰：走 Cloudflare 新的批量接口，單次調用原子生效，不再逐條保存。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON を貼り付けるだけで変数やシークレットを一括登録。Cloudflare の新しいバルク API を使い、1 回の呼び出しでアトミックに反映されます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega un objeto JSON para escribir variables o secretos en lote: usa el nuevo endpoint masivo de Cloudflare, una sola llamada atómica en vez de guardar uno por uno."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON을 붙여넣어 변수나 시크릿을 일괄 기록하세요. Cloudflare의 새 벌크 엔드포인트로 한 번의 원자적 호출이면 됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cole um objeto JSON para gravar variáveis ou segredos em lote — usa o novo endpoint em massa da Cloudflare, uma única chamada atômica em vez de salvar um por um."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cole um objeto JSON para gravar variáveis ou segredos em lote — usa o novo endpoint em massa da Cloudflare, uma única chamada atómica em vez de guardar um a um."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON einfügen und Variablen oder Secrets im Stapel schreiben – über Cloudflares neuen Bulk-Endpunkt, ein atomarer Aufruf statt Einzelspeichern."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collez un objet JSON pour écrire variables ou secrets en masse — via le nouvel endpoint bulk de Cloudflare, un seul appel atomique au lieu d'enregistrer un par un."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصق كائن JSON لكتابة المتغيرات أو الأسرار دفعة واحدة — عبر واجهة Cloudflare الجديدة للعمليات المجمعة، استدعاء ذرّي واحد بدل الحفظ واحدًا تلو الآخر."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir JSON nesnesi yapıştırarak değişken veya gizli anahtarları toplu yazın — Cloudflare'ın yeni toplu uç noktasıyla tek atomik çağrı, tek tek kaydetmek yok."
+          }
+        }
+      }
+    },
     "缓存规则": {
       "localizations": {
         "en": {
@@ -9957,6 +10337,82 @@
         }
       }
     },
+    "缓存规则认识 JA3/JA4 了": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache Rules learn JA3/JA4"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快取規則認識 JA3/JA4 了"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "緩存規則認識 JA3/JA4 了"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャッシュルールが JA3/JA4 に対応"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las reglas de caché aprenden JA3/JA4"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캐시 규칙이 JA3/JA4를 알게 됐어요"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regras de cache aprendem JA3/JA4"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regras de cache aprendem JA3/JA4"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache-Regeln lernen JA3/JA4"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les règles de cache apprennent JA3/JA4"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قواعد التخزين المؤقت تتعرف على JA3/JA4"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Önbellek kuralları JA3/JA4 öğrendi"
+          }
+        }
+      }
+    },
     "编辑 WAF 规则": {
       "localizations": {
         "en": {
@@ -10029,6 +10485,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "WAF kurallarını düzenleme"
+          }
+        }
+      }
+    },
+    "表达式速插芯片补上 JA3/JA4 指纹字段（需 Bot Management 订阅）；带 Vary 多版本缓存的规则自动只读，避免在 App 里误改丢掉配置。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expression quick-insert chips now include JA3/JA4 fingerprint fields (Bot Management subscription required). Rules using Vary-based caching turn read-only in the app so edits can't drop that config."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "運算式速插晶片補上 JA3/JA4 指紋欄位（需 Bot Management 訂閱）；帶 Vary 多版本快取的規則自動唯讀，避免在 App 裡誤改遺失設定。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表達式速插芯片補上 JA3/JA4 指紋欄位（需 Bot Management 訂閱）；帶 Vary 多版本緩存的規則自動只讀，避免在 App 裡誤改丟掉配置。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "式のクイック挿入チップに JA3/JA4 フィンガープリントを追加（Bot Management サブスクリプションが必要）。Vary による複数バージョンキャッシュを使うルールはアプリ内で読み取り専用になり、誤編集で設定が消えるのを防ぎます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los chips de inserción rápida suman los campos de huella JA3/JA4 (requiere suscripción a Bot Management). Las reglas con caché por Vary pasan a solo lectura en la app para que una edición no borre esa configuración."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표현식 빠른 삽입 칩에 JA3/JA4 지문 필드가 추가되었습니다(Bot Management 구독 필요). Vary 다중 버전 캐시를 쓰는 규칙은 앱에서 읽기 전용이 되어 잘못 수정해 설정을 잃는 일을 막습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os chips de inserção rápida ganham os campos de impressão digital JA3/JA4 (requer assinatura do Bot Management). Regras com cache por Vary ficam somente leitura no app, para uma edição não descartar essa configuração."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os chips de inserção rápida ganham os campos de impressão digital JA3/JA4 (requer subscrição do Bot Management). Regras com cache por Vary ficam só de leitura na app, para uma edição não descartar essa configuração."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Schnelleinfüge-Chips für Ausdrücke enthalten jetzt JA3/JA4-Fingerprint-Felder (Bot-Management-Abo erforderlich). Regeln mit Vary-Caching werden in der App schreibgeschützt, damit Bearbeitungen diese Konfiguration nicht verwerfen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les puces d'insertion rapide gagnent les champs d'empreinte JA3/JA4 (abonnement Bot Management requis). Les règles utilisant le cache par Vary passent en lecture seule dans l'app pour qu'une modification ne supprime pas cette configuration."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضفنا حقول بصمتي JA3/JA4 إلى شرائح الإدراج السريع (يتطلب اشتراك Bot Management). القواعد التي تستخدم التخزين المؤقت عبر Vary تصبح للقراءة فقط في التطبيق حتى لا يُفقد هذا الإعداد عند التعديل."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hızlı ekleme çiplerine JA3/JA4 parmak izi alanları eklendi (Bot Management aboneliği gerekir). Vary tabanlı önbellek kullanan kurallar uygulamada salt okunur olur, böylece düzenlemeler bu yapılandırmayı silmez."
           }
         }
       }
@@ -10637,6 +11169,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cam kartlar aynı görünümü koruyarak çok daha düşük maliyetle çiziliyor — listeler ve Genel Bakış, özellikle eski cihazlarda belirgin şekilde daha akıcı kayıyor."
+          }
+        }
+      }
+    },
+    "随手管理 Turnstile 人机验证": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Turnstile from your pocket"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隨手管理 Turnstile 人機驗證"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隨手管理 Turnstile 人機驗證"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile をポケットから管理"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestiona Turnstile desde el bolsillo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile을 주머니 속에서 관리"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie o Turnstile do bolso"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faça a gestão do Turnstile no bolso"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile aus der Hosentasche verwalten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérez Turnstile depuis votre poche"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدر Turnstile من جيبك"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile'ı cebinizden yönetin"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,28 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "2.1.0", items: [
+            WhatsNewItem(
+                icon:   "checkmark.shield",
+                title:  String(localized: "随手管理 Turnstile 人机验证", table: "WhatsNew"),
+                detail: String(localized: "概览页新增 Turnstile 入口：查看全部组件，新建、改域名与模式，密钥一键轮换（可留 2 小时宽限平滑过渡），sitekey 和 secret 点按即复制。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "terminal",
+                title:  String(localized: "R2 数据目录，直接用 SQL 查", table: "WhatsNew"),
+                detail: String(localized: "桶设置的数据目录里新增 R2 SQL 查询控制台：点选表名生成查询，结果表格展示。按扫描量计费（每月 10 GB 免费），控制台内有提示。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "key.fill",
+                title:  String(localized: "Workers 密钥，一次批量导入", table: "WhatsNew"),
+                detail: String(localized: "粘贴一段 JSON 就能批量写入变量或密钥：走 Cloudflare 新的批量接口，单次调用原子生效，不再逐条保存。", table: "WhatsNew")
+            ),
+            WhatsNewItem(
+                icon:   "bolt.horizontal",
+                title:  String(localized: "缓存规则认识 JA3/JA4 了", table: "WhatsNew"),
+                detail: String(localized: "表达式速插芯片补上 JA3/JA4 指纹字段（需 Bot Management 订阅）；带 Vary 多版本缓存的规则自动只读，避免在 App 里误改丢掉配置。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "2.0.0", items: [
             WhatsNewItem(
                 icon:   "brain",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -29260,82 +29260,6 @@
         }
       }
     },
-    "作为密钥写入，逐个保存；同名将被覆盖，保存后不可读取。": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تُكتب كأسرار وتُحفظ واحدًا تلو الآخر؛ تُستبدل الأسماء المتطابقة ولا يمكن قراءتها بعد الحفظ."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Werden als Secrets einzeln gespeichert; gleiche Namen werden überschrieben und sind nach dem Speichern nicht lesbar."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Written as secrets, saved one by one; same names are overwritten and can’t be read after saving."
-          }
-        },
-        "es-MX": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se guardan como secretos, uno por uno; los nombres iguales se sobrescriben y no se pueden leer después."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enregistrés comme secrets, un par un ; les mêmes noms sont écrasés et illisibles après enregistrement."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シークレットとして1つずつ保存します。同名は上書きされ、保存後は読み取れません。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "비밀로 하나씩 저장됩니다. 동일한 이름은 덮어쓰며 저장 후에는 읽을 수 없습니다."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gravados como segredos, um a um; nomes iguais são sobrescritos e não podem ser lidos após salvar."
-          }
-        },
-        "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gravados como segredos, um a um; nomes iguais são substituídos e não podem ser lidos após guardar."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sırlar olarak tek tek kaydedilir; aynı adlar üzerine yazılır ve kaydettikten sonra okunamaz."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "以密鑰寫入，逐一儲存；同名會被覆寫，儲存後無法讀取。"
-          }
-        },
-        "zh-HK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "以密鑰寫入，逐一儲存；同名會被覆寫，儲存後無法讀取。"
-          }
-        }
-      }
-    },
     "作为明文变量一次性写入；同名将被覆盖，不影响其它绑定。": {
       "localizations": {
         "ar": {
@@ -158941,82 +158865,6 @@
         }
       }
     },
-    "把 R2 桶启用为 Iceberg 数据仓库": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفعيل دلو R2 كمستودع Iceberg"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einen R2-Bucket als Iceberg-Warehouse aktivieren"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable an R2 bucket as an Iceberg warehouse"
-          }
-        },
-        "es-MX": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activa un bucket de R2 como almacén Iceberg"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activer un bucket R2 comme entrepôt Iceberg"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "R2 バケットを Iceberg データウェアハウスとして有効にします"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "R2 버킷을 Iceberg 웨어하우스로 사용합니다"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ative um bucket do R2 como data warehouse Iceberg"
-          }
-        },
-        "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ative um bucket do R2 como data warehouse Iceberg"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bir R2 kovasını Iceberg ambarı olarak etkinleştirin"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "把 R2 儲存桶啟用為 Iceberg 資料倉儲"
-          }
-        },
-        "zh-HK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "把 R2 存儲桶啟用為 Iceberg 數據倉庫"
-          }
-        }
-      }
-    },
     "构建记录（%@）": {
       "localizations": {
         "ar": {
@@ -163193,6 +163041,3426 @@
           "stringUnit": {
             "state": "translated",
             "value": "已驗證機械人"
+          }
+        }
+      }
+    },
+    "JA3 指纹": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3 fingerprint"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3 指紋"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3 指紋"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3 フィンガープリント"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huella JA3"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3 지문"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impressão digital JA3"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impressão digital JA3"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3-Fingerprint"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empreinte JA3"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بصمة JA3"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA3 parmak izi"
+          }
+        }
+      }
+    },
+    "JA4 指纹": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4 fingerprint"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4 指紋"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4 指紋"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4 フィンガープリント"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huella JA4"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4 지문"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impressão digital JA4"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impressão digital JA4"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4-Fingerprint"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empreinte JA4"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بصمة JA4"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JA4 parmak izi"
+          }
+        }
+      }
+    },
+    "模式": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モード"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모드"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوضع"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mod"
+          }
+        }
+      }
+    },
+    "区域": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Region"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "區域"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "區域"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リージョン"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Región"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지역"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Região"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Região"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Region"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Région"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المنطقة"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bölge"
+          }
+        }
+      }
+    },
+    "中国": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "China"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中國"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中國"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中国"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "China"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중국"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "China"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "China"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "China"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chine"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصين"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çin"
+          }
+        }
+      }
+    },
+    "全球": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全球"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全球"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グローバル"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글로벌"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mondial"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عالمي"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Küresel"
+          }
+        }
+      }
+    },
+    "任意主机名": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Any hostname"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意主機名稱"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意主機名"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意のホスト名"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cualquier nombre de host"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 호스트 이름"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualquer nome de host"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualquer nome de anfitrião"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beliebiger Hostname"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout nom d'hôte"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أي اسم مضيف"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herhangi bir ana bilgisayar adı"
+          }
+        }
+      }
+    },
+    "作为密钥一次性写入；同名将被覆盖，保存后不可读取。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Written as secrets in a single request; matching names are overwritten and values can't be read back."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以密鑰形式一次寫入；同名將被覆蓋，儲存後無法讀取。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以密鑰形式一次寫入；同名將被覆蓋，儲存後無法讀取。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シークレットとして一括で書き込みます。同名は上書きされ、保存後は読み取れません。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se escriben como secretos en una sola solicitud; los nombres duplicados se sobrescriben y no se pueden leer después."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시크릿으로 한 번에 기록됩니다. 같은 이름은 덮어쓰이며 저장 후에는 읽을 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gravados como segredos em uma única solicitação; nomes iguais são sobrescritos e não podem ser lidos depois."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gravados como segredos num único pedido; nomes iguais são substituídos e não podem ser lidos depois."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Werden in einer einzigen Anfrage als Secrets geschrieben; gleiche Namen werden überschrieben und sind danach nicht mehr lesbar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Écrits comme secrets en une seule requête ; les noms identiques sont écrasés et illisibles ensuite."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُكتب كأسرار في طلب واحد؛ يتم استبدال الأسماء المكررة ولا يمكن قراءتها بعد الحفظ."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tek istekte gizli bilgi olarak yazılır; aynı adlar üzerine yazılır ve kaydedildikten sonra okunamaz."
+          }
+        }
+      }
+    },
+    "托管（推荐）": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Managed (recommended)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "託管（建議）"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "託管（推薦）"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マネージド（推奨）"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administrado (recomendado)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "관리형(권장)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerenciado (recomendado)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerido (recomendado)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwaltet (empfohlen)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Géré (recommandé)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُدار (موصى به)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yönetilen (önerilen)"
+          }
+        }
+      }
+    },
+    "非交互": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non-interactive"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非互動"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非互動"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非対話型"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No interactivo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비대화형"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não interativo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não interativo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht interaktiv"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non interactif"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير تفاعلي"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etkileşimsiz"
+          }
+        }
+      }
+    },
+    "隐形": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invisible"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱形"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱形"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非表示"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invisible"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보이지 않음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invisível"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invisível"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsichtbar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invisible"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير مرئي"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Görünmez"
+          }
+        }
+      }
+    },
+    "由 Cloudflare 判断是否要求访客勾选复选框": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare decides whether visitors must check a box"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 判斷是否要求訪客勾選核取方塊"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Cloudflare 判斷是否要求訪客勾選方格"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェックボックスの操作を求めるかどうかを Cloudflare が判断します"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare decide si los visitantes deben marcar una casilla"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "방문자에게 체크박스를 요구할지 Cloudflare가 판단합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare decide se os visitantes precisam marcar uma caixa"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Cloudflare decide se os visitantes têm de marcar uma caixa"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare entscheidet, ob Besucher ein Kästchen anhaken müssen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare décide si les visiteurs doivent cocher une case"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تقرر Cloudflare ما إذا كان على الزوار تحديد مربع اختيار"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziyaretçilerin kutu işaretlemesi gerekip gerekmediğine Cloudflare karar verir"
+          }
+        }
+      }
+    },
+    "显示验证进度但不需要访客操作": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows verification progress without requiring any action"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示驗證進度但不需要訪客操作"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示驗證進度但不需要訪客操作"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証の進行状況を表示しますが、訪問者の操作は不要です"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra el progreso de la verificación sin requerir acción"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 진행 상황을 표시하지만 방문자의 조작은 필요 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra o progresso da verificação sem exigir ação"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra o progresso da verificação sem exigir ação"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigt den Prüffortschritt an, ohne Aktionen zu verlangen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affiche la progression de la vérification sans action requise"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعرض تقدم التحقق دون الحاجة إلى أي إجراء"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doğrulama ilerlemesini gösterir, ziyaretçi işlemi gerekmez"
+          }
+        }
+      }
+    },
+    "完全不可见，静默完成验证": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completely invisible; verification happens silently"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全不可見，靜默完成驗證"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全不可見，靜默完成驗證"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全に非表示で、検証はサイレントに行われます"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamente invisible; la verificación ocurre en silencio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완전히 보이지 않으며 확인이 조용히 진행됩니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamente invisível; a verificação acontece em silêncio"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamente invisível; a verificação decorre em silêncio"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Völlig unsichtbar; die Prüfung läuft im Hintergrund"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Totalement invisible ; la vérification se fait en silence"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير مرئي تمامًا؛ يتم التحقق بصمت"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamamen görünmez; doğrulama sessizce tamamlanır"
+          }
+        }
+      }
+    },
+    "没有 Turnstile 组件": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Turnstile widgets"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有 Turnstile 元件"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有 Turnstile 組件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile ウィジェットがありません"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay widgets de Turnstile"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile 위젯이 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum widget do Turnstile"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum widget do Turnstile"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Turnstile-Widgets"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun widget Turnstile"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد عناصر Turnstile"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile öğesi yok"
+          }
+        }
+      }
+    },
+    "Turnstile 是 Cloudflare 的免费人机验证，替代传统验证码。新建组件后把 sitekey 嵌进你的网站即可。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile is Cloudflare's free CAPTCHA alternative. Create a widget, then embed its sitekey on your site."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile 是 Cloudflare 的免費人機驗證，可取代傳統驗證碼。建立元件後把 sitekey 嵌入你的網站即可。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile 是 Cloudflare 的免費人機驗證，可取代傳統驗證碼。新建組件後把 sitekey 嵌入你的網站即可。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile は Cloudflare の無料 CAPTCHA 代替です。ウィジェットを作成し、sitekey をサイトに埋め込むだけで使えます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile es la alternativa gratuita de Cloudflare al CAPTCHA. Crea un widget e inserta su sitekey en tu sitio."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile은 기존 CAPTCHA를 대체하는 Cloudflare의 무료 사람 확인입니다. 위젯을 만든 뒤 sitekey를 사이트에 삽입하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Turnstile é a alternativa gratuita da Cloudflare ao CAPTCHA. Crie um widget e incorpore a sitekey no seu site."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Turnstile é a alternativa gratuita da Cloudflare ao CAPTCHA. Crie um widget e incorpore a sitekey no seu site."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile ist Cloudflares kostenlose CAPTCHA-Alternative. Widget erstellen und den Sitekey in die Website einbetten – fertig."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile est l'alternative CAPTCHA gratuite de Cloudflare. Créez un widget puis intégrez sa sitekey à votre site."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile هو بديل CAPTCHA المجاني من Cloudflare. أنشئ عنصرًا ثم ضمِّن sitekey في موقعك."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile, Cloudflare'ın ücretsiz CAPTCHA alternatifidir. Bir öğe oluşturup sitekey'i sitenize ekleyin."
+          }
+        }
+      }
+    },
+    "新建组件": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Widget"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增元件"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建組件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィジェットを作成"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo widget"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 위젯"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo widget"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo widget"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neues Widget"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveau widget"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عنصر جديد"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni öğe"
+          }
+        }
+      }
+    },
+    "删除组件「%@」？": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete widget \"%@\"?"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除元件「%@」？"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除組件「%@」？"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィジェット「%@」を削除しますか？"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar el widget \"%@\"?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위젯 '%@'을(를) 삭제하시겠습니까?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir o widget \"%@\"?"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar o widget \"%@\"?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget „%@“ löschen?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le widget « %@ » ?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل تريد حذف العنصر «%@»؟"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" öğesi silinsin mi?"
+          }
+        }
+      }
+    },
+    "嵌在网站上的该组件将立即失效，此操作不可撤销。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The widget embedded on your site will stop working immediately. This cannot be undone."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "嵌在網站上的該元件將立即失效，此操作無法復原。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "嵌在網站上的該組件將立即失效，此操作不可撤銷。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイトに埋め込まれたウィジェットは直ちに無効になります。この操作は取り消せません。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El widget insertado en tu sitio dejará de funcionar de inmediato. Esta acción no se puede deshacer."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이트에 삽입된 위젯이 즉시 작동을 멈춥니다. 이 작업은 취소할 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O widget incorporado no seu site deixará de funcionar imediatamente. Esta ação não pode ser desfeita."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O widget incorporado no seu site deixará de funcionar imediatamente. Esta ação não pode ser anulada."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das auf Ihrer Website eingebettete Widget funktioniert sofort nicht mehr. Dies kann nicht rückgängig gemacht werden."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le widget intégré à votre site cessera immédiatement de fonctionner. Cette action est irréversible."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سيتوقف العنصر المضمّن في موقعك عن العمل فورًا. لا يمكن التراجع عن هذا الإجراء."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitenize gömülü öğe hemen çalışmayı durdurur. Bu işlem geri alınamaz."
+          }
+        }
+      }
+    },
+    "当前授权未包含 Turnstile 编辑权限（challenge-widgets.write）。\n请在设置中重新授权以启用此功能。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your current authorization doesn't include Turnstile edit permission (challenge-widgets.write).\nPlease re-authorize in Settings to enable this feature."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權未包含 Turnstile 編輯權限（challenge-widgets.write）。\n請在設定中重新授權以啟用此功能。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前授權未包含 Turnstile 編輯權限（challenge-widgets.write）。\n請在設定中重新授權以啟用此功能。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の認可には Turnstile の編集権限（challenge-widgets.write）が含まれていません。\n設定から再認可してこの機能を有効にしてください。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu autorización actual no incluye el permiso de edición de Turnstile (challenge-widgets.write).\nVuelve a autorizar en Ajustes para habilitar esta función."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 인증에 Turnstile 편집 권한(challenge-widgets.write)이 포함되어 있지 않습니다.\n설정에서 다시 인증하여 이 기능을 활성화하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua autorização atual não inclui a permissão de edição do Turnstile (challenge-widgets.write).\nReautorize em Ajustes para ativar este recurso."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A sua autorização atual não inclui a permissão de edição do Turnstile (challenge-widgets.write).\nVolte a autorizar nas Definições para ativar esta funcionalidade."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre aktuelle Autorisierung enthält keine Turnstile-Bearbeitungsberechtigung (challenge-widgets.write).\nBitte autorisieren Sie in den Einstellungen erneut, um diese Funktion zu aktivieren."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votre autorisation actuelle n'inclut pas la permission d'édition Turnstile (challenge-widgets.write).\nRéautorisez dans Réglages pour activer cette fonction."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يتضمن التفويض الحالي إذن تحرير Turnstile ‏(challenge-widgets.write).\nيرجى إعادة التفويض من الإعدادات لتفعيل هذه الميزة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut yetkilendirme Turnstile düzenleme iznini (challenge-widgets.write) içermiyor.\nBu özelliği etkinleştirmek için Ayarlar'dan yeniden yetkilendirin."
+          }
+        }
+      }
+    },
+    "轮换密钥": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotate Secret"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輪替密鑰"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輪換密鑰"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シークレットをローテーション"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotar secreto"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시크릿 교체"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotacionar segredo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rodar segredo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secret rotieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renouveler le secret"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تدوير السر"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gizli bilgiyi değiştir"
+          }
+        }
+      }
+    },
+    "轮换（旧密钥保留 2 小时）": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotate (old secret valid 2 more hours)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輪替（舊密鑰保留 2 小時）"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輪換（舊密鑰保留 2 小時）"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローテーション（旧シークレットは 2 時間有効）"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotar (el secreto anterior sigue válido 2 horas)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "교체(이전 시크릿 2시간 유지)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotacionar (segredo antigo válido por 2 horas)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rodar (segredo antigo válido por 2 horas)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotieren (altes Secret bleibt 2 Stunden gültig)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renouveler (ancien secret valable 2 h)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تدوير (يبقى السر القديم صالحًا لساعتين)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Değiştir (eski anahtar 2 saat geçerli)"
+          }
+        }
+      }
+    },
+    "立即作废旧密钥": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalidate Old Secret Now"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即作廢舊密鑰"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即作廢舊密鑰"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "旧シークレットを直ちに無効化"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalidar el secreto anterior ahora"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 시크릿 즉시 무효화"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalidar o segredo antigo agora"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalidar o segredo antigo agora"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altes Secret sofort ungültig machen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalider l'ancien secret maintenant"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إبطال السر القديم فورًا"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eski anahtarı hemen geçersiz kıl"
+          }
+        }
+      }
+    },
+    "轮换后服务端需改用新密钥调用 siteverify。选择宽限可让旧密钥再工作 2 小时，平滑过渡。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After rotating, your server must call siteverify with the new secret. The grace option keeps the old secret working for 2 more hours for a smooth transition."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輪替後伺服器端需改用新密鑰呼叫 siteverify。選擇寬限可讓舊密鑰再運作 2 小時，平滑過渡。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輪換後伺服器端需改用新密鑰調用 siteverify。選擇寬限可讓舊密鑰再運作 2 小時，平滑過渡。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローテーション後、サーバー側は新しいシークレットで siteverify を呼び出す必要があります。猶予を選ぶと旧シークレットがさらに 2 時間有効になり、移行がスムーズです。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Después de rotar, tu servidor debe llamar a siteverify con el nuevo secreto. Con el periodo de gracia, el secreto anterior sigue funcionando 2 horas para una transición fluida."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "교체 후 서버는 새 시크릿으로 siteverify를 호출해야 합니다. 유예를 선택하면 이전 시크릿이 2시간 더 작동하여 부드럽게 전환할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Após a rotação, seu servidor deve chamar o siteverify com o novo segredo. Com o período de carência, o segredo antigo continua funcionando por 2 horas para uma transição suave."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Após a rotação, o seu servidor deve chamar o siteverify com o novo segredo. Com o período de tolerância, o segredo antigo continua a funcionar por 2 horas para uma transição suave."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach der Rotation muss Ihr Server siteverify mit dem neuen Secret aufrufen. Mit Karenzzeit bleibt das alte Secret noch 2 Stunden gültig – für einen sanften Übergang."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Après la rotation, votre serveur doit appeler siteverify avec le nouveau secret. Avec le délai de grâce, l'ancien secret reste valable 2 h pour une transition en douceur."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بعد التدوير، يجب أن يستدعي خادمك siteverify بالسر الجديد. اختيار المهلة يُبقي السر القديم صالحًا لساعتين لضمان انتقال سلس."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Değişimden sonra sunucunuz siteverify'ı yeni anahtarla çağırmalıdır. Geçiş süresi seçilirse eski anahtar 2 saat daha çalışır."
+          }
+        }
+      }
+    },
+    "集成密钥": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integration Keys"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "整合金鑰"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "整合密鑰"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統合キー"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claves de integración"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "통합 키"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chaves de integração"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chaves de integração"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integrationsschlüssel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clés d'intégration"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح التكامل"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entegrasyon anahtarları"
+          }
+        }
+      }
+    },
+    "sitekey 嵌进网页组件，secret 用于服务端 siteverify 校验——secret 请勿泄露。点按可复制。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Embed the sitekey in the web widget; the secret is for server-side siteverify — never expose it. Tap to copy."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sitekey 嵌入網頁元件，secret 用於伺服器端 siteverify 驗證——切勿洩露 secret。點按即可複製。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sitekey 嵌入網頁組件，secret 用於伺服器端 siteverify 校驗——切勿洩露 secret。點按可複製。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sitekey はウェブウィジェットに埋め込み、secret はサーバー側の siteverify 検証に使います。secret は絶対に公開しないでください。タップでコピーできます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserta la sitekey en el widget web; el secreto es para la verificación siteverify del servidor — nunca lo expongas. Toca para copiar."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sitekey는 웹 위젯에 삽입하고 secret은 서버 측 siteverify 검증에 사용합니다. secret은 절대 노출하지 마세요. 탭하여 복사합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorpore a sitekey no widget web; o segredo é para a verificação siteverify no servidor — nunca o exponha. Toque para copiar."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorpore a sitekey no widget web; o segredo destina-se à verificação siteverify no servidor — nunca o exponha. Toque para copiar."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Sitekey wird ins Web-Widget eingebettet, das Secret dient der serverseitigen siteverify-Prüfung – niemals offenlegen. Zum Kopieren tippen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intégrez la sitekey dans le widget web ; le secret sert à la vérification siteverify côté serveur — ne l'exposez jamais. Touchez pour copier."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضمِّن sitekey في عنصر الويب؛ يُستخدم secret للتحقق عبر siteverify على الخادم — لا تكشفه أبدًا. انقر للنسخ."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sitekey web öğesine gömülür; secret sunucu tarafındaki siteverify doğrulaması içindir — asla paylaşmayın. Kopyalamak için dokunun."
+          }
+        }
+      }
+    },
+    "组件在所列域名及其子域生效；域名留空表示任意主机名均可使用。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The widget works on the listed domains and their subdomains; leave empty to allow any hostname."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元件在所列網域及其子網域生效；留空表示任何主機名稱皆可使用。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組件在所列域名及其子域生效；留空表示任何主機名均可使用。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィジェットは記載したドメインとそのサブドメインで有効です。空欄の場合は任意のホスト名で使用できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El widget funciona en los dominios listados y sus subdominios; déjalo vacío para permitir cualquier nombre de host."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위젯은 나열된 도메인과 그 하위 도메인에서 작동합니다. 비워 두면 모든 호스트 이름이 허용됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O widget funciona nos domínios listados e em seus subdomínios; deixe vazio para permitir qualquer nome de host."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O widget funciona nos domínios listados e nos seus subdomínios; deixe vazio para permitir qualquer nome de anfitrião."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Widget funktioniert auf den gelisteten Domains und deren Subdomains; leer lassen, um jeden Hostnamen zu erlauben."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le widget fonctionne sur les domaines listés et leurs sous-domaines ; laissez vide pour autoriser tout nom d'hôte."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعمل العنصر على النطاقات المدرجة ونطاقاتها الفرعية؛ اتركه فارغًا للسماح بأي اسم مضيف."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öğe, listelenen alan adlarında ve alt alan adlarında çalışır; boş bırakılırsa tüm ana bilgisayar adlarına izin verilir."
+          }
+        }
+      }
+    },
+    "删除组件": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Widget"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除元件"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除組件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィジェットを削除"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar widget"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위젯 삭제"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir widget"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar widget"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le widget"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف العنصر"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öğeyi sil"
+          }
+        }
+      }
+    },
+    "如：官网登录页": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. Login page"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如：官網登入頁"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如：官網登入頁"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例：ログインページ"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p. ej., página de inicio de sesión"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예: 로그인 페이지"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ex.: página de login"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ex.: página de início de sessão"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. Login-Seite"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ex. : page de connexion"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثال: صفحة تسجيل الدخول"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "örn. giriş sayfası"
+          }
+        }
+      }
+    },
+    "最多 10 个域名（当前 %lld 个）。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At most 10 domains (currently %lld)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最多 10 個網域（目前 %lld 個）。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最多 10 個域名（目前 %lld 個）。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメインは最大 10 件です（現在 %lld 件）。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máximo 10 dominios (actualmente %lld)."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인은 최대 10개입니다(현재 %lld개)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No máximo 10 domínios (atualmente %lld)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No máximo 10 domínios (atualmente %lld)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Höchstens 10 Domains (aktuell %lld)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 domaines maximum (actuellement %lld)."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 نطاقات كحد أقصى (حاليًا %lld)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En fazla 10 alan adı (şu anda %lld)."
+          }
+        }
+      }
+    },
+    "每行一个主机名或 IP，子域自动生效；留空表示任意主机名均可使用。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One hostname or IP per line; subdomains are covered automatically. Leave empty to allow any hostname."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每行一個主機名稱或 IP，子網域自動生效；留空表示任何主機名稱皆可使用。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每行一個主機名或 IP，子域自動生效；留空表示任何主機名均可使用。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 行に 1 つのホスト名または IP を入力します。サブドメインは自動的に対象になります。空欄の場合は任意のホスト名で使用できます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un nombre de host o IP por línea; los subdominios se incluyen automáticamente. Déjalo vacío para permitir cualquier nombre de host."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 줄에 호스트 이름 또는 IP 하나씩 입력하세요. 하위 도메인은 자동으로 적용됩니다. 비워 두면 모든 호스트 이름이 허용됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um nome de host ou IP por linha; subdomínios são incluídos automaticamente. Deixe vazio para permitir qualquer nome de host."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um nome de anfitrião ou IP por linha; os subdomínios são incluídos automaticamente. Deixe vazio para permitir qualquer nome de anfitrião."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Hostname oder eine IP pro Zeile; Subdomains gelten automatisch. Leer lassen, um jeden Hostnamen zu erlauben."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un nom d'hôte ou une IP par ligne ; les sous-domaines sont couverts automatiquement. Laissez vide pour autoriser tout nom d'hôte."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم مضيف أو عنوان IP واحد في كل سطر؛ تُشمل النطاقات الفرعية تلقائيًا. اتركه فارغًا للسماح بأي اسم مضيف."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Her satıra bir ana bilgisayar adı veya IP; alt alan adları otomatik geçerlidir. Boş bırakılırsa tüm ana bilgisayar adlarına izin verilir."
+          }
+        }
+      }
+    },
+    "对疑似机器人的请求发放高算力挑战，加大自动化攻击成本。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serves computationally expensive challenges to suspected bots, raising the cost of automated attacks."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "對疑似機器人的請求發出高算力挑戰，加大自動化攻擊成本。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "對疑似機械人的請求發出高算力挑戰，加大自動化攻擊成本。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボットと疑われるリクエストに高負荷のチャレンジを課し、自動化攻撃のコストを高めます。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía desafíos de alto costo computacional a los bots sospechosos, encareciendo los ataques automatizados."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "봇으로 의심되는 요청에 고연산 챌린지를 부과하여 자동화 공격 비용을 높입니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica desafios computacionalmente caros a bots suspeitos, aumentando o custo de ataques automatizados."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica desafios computacionalmente dispendiosos a bots suspeitos, aumentando o custo de ataques automatizados."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stellt mutmaßlichen Bots rechenintensive Challenges, um automatisierte Angriffe zu verteuern."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impose des défis coûteux en calcul aux bots suspects, augmentant le coût des attaques automatisées."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يفرض تحديات مكلفة حسابيًا على الطلبات المشتبه بأنها روبوتات، ما يرفع كلفة الهجمات الآلية."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şüpheli botlara yüksek işlem gücü gerektiren doğrulamalar uygulayarak otomatik saldırıların maliyetini artırır."
+          }
+        }
+      }
+    },
+    "创建后不可更改。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot be changed after creation."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立後無法更改。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創建後不可更改。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成後は変更できません。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede cambiar después de crearlo."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생성 후에는 변경할 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não pode ser alterado após a criação."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não pode ser alterado após a criação."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kann nach dem Erstellen nicht geändert werden."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible à modifier après création."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يمكن تغييره بعد الإنشاء."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oluşturulduktan sonra değiştirilemez."
+          }
+        }
+      }
+    },
+    "编辑组件": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Widget"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯元件"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯組件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィジェットを編集"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar widget"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위젯 편집"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar widget"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar widget"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier le widget"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير العنصر"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öğeyi düzenle"
+          }
+        }
+      }
+    },
+    "Turnstile 需要 Pro": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile requires Pro"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile 需要 Pro"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile 需要 Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile には Pro が必要です"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile requiere Pro"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile은 Pro가 필요합니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Turnstile requer o Pro"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Turnstile requer o Pro"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile erfordert Pro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile nécessite Pro"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب Turnstile اشتراك Pro"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile için Pro gerekir"
+          }
+        }
+      }
+    },
+    "管理 Turnstile 人机验证组件（新建 / 编辑 / 密钥轮换）属于 Orange Cloud Pro。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Managing Turnstile widgets (create / edit / secret rotation) is part of Orange Cloud Pro."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Turnstile 人機驗證元件（新增 / 編輯 / 金鑰輪替）屬於 Orange Cloud Pro。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Turnstile 人機驗證組件（新建 / 編輯 / 密鑰輪換）屬於 Orange Cloud Pro。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile ウィジェットの管理（作成 / 編集 / シークレットのローテーション）は Orange Cloud Pro の機能です。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La gestión de widgets de Turnstile (crear / editar / rotar secretos) forma parte de Orange Cloud Pro."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile 위젯 관리(생성/편집/시크릿 교체)는 Orange Cloud Pro에 포함됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerenciar widgets do Turnstile (criar / editar / rotação de segredos) faz parte do Orange Cloud Pro."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerir widgets do Turnstile (criar / editar / rotação de segredos) faz parte do Orange Cloud Pro."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Verwaltung von Turnstile-Widgets (Erstellen / Bearbeiten / Secret-Rotation) ist Teil von Orange Cloud Pro."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La gestion des widgets Turnstile (création / édition / rotation du secret) fait partie d'Orange Cloud Pro."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة عناصر Turnstile (إنشاء / تحرير / تدوير الأسرار) جزء من Orange Cloud Pro."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile öğelerini yönetme (oluşturma / düzenleme / anahtar değiştirme) Orange Cloud Pro kapsamındadır."
+          }
+        }
+      }
+    },
+    "管理人机验证组件与密钥轮换": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage human-verification widgets and rotate secrets"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理人機驗證元件與金鑰輪替"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理人機驗證組件與密鑰輪換"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "人間確認ウィジェットの管理とシークレットのローテーション"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestiona widgets de verificación humana y rota secretos"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사람 확인 위젯 관리 및 시크릿 교체"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie widgets de verificação humana e rotacione segredos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gira widgets de verificação humana e rode segredos"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widgets zur Menschprüfung verwalten und Secrets rotieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérer les widgets de vérification humaine et la rotation des secrets"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة عناصر التحقق البشري وتدوير الأسرار"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İnsan doğrulama öğelerini yönetin ve anahtarları değiştirin"
+          }
+        }
+      }
+    },
+    "把 R2 桶启用为 Iceberg 数据仓库，并用 R2 SQL 查询": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn R2 buckets into Iceberg data warehouses and query them with R2 SQL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把 R2 儲存桶啟用為 Iceberg 資料倉儲，並用 R2 SQL 查詢"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把 R2 儲存桶啟用為 Iceberg 數據倉庫，並用 R2 SQL 查詢"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 バケットを Iceberg データウェアハウスとして有効化し、R2 SQL でクエリ"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convierte buckets R2 en almacenes de datos Iceberg y consúltalos con R2 SQL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 버킷을 Iceberg 데이터 웨어하우스로 활성화하고 R2 SQL로 쿼리"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transforme buckets R2 em data warehouses Iceberg e consulte com R2 SQL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transforme buckets R2 em armazéns de dados Iceberg e consulte com R2 SQL"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2-Buckets als Iceberg-Data-Warehouse aktivieren und mit R2 SQL abfragen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez des buckets R2 comme entrepôts Iceberg et interrogez-les avec R2 SQL"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حوّل حاويات R2 إلى مستودعات بيانات Iceberg واستعلم عنها باستخدام R2 SQL"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 kovalarını Iceberg veri ambarına dönüştürün ve R2 SQL ile sorgulayın"
+          }
+        }
+      }
+    },
+    "R2 SQL 查询被拒绝。请确认授权包含 R2 SQL / 数据目录 / R2 读权限；若仍失败，说明该接口暂不接受 App 的登录方式，请先用 Wrangler 查询。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL query was rejected. Make sure your authorization includes R2 SQL, Data Catalog, and R2 read permissions. If it still fails, this endpoint doesn't yet accept the app's sign-in method — use Wrangler for now."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL 查詢被拒絕。請確認授權包含 R2 SQL / 資料目錄 / R2 讀取權限；若仍失敗，表示該介面暫不接受 App 的登入方式，請先用 Wrangler 查詢。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL 查詢被拒絕。請確認授權包含 R2 SQL / 數據目錄 / R2 讀取權限；若仍失敗，表示該接口暫不接受 App 的登入方式，請先用 Wrangler 查詢。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL クエリが拒否されました。認可に R2 SQL / データカタログ / R2 の読み取り権限が含まれているか確認してください。それでも失敗する場合、このエンドポイントはまだアプリのサインイン方式に対応していません。当面は Wrangler をご利用ください。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La consulta de R2 SQL fue rechazada. Asegúrate de que tu autorización incluya permisos de lectura de R2 SQL, Data Catalog y R2. Si sigue fallando, este endpoint aún no acepta el método de inicio de sesión de la app; usa Wrangler por ahora."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL 쿼리가 거부되었습니다. 인증에 R2 SQL / 데이터 카탈로그 / R2 읽기 권한이 포함되어 있는지 확인하세요. 계속 실패하면 이 엔드포인트가 아직 앱의 로그인 방식을 지원하지 않는 것입니다. 당분간 Wrangler를 사용하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A consulta R2 SQL foi rejeitada. Verifique se sua autorização inclui permissões de leitura de R2 SQL, Data Catalog e R2. Se ainda falhar, este endpoint ainda não aceita o método de login do app — use o Wrangler por enquanto."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A consulta R2 SQL foi rejeitada. Verifique se a sua autorização inclui permissões de leitura de R2 SQL, Data Catalog e R2. Se continuar a falhar, este endpoint ainda não aceita o método de início de sessão da app — use o Wrangler por agora."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die R2-SQL-Abfrage wurde abgelehnt. Stellen Sie sicher, dass Ihre Autorisierung Leserechte für R2 SQL, Data Catalog und R2 enthält. Schlägt sie weiterhin fehl, akzeptiert dieser Endpunkt die Anmeldemethode der App noch nicht – nutzen Sie vorerst Wrangler."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La requête R2 SQL a été refusée. Vérifiez que votre autorisation inclut les permissions de lecture R2 SQL, Data Catalog et R2. Si l'échec persiste, ce point de terminaison n'accepte pas encore la méthode de connexion de l'app — utilisez Wrangler pour le moment."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رُفض استعلام R2 SQL. تأكد من أن التفويض يتضمن أذونات قراءة R2 SQL وData Catalog وR2. إذا استمر الفشل، فهذا يعني أن نقطة النهاية لا تقبل بعد طريقة تسجيل دخول التطبيق — استخدم Wrangler حاليًا."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL sorgusu reddedildi. Yetkilendirmenizin R2 SQL / Veri Kataloğu / R2 okuma izinlerini içerdiğinden emin olun. Yine de başarısız olursa bu uç nokta henüz uygulamanın oturum açma yöntemini kabul etmiyor demektir — şimdilik Wrangler kullanın."
+          }
+        }
+      }
+    },
+    "只读查询（SELECT / EXPLAIN）。按扫描数据量计费：每月前 10 GB 免费，超出 $0.0025/GB，单次查询至少计 10 MB——大表请先加 WHERE / LIMIT。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read-only queries (SELECT / EXPLAIN). Billed by data scanned: first 10 GB per month free, then $0.0025/GB, 10 MB minimum per query — add WHERE / LIMIT before querying large tables."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "唯讀查詢（SELECT / EXPLAIN）。按掃描資料量計費：每月前 10 GB 免費，超出 $0.0025/GB，單次查詢至少計 10 MB——大型資料表請先加 WHERE / LIMIT。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只讀查詢（SELECT / EXPLAIN）。按掃描數據量計費：每月首 10 GB 免費，超出 $0.0025/GB，單次查詢至少計 10 MB——大表請先加 WHERE / LIMIT。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み取り専用クエリ（SELECT / EXPLAIN）。スキャンしたデータ量で課金：毎月 10 GB まで無料、以降 $0.0025/GB、1 クエリあたり最低 10 MB を計上——大きなテーブルには先に WHERE / LIMIT を付けてください。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultas de solo lectura (SELECT / EXPLAIN). Se factura por datos escaneados: los primeros 10 GB al mes son gratis, luego $0.0025/GB, mínimo 10 MB por consulta — agrega WHERE / LIMIT antes de consultar tablas grandes."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽기 전용 쿼리(SELECT / EXPLAIN). 스캔한 데이터양으로 과금: 매월 처음 10 GB 무료, 이후 $0.0025/GB, 쿼리당 최소 10 MB — 큰 테이블은 먼저 WHERE / LIMIT을 추가하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultas somente leitura (SELECT / EXPLAIN). Cobrança por dados verificados: os primeiros 10 GB por mês são gratuitos, depois $0.0025/GB, mínimo de 10 MB por consulta — adicione WHERE / LIMIT antes de consultar tabelas grandes."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultas apenas de leitura (SELECT / EXPLAIN). Faturação por dados analisados: os primeiros 10 GB por mês são gratuitos, depois $0.0025/GB, mínimo de 10 MB por consulta — adicione WHERE / LIMIT antes de consultar tabelas grandes."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur-Lese-Abfragen (SELECT / EXPLAIN). Abgerechnet nach gescannter Datenmenge: 10 GB pro Monat frei, danach $0,0025/GB, mindestens 10 MB pro Abfrage – bei großen Tabellen zuerst WHERE / LIMIT setzen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requêtes en lecture seule (SELECT / EXPLAIN). Facturation au volume scanné : 10 premiers GB par mois gratuits, puis 0,0025 $/GB, minimum 10 MB par requête — ajoutez WHERE / LIMIT avant d'interroger de grandes tables."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استعلامات للقراءة فقط (SELECT / EXPLAIN). تُحتسب التكلفة حسب حجم البيانات الممسوحة: أول 10 GB شهريًا مجانًا، ثم ‎$0.0025/GB، بحد أدنى 10 MB لكل استعلام — أضف WHERE / LIMIT قبل استعلام الجداول الكبيرة."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salt okunur sorgular (SELECT / EXPLAIN). Taranan veriye göre ücretlendirilir: ayda ilk 10 GB ücretsiz, sonrası $0,0025/GB, sorgu başına en az 10 MB — büyük tablolara önce WHERE / LIMIT ekleyin."
+          }
+        }
+      }
+    },
+    "%lld 行 · %lld 列": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld rows · %2$lld columns"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 列 · %2$lld 欄"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 行 · %2$lld 列"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 行 · %2$lld 列"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld filas · %2$lld columnas"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld행 · %2$lld열"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld linhas · %2$lld colunas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld linhas · %2$lld colunas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld Zeilen · %2$lld Spalten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld lignes · %2$lld colonnes"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld صف · %2$lld عمود"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld satır · %2$lld sütun"
+          }
+        }
+      }
+    },
+    "R2 SQL 查询": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL Query"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL 查詢"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL 查詢"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL クエリ"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta R2 SQL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL 쿼리"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta R2 SQL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta R2 SQL"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2-SQL-Abfrage"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requête R2 SQL"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استعلام R2 SQL"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL sorgusu"
+          }
+        }
+      }
+    },
+    "Turnstile": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turnstile"
+          }
+        }
+      }
+    },
+    "R2 SQL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "R2 SQL"
+          }
+        }
+      }
+    },
+    "Bot Fight Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bot Fight Mode"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/CacheRuleModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/CacheRuleModels.swift
@@ -59,6 +59,7 @@ nonisolated struct CacheActionParameters: Codable, Sendable {
     var readTimeout: Int? = nil
     var originCacheControl: Bool? = nil
     var additionalCacheablePorts: [Int]? = nil
+    var vary: VaryProbe? = nil             // 2026-07-02 新增：按 Vary 响应头缓存多版本
 
     enum CodingKeys: String, CodingKey {
         case cache
@@ -72,18 +73,21 @@ nonisolated struct CacheActionParameters: Codable, Sendable {
         case readTimeout = "read_timeout"
         case originCacheControl = "origin_cache_control"
         case additionalCacheablePorts = "additional_cacheable_ports"
+        case vary
     }
 
     /// 含我们未开放的高级设置 → 编辑器只读（status_code_ttl 不计入，编辑时会原样保留）
     var hasAdvancedSettings: Bool {
         cacheKey != nil || cacheReserve != nil || readTimeout != nil
             || originCacheControl != nil || (additionalCacheablePorts?.isEmpty == false)
+            || vary != nil
     }
 }
 
 /// 仅探测存在性的占位（不还原内部结构，故含此设置的规则在 App 内只读）
 nonisolated struct CacheKeyProbe: Codable, Sendable {}
 nonisolated struct CacheReserveProbe: Codable, Sendable {}
+nonisolated struct VaryProbe: Codable, Sendable {}
 
 nonisolated struct CacheEdgeTTL: Codable, Sendable {
     var mode: String                       // respect_origin | override_origin | bypass_by_default
@@ -199,15 +203,18 @@ nonisolated struct CacheRuleField: Identifiable, Sendable {
     var id: String { token }
 
     static let common: [CacheRuleField] = [
-        .init(label: "路径",     token: "http.request.uri.path"),
-        .init(label: "主机",     token: "http.host"),
-        .init(label: "查询串",   token: "http.request.uri.query"),
-        .init(label: "方法",     token: "http.request.method"),
-        .init(label: "Cookie",  token: "http.cookie"),
-        .init(label: "国家",     token: "ip.src.country"),
-        // 2026-07-16 新增：缓存规则现在也能按 bot 分数与来源 ASN 匹配
-        .init(label: "Bot 分数", token: "cf.bot_management.score"),
-        .init(label: "已验证机器人", token: "cf.bot_management.verified_bot"),
-        .init(label: "ASN",     token: "ip.src.asnum"),
+        .init(label: String(localized: "路径"),   token: "http.request.uri.path"),
+        .init(label: String(localized: "主机"),   token: "http.host"),
+        .init(label: String(localized: "查询串"), token: "http.request.uri.query"),
+        .init(label: String(localized: "方法"),   token: "http.request.method"),
+        .init(label: "Cookie",                   token: "http.cookie"),
+        .init(label: String(localized: "国家"),   token: "ip.src.country"),
+        // 2026-07-16 新增：缓存规则现在也能按 bot 分数、JA3/JA4 指纹与来源 ASN 匹配
+        // （bot 字段需 Bot Management 订阅；ASN 全套餐可用）
+        .init(label: String(localized: "Bot 分数"),     token: "cf.bot_management.score"),
+        .init(label: String(localized: "已验证机器人"), token: "cf.bot_management.verified_bot"),
+        .init(label: String(localized: "JA3 指纹"),     token: "cf.bot_management.ja3_hash"),
+        .init(label: String(localized: "JA4 指纹"),     token: "cf.bot_management.ja4"),
+        .init(label: "ASN",                            token: "ip.src.asnum"),
     ]
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/PermissionModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/PermissionModels.swift
@@ -153,9 +153,10 @@ extension FeaturePermission {
         .init(
             id: "r2_catalog",
             title: String(localized: "R2 数据目录"),
-            description: String(localized: "把 R2 桶启用为 Iceberg 数据仓库"),
+            description: String(localized: "把 R2 桶启用为 Iceberg 数据仓库，并用 R2 SQL 查询"),
             icon: "tablecells",
-            readScopes: ["r2-catalog.read"],
+            // r2-catalog-sql.read 供 R2 SQL 查询控制台（api.sql.cloudflarestorage.com）
+            readScopes: ["r2-catalog.read", "r2-catalog-sql.read"],
             editScopes: ["r2-catalog.write"],
             isRequired: false
         ),
@@ -380,6 +381,15 @@ extension FeaturePermission {
             icon: "bolt.horizontal.circle",
             readScopes: ["query-cache.read"],
             editScopes: ["query-cache.write"],
+            isRequired: false
+        ),
+        .init(
+            id: "turnstile",
+            title: "Turnstile",
+            description: String(localized: "管理人机验证组件与密钥轮换"),
+            icon: "checkmark.shield",
+            readScopes: ["challenge-widgets.read"],
+            editScopes: ["challenge-widgets.write"],
             isRequired: false
         ),
         .init(

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/R2CatalogModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/R2CatalogModels.swift
@@ -80,4 +80,26 @@ nonisolated struct R2CatalogNamespace: Codable, Identifiable, Hashable, Sendable
     var displayName: String {
         (name ?? []).joined(separator: " · ")
     }
+
+    /// SQL 里引用表用的前缀（嵌套命名空间以 . 连接）
+    var sqlName: String {
+        (name ?? []).joined(separator: ".")
+    }
+}
+
+/// 表清单的 result 外壳（GET .../namespaces/{ns}/tables）
+nonisolated struct R2CatalogTableList: Codable, Sendable {
+    let identifiers: [R2CatalogTableIdentifier]?
+}
+
+nonisolated struct R2CatalogTableIdentifier: Codable, Identifiable, Hashable, Sendable {
+    let name:      String?
+    let namespace: [String]?
+
+    var id: String { sqlName }
+
+    /// SQL 里的完整引用：namespace.table
+    var sqlName: String {
+        ((namespace ?? []) + [name ?? ""]).filter { !$0.isEmpty }.joined(separator: ".")
+    }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/TurnstileModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/TurnstileModels.swift
@@ -1,0 +1,100 @@
+//
+//  TurnstileModels.swift
+//  Orange Cloud
+//
+//  Turnstile 人机验证组件（账号级 /accounts/{id}/challenges/widgets，
+//  OAuth scope challenge-widgets.read / .write）。
+//
+//  端点与字段以 api-schemas OpenAPI 为准（2026-08 核对）：
+//  · widget 主键是 sitekey；secret 仅 list/get/create/rotate 响应携带
+//  · mode 枚举：managed / non-interactive / invisible
+//  · domains 最多 10 条（主机名或 IP，含子域生效）；空数组 = 允许任意主机名
+//  · region（world / china）创建后不可改；offlabel / ephemeral_id 是 ENT 专属，
+//    App 只透传显示、不提供编辑（免费/付费账号写它必 403）
+//
+
+import Foundation
+
+nonisolated struct TurnstileWidget: Codable, Identifiable, Hashable, Sendable {
+    let sitekey:        String
+    let name:           String
+    let mode:           String
+    let domains:        [String]
+    /// 服务端校验用密钥。出于最小暴露，详情页默认遮蔽、点按显示/复制。
+    let secret:         String?
+    let botFightMode:   Bool?
+    let clearanceLevel: String?
+    let region:         String?
+    let offlabel:       Bool?
+    let ephemeralId:    Bool?
+    let createdOn:      String?
+    let modifiedOn:     String?
+
+    var id: String { sitekey }
+
+    enum CodingKeys: String, CodingKey {
+        case sitekey, name, mode, domains, secret, region, offlabel
+        case botFightMode   = "bot_fight_mode"
+        case clearanceLevel = "clearance_level"
+        case ephemeralId    = "ephemeral_id"
+        case createdOn      = "created_on"
+        case modifiedOn     = "modified_on"
+    }
+}
+
+/// 创建 / 更新载荷（PUT 必填 name + mode + domains；未提及字段服务端保持原值，
+/// 但 bot_fight_mode / clearance_level 我们开放编辑，故显式带上）
+nonisolated struct TurnstileWidgetInput: Codable, Sendable {
+    let name:           String
+    let mode:           String
+    let domains:        [String]
+    let botFightMode:   Bool?
+    /// 仅创建时有效（world / china），创建后不可改
+    let region:         String?
+    let clearanceLevel: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name, mode, domains, region
+        case botFightMode   = "bot_fight_mode"
+        case clearanceLevel = "clearance_level"
+    }
+}
+
+/// 轮换密钥请求体。invalidate_immediately = false 时旧密钥保留 2 小时宽限。
+nonisolated struct TurnstileRotateRequest: Codable, Sendable {
+    let invalidateImmediately: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case invalidateImmediately = "invalidate_immediately"
+    }
+}
+
+/// Widget 模式。清障强度递增：invisible（无感）→ non-interactive（可见不点选）→ managed（必要时勾选）。
+nonisolated enum TurnstileMode: String, CaseIterable, Identifiable, Sendable {
+    case managed
+    case nonInteractive = "non-interactive"
+    case invisible
+
+    var id: String { rawValue }
+
+    /// 未知取值（CF 日后加模式）按 managed 显示
+    init(apiValue: String) {
+        self = TurnstileMode(rawValue: apiValue) ?? .managed
+    }
+
+    var label: String {
+        switch self {
+        case .managed:        String(localized: "托管（推荐）")
+        case .nonInteractive: String(localized: "非交互")
+        case .invisible:      String(localized: "隐形")
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .managed:        String(localized: "由 Cloudflare 判断是否要求访客勾选复选框")
+        case .nonInteractive: String(localized: "显示验证进度但不需要访客操作")
+        case .invisible:      String(localized: "完全不可见，静默完成验证")
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerConfigModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerConfigModels.swift
@@ -393,6 +393,12 @@ nonisolated struct WorkerSecretInput: Codable, Sendable {
     }
 }
 
+/// 批量增删密钥（PATCH .../secrets-bulk，2026-06 新端点，单次 ≤100 项）。
+/// JSON Merge Patch 语义：值为密钥对象 → 新建/覆盖，值为 null → 删除，未提及 → 不动。
+nonisolated struct WorkerSecretsBulkPatch: Codable, Sendable {
+    let secrets: [String: WorkerSecretInput?]
+}
+
 // MARK: - Cron 触发器
 
 /// 单条 Cron 触发器（GET .../schedules）

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/R2CatalogService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/R2CatalogService.swift
@@ -63,6 +63,18 @@ struct R2CatalogService {
         }
         return response.result?.namespaces ?? []
     }
+
+    /// 某命名空间下的表清单（嵌套命名空间按 Iceberg 惯例以 . 连接进路径）
+    func tables(accountId: String, bucketName: String, namespace: String) async throws -> [R2CatalogTableIdentifier] {
+        let response: CFAPIResponse<R2CatalogTableList> = try await client.get(
+            "accounts/\(accountId)/r2-catalog/\(bucketName)/namespaces/\(namespace)/tables",
+            queryItems: [URLQueryItem(name: "page_size", value: "100")]
+        )
+        guard response.success else {
+            throw response.toAPIError()
+        }
+        return response.result?.identifiers ?? []
+    }
 }
 
 /// enable / disable 是无体 POST，但 CFAPIClient.post 要求 Encodable body

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/R2SQLService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/R2SQLService.swift
@@ -1,0 +1,126 @@
+//
+//  R2SQLService.swift
+//  Orange Cloud
+//
+//  R2 SQL：对 R2 Data Catalog（Iceberg）表跑只读分析查询。
+//
+//  查询端点在独立主机 api.sql.cloudflarestorage.com（**不是** client/v4）：
+//  POST /api/v1/accounts/{account_id}/r2-sql/query/{bucket_name}  body {"query": "..."}
+//  鉴权是 Cloudflare Bearer token（需 r2-catalog-sql.read + r2-catalog.read + workers-r2.read）。
+//  该主机对 OAuth token 的接受度未见官方明说，401/403 时由 ViewModel 给出友好指引。
+//
+//  响应格式官方未列 schema，按宽容策略解析：在常见容器键（result/data/rows…）下
+//  找「对象数组」当作行集，列序优先取首行键序。**计费提醒**：按扫描量计费
+//  （$0.0025/GB，10GB/月免费，单次查询最少计 10MB），调用方 UI 需带提示。
+//
+
+import Foundation
+
+struct R2SQLService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 执行一条 R2 SQL 查询，返回展平后的行集
+    func query(accountId: String, bucketName: String, sql: String) async throws -> R2SQLResult {
+        guard let url = URL(string:
+            "https://api.sql.cloudflarestorage.com/api/v1/accounts/\(accountId)/r2-sql/query/\(bucketName)"
+        ) else {
+            throw APIError.networkError(URLError(.badURL))
+        }
+        let data = try await client.postExternalJSON(url: url, body: R2SQLQueryRequest(query: sql))
+        return try Self.parse(data)
+    }
+
+    // MARK: - 宽容解析
+
+    /// 从响应 JSON 里挖出行集：顶层或 result/data 容器下的第一个「对象数组」。
+    static func parse(_ data: Data) throws -> R2SQLResult {
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw APIError.decodingError(error)
+        }
+
+        // 顶层直接就是数组
+        if let rows = object as? [[String: Any]] {
+            return flatten(rows)
+        }
+
+        guard let dict = object as? [String: Any] else {
+            throw APIError.decodingError(DecodingError.dataCorrupted(
+                .init(codingPath: [], debugDescription: "R2 SQL 响应不是 JSON 对象")
+            ))
+        }
+
+        // CF 信封形态：success=false 时抛出首个错误
+        if let success = dict["success"] as? Bool, !success {
+            let errors = dict["errors"] as? [[String: Any]]
+            let message = errors?.first?["message"] as? String ?? String(localized: "查询失败")
+            let code = errors?.first?["code"] as? Int ?? 0
+            throw APIError.cloudflareError(code: code, message: message)
+        }
+
+        // 常见容器键逐层找对象数组（最多两层，避免误挖嵌套数据）
+        let containerKeys = ["result", "data", "rows", "results", "records"]
+        var candidates: [Any] = [dict]
+        for key in containerKeys {
+            if let nested = dict[key] { candidates.append(nested) }
+            if let inner = dict["result"] as? [String: Any], let nested = inner[key] {
+                candidates.append(nested)
+            }
+        }
+        for candidate in candidates {
+            if let rows = candidate as? [[String: Any]] {
+                return flatten(rows)
+            }
+        }
+        // 无行集但也没报错：当作执行成功、零行
+        return R2SQLResult(columns: [], rows: [])
+    }
+
+    /// 对象数组 → 列名 + 字符串矩阵（列序优先按首行键序，缺失键补空）
+    private static func flatten(_ rows: [[String: Any]]) -> R2SQLResult {
+        guard !rows.isEmpty else { return R2SQLResult(columns: [], rows: []) }
+        // 首行键序不可得（字典无序），统一按字母序，稳定可预期
+        var columnSet = Set<String>()
+        for row in rows { columnSet.formUnion(row.keys) }
+        let columns = columnSet.sorted()
+        let matrix = rows.map { row in
+            columns.map { display(row[$0]) }
+        }
+        return R2SQLResult(columns: columns, rows: matrix)
+    }
+
+    private static func display(_ value: Any?) -> String {
+        switch value {
+        case nil, is NSNull:      return "NULL"
+        case let s as String:     return s
+        case let n as NSNumber:
+            return CFGetTypeID(n) == CFBooleanGetTypeID() ? (n.boolValue ? "true" : "false") : n.stringValue
+        case let other:
+            // 嵌套对象/数组压成紧凑 JSON
+            if let data = try? JSONSerialization.data(withJSONObject: other, options: [.fragmentsAllowed]),
+               let text = String(data: data, encoding: .utf8) {
+                return text
+            }
+            return String(describing: other)
+        }
+    }
+}
+
+// MARK: - 模型
+
+nonisolated struct R2SQLQueryRequest: Codable, Sendable {
+    let query: String
+}
+
+/// 展平后的查询结果（值统一字符串化用于展示 / 导出）
+nonisolated struct R2SQLResult: Sendable {
+    let columns: [String]
+    let rows:    [[String]]
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/TurnstileService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/TurnstileService.swift
@@ -1,0 +1,92 @@
+//
+//  TurnstileService.swift
+//  Orange Cloud
+//
+//  Turnstile 人机验证组件管理（challenge-widgets.read / .write）。
+//
+
+import Foundation
+
+struct TurnstileService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 账号下全部 widget（页码分页）
+    func listWidgets(accountId: String) async throws -> [TurnstileWidget] {
+        var widgets: [TurnstileWidget] = []
+        var page = 1
+        while true {
+            let response: CFAPIResponseArray<TurnstileWidget> = try await client.get(
+                "accounts/\(accountId)/challenges/widgets",
+                queryItems: [
+                    URLQueryItem(name: "page",     value: String(page)),
+                    URLQueryItem(name: "per_page", value: "50"),
+                ]
+            )
+            guard response.success else {
+                throw response.toAPIError()
+            }
+            widgets.append(contentsOf: response.result ?? [])
+            let totalPages = response.resultInfo?.totalPages ?? 1
+            guard page < totalPages else { break }
+            page += 1
+        }
+        return widgets
+    }
+
+    /// 单个 widget 详情（响应含 secret）
+    func widget(accountId: String, sitekey: String) async throws -> TurnstileWidget {
+        let response: CFAPIResponse<TurnstileWidget> = try await client.get(
+            "accounts/\(accountId)/challenges/widgets/\(sitekey)"
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 新建 widget（响应含 sitekey + secret）
+    func createWidget(accountId: String, input: TurnstileWidgetInput) async throws -> TurnstileWidget {
+        let response: CFAPIResponse<TurnstileWidget> = try await client.post(
+            "accounts/\(accountId)/challenges/widgets",
+            body: input
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 更新 widget（PUT，name / mode / domains 必填）
+    func updateWidget(accountId: String, sitekey: String, input: TurnstileWidgetInput) async throws -> TurnstileWidget {
+        let response: CFAPIResponse<TurnstileWidget> = try await client.put(
+            "accounts/\(accountId)/challenges/widgets/\(sitekey)",
+            body: input
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+
+    /// 删除 widget
+    func deleteWidget(accountId: String, sitekey: String) async throws {
+        try await client.delete("accounts/\(accountId)/challenges/widgets/\(sitekey)")
+    }
+
+    /// 轮换服务端密钥。immediately = false 时旧密钥保留 2 小时宽限期。
+    func rotateSecret(accountId: String, sitekey: String, immediately: Bool) async throws -> TurnstileWidget {
+        let response: CFAPIResponse<TurnstileWidget> = try await client.post(
+            "accounts/\(accountId)/challenges/widgets/\(sitekey)/rotate_secret",
+            body: TurnstileRotateRequest(invalidateImmediately: immediately)
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerService.swift
@@ -288,6 +288,29 @@ struct WorkerService {
         try await client.delete("accounts/\(accountId)/workers/scripts/\(scriptName)/secrets/\(name)")
     }
 
+    /// 批量写密钥（2026-06 新端点，单次 ≤100 项，原子生效）。
+    /// JSON Merge Patch：对象 → 新建/覆盖，null → 删除；未提及的密钥不受影响。
+    func bulkPatchSecrets(
+        accountId: String,
+        scriptName: String,
+        upserts: [(name: String, text: String)],
+        deletes: [String] = []
+    ) async throws {
+        var secrets: [String: WorkerSecretInput?] = [:]
+        for item in upserts {
+            secrets[item.name] = WorkerSecretInput(name: item.name, text: item.text)
+        }
+        for name in deletes {
+            // 双重可选陷阱：subscript 赋 nil 会移除键，须 updateValue 才能存下「值为 null」
+            secrets.updateValue(nil, forKey: name)
+        }
+        let response: CFAPIResponse<EmptyResponse> = try await client.patch(
+            "accounts/\(accountId)/workers/scripts/\(scriptName)/secrets-bulk",
+            body: WorkerSecretsBulkPatch(secrets: secrets)
+        )
+        guard response.success else { throw response.toAPIError() }
+    }
+
     // MARK: - Cron 触发器
 
     func schedules(accountId: String, scriptName: String) async throws -> [WorkerSchedule] {

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/R2SQLViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/R2SQLViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  R2SQLViewModel.swift
+//  Orange Cloud
+//
+//  R2 SQL 查询控制台：命名空间/表清单（点按插入引用）+ 查询执行。
+//  只读引擎（SELECT / EXPLAIN），行数超限截断展示（对齐 D1 控制台的防线）。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class R2SQLViewModel {
+
+    /// 展示行数上限（查询本身不截断，展示截断——扫描量在服务端已发生）
+    static let maxRows = 500
+
+    private(set) var namespaces: [R2CatalogNamespace] = []
+    /// 命名空间 sqlName → 表引用清单
+    private(set) var tables: [String: [R2CatalogTableIdentifier]] = [:]
+    private(set) var result: R2SQLResult?
+    private(set) var loadedSchema = false
+    var isRunning = false
+    var error: String?
+
+    private let sqlService: R2SQLService
+    private let catalogService: R2CatalogService
+    let accountId: String
+    let bucketName: String
+
+    init(sqlService: R2SQLService, catalogService: R2CatalogService, accountId: String, bucketName: String) {
+        self.sqlService = sqlService
+        self.catalogService = catalogService
+        self.accountId = accountId
+        self.bucketName = bucketName
+    }
+
+    /// 拉命名空间与各自的表（一次拉全，目录规模通常很小；失败静默，不挡查询输入）
+    func loadSchema() async {
+        guard !loadedSchema else { return }
+        namespaces = (try? await catalogService.namespaces(accountId: accountId, bucketName: bucketName)) ?? []
+        for namespace in namespaces {
+            let list = (try? await catalogService.tables(
+                accountId: accountId, bucketName: bucketName, namespace: namespace.sqlName
+            )) ?? []
+            tables[namespace.sqlName] = list
+        }
+        loadedSchema = true
+    }
+
+    /// 全部表的 SQL 引用（namespace.table），供点按插入
+    var tableReferences: [String] {
+        namespaces.flatMap { tables[$0.sqlName] ?? [] }.map(\.sqlName)
+    }
+
+    func run(sql: String) async {
+        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isRunning else { return }
+        isRunning = true
+        error = nil
+        do {
+            result = try await sqlService.query(accountId: accountId, bucketName: bucketName, sql: trimmed)
+        } catch APIError.unauthorized, APIError.forbidden {
+            // 独立主机对 OAuth token 的接受度未官方明说：401/403 给出定向指引而非通用文案
+            error = String(localized: "R2 SQL 查询被拒绝。请确认授权包含 R2 SQL / 数据目录 / R2 读权限；若仍失败，说明该接口暂不接受 App 的登录方式，请先用 Wrangler 查询。")
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isRunning = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SessionStore.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SessionStore.swift
@@ -53,6 +53,8 @@ final class SessionStore {
     let workersAIService:          WorkersAIService
     let hyperdriveService:         HyperdriveService
     let zoneRulesetService:        ZoneRulesetService
+    let turnstileService:          TurnstileService
+    let r2SQLService:              R2SQLService
 
     var accounts: [Account] = []
     var selectedAccount: Account? {
@@ -118,6 +120,8 @@ final class SessionStore {
         self.workersAIService          = WorkersAIService(client: client)
         self.hyperdriveService         = HyperdriveService(client: client)
         self.zoneRulesetService        = ZoneRulesetService(client: client)
+        self.turnstileService          = TurnstileService(client: client)
+        self.r2SQLService              = R2SQLService(client: client)
     }
 
     /// 幂等加载账号列表，选中上次选定的账号（没有则首个）

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/TurnstileViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/TurnstileViewModel.swift
@@ -1,0 +1,119 @@
+//
+//  TurnstileViewModel.swift
+//  Orange Cloud
+//
+//  Turnstile widget 列表与增删改、密钥轮换。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class TurnstileViewModel {
+
+    private(set) var widgets: [TurnstileWidget] = []
+    private(set) var loaded = false
+    var isLoading = false
+    var isSaving  = false
+    var error: String?
+
+    private let service: TurnstileService
+    let accountId: String
+
+    init(service: TurnstileService, accountId: String) {
+        self.service = service
+        self.accountId = accountId
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        do {
+            widgets = try await service.listWidgets(accountId: accountId)
+            loaded = true
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func create(input: TurnstileWidgetInput) async -> TurnstileWidget? {
+        guard !isSaving else { return nil }
+        isSaving = true
+        error = nil
+        defer { isSaving = false }
+        do {
+            let widget = try await service.createWidget(accountId: accountId, input: input)
+            widgets.append(widget)
+            return widget
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
+
+    func update(sitekey: String, input: TurnstileWidgetInput) async -> TurnstileWidget? {
+        guard !isSaving else { return nil }
+        isSaving = true
+        error = nil
+        defer { isSaving = false }
+        do {
+            let widget = try await service.updateWidget(accountId: accountId, sitekey: sitekey, input: input)
+            replace(widget)
+            return widget
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
+
+    func delete(_ widget: TurnstileWidget) async -> Bool {
+        error = nil
+        do {
+            try await service.deleteWidget(accountId: accountId, sitekey: widget.sitekey)
+            widgets.removeAll { $0.sitekey == widget.sitekey }
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
+    func rotateSecret(sitekey: String, immediately: Bool) async -> TurnstileWidget? {
+        guard !isSaving else { return nil }
+        isSaving = true
+        error = nil
+        defer { isSaving = false }
+        do {
+            let widget = try await service.rotateSecret(
+                accountId: accountId, sitekey: sitekey, immediately: immediately
+            )
+            replace(widget)
+            return widget
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
+
+    /// 详情页拉带 secret 的完整对象（列表响应含 secret，但以单查为准兜底）
+    func detail(sitekey: String) async -> TurnstileWidget? {
+        do {
+            let widget = try await service.widget(accountId: accountId, sitekey: sitekey)
+            replace(widget)
+            return widget
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
+
+    private func replace(_ widget: TurnstileWidget) {
+        if let index = widgets.firstIndex(where: { $0.sitekey == widget.sitekey }) {
+            widgets[index] = widget
+        } else {
+            widgets.append(widget)
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerBindingsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerBindingsViewModel.swift
@@ -207,25 +207,38 @@ final class WorkerBindingsViewModel {
         }
     }
 
-    /// 批量导入密钥（secret_text）：逐个 PUT（端点不支持批量），同名覆盖。
-    /// 任一失败即停，报告已写入数量并刷新列表反映真实状态。
+    /// 批量导入密钥（secret_text）：走 secrets-bulk 端点单次 PATCH 原子生效，同名覆盖。
+    /// 超过 100 项自动分批（每批各自原子）。
     func bulkImportSecrets(_ pairs: [(name: String, value: String)]) async -> Bool {
         guard !isSaving, !pairs.isEmpty else { return false }
         isSaving = true
         error = nil
         defer { isSaving = false }
-        var done = 0
         do {
-            for pair in pairs {
-                try await service.putSecret(accountId: accountId, scriptName: scriptName, name: pair.name, text: pair.value)
-                done += 1
+            // secrets-bulk（2026-06 新端点）：单次 PATCH 原子生效，不再逐个 PUT（单次上限 100 项）
+            for chunk in pairs.chunked(into: 100) {
+                try await service.bulkPatchSecrets(
+                    accountId: accountId, scriptName: scriptName,
+                    upserts: chunk.map { (name: $0.name, text: $0.value) }
+                )
             }
             secrets = (try? await service.listSecrets(accountId: accountId, scriptName: scriptName)) ?? secrets
             return true
         } catch {
-            self.error = String(localized: "已导入 \(done)/\(pairs.count) 项后失败：\(error.localizedDescription)")
+            self.error = error.localizedDescription
             secrets = (try? await service.listSecrets(accountId: accountId, scriptName: scriptName)) ?? secrets
             return false
+        }
+    }
+}
+
+// MARK: - 分块工具（secrets-bulk 单次上限 100 项）
+
+private extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return [self] }
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Components/ProGate.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Components/ProGate.swift
@@ -17,6 +17,7 @@ nonisolated enum ProFeature: String, Identifiable, Sendable {
     case aiInsights, aiDNS, filesApp
     case queues, aiGateway, durableObjects, workersAI, hyperdrive
     case zoneRules
+    case turnstile
 
     var id: String { rawValue }
 
@@ -51,6 +52,7 @@ nonisolated enum ProFeature: String, Identifiable, Sendable {
         case .workersAI:      String(localized: "Workers AI 需要 Pro")
         case .hyperdrive:     String(localized: "Hyperdrive 需要 Pro")
         case .zoneRules:      String(localized: "规则管理需要 Pro")
+        case .turnstile:      String(localized: "Turnstile 需要 Pro")
         }
     }
 
@@ -85,6 +87,7 @@ nonisolated enum ProFeature: String, Identifiable, Sendable {
         case .workersAI:      String(localized: "浏览 Workers AI 模型目录，并试运行文本生成模型属于 Orange Cloud Pro。")
         case .hyperdrive:     String(localized: "查看与管理 Hyperdrive 数据库加速配置（缓存设置、改源连接、新建 / 删除）属于 Orange Cloud Pro。")
         case .zoneRules:      String(localized: "单条重定向、源站 / 配置 / 压缩规则、自定义错误与 Page Rules 的查看、启停与删除属于 Orange Cloud Pro。")
+        case .turnstile:      String(localized: "管理 Turnstile 人机验证组件（新建 / 编辑 / 密钥轮换）属于 Orange Cloud Pro。")
         }
     }
 
@@ -119,6 +122,7 @@ nonisolated enum ProFeature: String, Identifiable, Sendable {
         case .workersAI:      "brain"
         case .hyperdrive:     "bolt.horizontal.circle"
         case .zoneRules:      "list.bullet.rectangle"
+        case .turnstile:      "checkmark.shield"
         }
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -65,6 +65,8 @@ struct DashboardView: View {
                         TunnelListView(session: session)
                     case .tunnelConnect(let tunnel):
                         TunnelConnectView(tunnel: tunnel, accountId: currentAccountId, session: session)
+                    case .turnstile:
+                        TurnstileListView(session: session)
                     case .accessApps:
                         AccessAppsView(session: session)
                     case .gatewayRules:
@@ -81,6 +83,10 @@ struct DashboardView: View {
                         canWrite: auth.hasScope("argotunnel.write"),
                         canWriteDNS: auth.hasScope("dns.write")
                     )
+                }
+                // Turnstile 详情同 Tunnel：列表行值式 push，目的页挂栈根
+                .navigationDestination(for: TurnstileWidget.self) { widget in
+                    TurnstileDetailView(widget: widget, session: session)
                 }
                 // 命令搜索 / 告警中心 / 跨类型置顶的跳转（Worker 详情、R2 对象、D1 控制台、
                 // KV 键列表内部都还要继续 push）同样只挂栈根，值式
@@ -1403,6 +1409,16 @@ private struct DashboardHomeView: View {
                 value: DashboardRoute.tunnels
             )
             Divider().padding(.leading, 44)
+            // Turnstile 列表点行还要 push 详情：同 Tunnel，必须值式 + 栈根 navdest
+            ProGatedValueLink(
+                label: "Turnstile",
+                systemImage: "checkmark.shield",
+                requiredScope: "challenge-widgets.read",
+                feature: .turnstile,
+                showsChevron: true,
+                value: DashboardRoute.turnstile
+            )
+            Divider().padding(.leading, 44)
             // Access / Gateway 同样必须值式：本岛（非 List 容器）里 eager 构造的目的页
             // 在 iOS 17.0 点击即整 App 冻结/看门狗杀（TF 用户实测，与 Tunnel 当年同症）。
             ProGatedValueLink(
@@ -1455,6 +1471,7 @@ enum DashboardRoute: Hashable {
     case requestTracer
     case tunnels
     case tunnelConnect(Tunnel)
+    case turnstile
     case accessApps
     case gatewayRules
     case bulkRedirects

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2BucketSettingsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2BucketSettingsView.swift
@@ -20,10 +20,12 @@ struct R2BucketSettingsView: View {
     @State private var showCatalogEnableConfirm = false
     @State private var showAddCors = false
     @State private var showDenied = false
+    @State private var showSQLConsole = false
 
     // 文件 App 挂载（Pro）
     private let bucketName: String
     private let accountId: String
+    private let session: SessionStore
     @State private var isMounted = false
     @State private var isMountBusy = false
     @State private var mountPaywall = false
@@ -32,6 +34,7 @@ struct R2BucketSettingsView: View {
         self.canWrite = canWrite
         self.bucketName = bucket.name
         self.accountId = session.selectedAccount?.id ?? ""
+        self.session = session
         _viewModel = State(initialValue: R2BucketSettingsViewModel(
             service: session.r2Service,
             accountId: session.selectedAccount?.id ?? "",
@@ -85,6 +88,9 @@ struct R2BucketSettingsView: View {
                 R2CorsRuleEditor { origins, methods, maxAge in
                     Task { await viewModel.addCorsRule(origins: origins, methods: methods, maxAgeSeconds: maxAge) }
                 }
+            }
+            .sheet(isPresented: $showSQLConsole) {
+                R2SQLQueryView(session: session, accountId: accountId, bucketName: bucketName)
             }
             .alert("权限不足", isPresented: $showDenied) {
                 Button("好", role: .cancel) {}
@@ -267,6 +273,14 @@ struct R2BucketSettingsView: View {
                             ForEach(catalogViewModel.namespaces) { namespace in
                                 Text(namespace.displayName)
                                     .font(.caption.monospaced())
+                            }
+                        }
+                        // R2 SQL 控制台（2026-08 起计费：$0.0025/GB 扫描、10GB/月免费）
+                        if auth.hasScope("r2-catalog-sql.read") {
+                            Button {
+                                showSQLConsole = true
+                            } label: {
+                                Label("R2 SQL 查询", systemImage: "terminal")
                             }
                         }
                     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2SQLQueryView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Storage/R2SQLQueryView.swift
@@ -1,0 +1,178 @@
+//
+//  R2SQLQueryView.swift
+//  Orange Cloud
+//
+//  R2 SQL 查询控制台（叶子页，桶设置 sheet 内再起一层 sheet 打开）。
+//  只读分析查询（SELECT / EXPLAIN），带计费提示与展示行数截断（对齐 D1 防线）。
+//
+
+import SwiftUI
+
+struct R2SQLQueryView: View {
+
+    @State private var viewModel: R2SQLViewModel
+    @State private var sql = ""
+    @FocusState private var editorFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    init(session: SessionStore, accountId: String, bucketName: String) {
+        _viewModel = State(initialValue: R2SQLViewModel(
+            sqlService: session.r2SQLService,
+            catalogService: session.r2CatalogService,
+            accountId: accountId,
+            bucketName: bucketName
+        ))
+    }
+
+    private var canRun: Bool {
+        !sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !viewModel.isRunning
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    editorCard
+                    if let error = viewModel.error {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 4)
+                    }
+                    if let result = viewModel.result {
+                        resultCard(result)
+                    }
+                }
+                .padding()
+            }
+            .background { SkyBackground() }
+            .navigationTitle("R2 SQL")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("完成") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        editorFocused = false
+                        Task { await viewModel.run(sql: sql) }
+                    } label: {
+                        if viewModel.isRunning {
+                            ProgressView()
+                        } else {
+                            Label("运行", systemImage: "play.fill")
+                        }
+                    }
+                    .disabled(!canRun)
+                }
+            }
+            .task { await viewModel.loadSchema() }
+        }
+    }
+
+    // MARK: - 编辑器
+
+    private var editorCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            TextEditor(text: $sql)
+                .font(.callout.monospaced())
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused($editorFocused)
+                .frame(minHeight: 120)
+                .scrollContentBackground(.hidden)
+                .overlay(alignment: .topLeading) {
+                    if sql.isEmpty {
+                        Text(verbatim: "SELECT * FROM namespace.table LIMIT 100")
+                            .font(.callout.monospaced())
+                            .foregroundStyle(.tertiary)
+                            .padding(.top, 8)
+                            .padding(.leading, 5)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+            if !viewModel.tableReferences.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(viewModel.tableReferences, id: \.self) { table in
+                            Button {
+                                insert(table)
+                            } label: {
+                                Text(table)
+                                    .font(.caption2.monospaced())
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(Color.ocOrange.opacity(0.12), in: Capsule())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                // 表引用是 SQL 标识符，保持 LTR
+                .environment(\.layoutDirection, .leftToRight)
+            }
+
+            Text("只读查询（SELECT / EXPLAIN）。按扫描数据量计费：每月前 10 GB 免费，超出 $0.0025/GB，单次查询至少计 10 MB——大表请先加 WHERE / LIMIT。")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(14)
+        .glassIsland(cornerRadius: 20)
+    }
+
+    private func insert(_ token: String) {
+        if sql.isEmpty {
+            sql = "SELECT * FROM \(token) LIMIT 100"
+        } else {
+            sql += sql.hasSuffix(" ") || sql.hasSuffix("\n") ? token : " \(token)"
+        }
+    }
+
+    // MARK: - 结果
+
+    private func resultCard(_ result: R2SQLResult) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if result.rows.isEmpty {
+                Label("执行成功，无返回行", systemImage: "checkmark.circle")
+                    .font(.callout)
+                    .foregroundStyle(.green)
+            } else {
+                Text("\(result.rows.count) 行 · \(result.columns.count) 列")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ScrollView(.horizontal, showsIndicators: true) {
+                    Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
+                        GridRow {
+                            ForEach(result.columns, id: \.self) { column in
+                                Text(column)
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Divider()
+                        ForEach(Array(result.rows.prefix(R2SQLViewModel.maxRows).enumerated()), id: \.offset) { _, row in
+                            GridRow {
+                                ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
+                                    Text(cell)
+                                        .font(.caption.monospaced())
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                // 查询结果表（列名/数据值）保持 LTR 列序
+                .environment(\.layoutDirection, .leftToRight)
+                if result.rows.count > R2SQLViewModel.maxRows {
+                    Text("仅显示前 \(R2SQLViewModel.maxRows) 行（共 \(result.rows.count) 行）")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(14)
+        .glassIsland(cornerRadius: 20)
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Turnstile/TurnstileDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Turnstile/TurnstileDetailView.swift
@@ -1,0 +1,223 @@
+//
+//  TurnstileDetailView.swift
+//  Orange Cloud
+//
+//  Turnstile 组件详情：sitekey / secret（遮蔽 + 复制）、模式与域名、
+//  编辑（sheet）、密钥轮换（立即 / 2 小时宽限）、删除。
+//  由宿主栈根 navigationDestination(for: TurnstileWidget.self) 解析（值式导航）。
+//
+
+import SwiftUI
+
+struct TurnstileDetailView: View {
+
+    @Environment(SessionStore.self) private var session
+    @Environment(AuthManager.self) private var auth
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var viewModel: TurnstileViewModel
+    @State private var widget: TurnstileWidget
+    @State private var showEditor = false
+    @State private var showRotate = false
+    @State private var showDelete = false
+    @State private var showDenied = false
+    @State private var secretRevealed = false
+    @State private var copied = false
+
+    init(widget: TurnstileWidget, session: SessionStore) {
+        _widget = State(initialValue: widget)
+        _viewModel = State(initialValue: TurnstileViewModel(
+            service: session.turnstileService,
+            accountId: session.selectedAccount?.id ?? ""
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("challenge-widgets.write") }
+
+    var body: some View {
+        List {
+            keysSection
+            configSection
+            if canWrite { dangerSection }
+        }
+        .scrollContentBackground(.hidden)
+        .background { SkyBackground() }
+        .navigationTitle(widget.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if canWrite {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("编辑") { showEditor = true }
+                }
+            }
+        }
+        .sheet(isPresented: $showEditor) {
+            TurnstileEditorSheet(viewModel: viewModel, existing: widget) { updated in
+                widget = updated
+            }
+        }
+        .task {
+            // 列表响应通常已含 secret，单查兜底一次拿完整对象
+            if widget.secret == nil, let fresh = await viewModel.detail(sitekey: widget.sitekey) {
+                widget = fresh
+            }
+        }
+        .sensoryFeedback(.success, trigger: copied)
+        .confirmationDialog("轮换密钥", isPresented: $showRotate, titleVisibility: .visible) {
+            Button("轮换（旧密钥保留 2 小时）") {
+                Task {
+                    if let updated = await viewModel.rotateSecret(sitekey: widget.sitekey, immediately: false) {
+                        widget = updated
+                        secretRevealed = true
+                    }
+                }
+            }
+            Button("立即作废旧密钥", role: .destructive) {
+                Task {
+                    if let updated = await viewModel.rotateSecret(sitekey: widget.sitekey, immediately: true) {
+                        widget = updated
+                        secretRevealed = true
+                    }
+                }
+            }
+        } message: {
+            Text("轮换后服务端需改用新密钥调用 siteverify。选择宽限可让旧密钥再工作 2 小时，平滑过渡。")
+        }
+        .confirmationDialog(
+            String(localized: "删除组件「\(widget.name)」？"),
+            isPresented: $showDelete,
+            titleVisibility: .visible
+        ) {
+            Button("删除", role: .destructive) {
+                Task {
+                    if await viewModel.delete(widget) { dismiss() }
+                }
+            }
+        } message: {
+            Text("嵌在网站上的该组件将立即失效，此操作不可撤销。")
+        }
+        .alert("权限不足", isPresented: $showDenied) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("当前授权未包含 Turnstile 编辑权限（challenge-widgets.write）。\n请在设置中重新授权以启用此功能。")
+        }
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil },
+            set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    // MARK: - 密钥
+
+    private var keysSection: some View {
+        Section {
+            Button {
+                UIPasteboard.general.string = widget.sitekey
+                copied.toggle()
+            } label: {
+                HStack(spacing: 12) {
+                    TintIcon(systemImage: "key.horizontal", color: .ocOrange)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(verbatim: "Sitekey")
+                            .font(.callout.weight(.medium))
+                            .foregroundStyle(.primary)
+                        Text(widget.sitekey)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                    Image(systemName: "doc.on.doc")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            if let secret = widget.secret {
+                Button {
+                    if secretRevealed {
+                        UIPasteboard.general.string = secret
+                        copied.toggle()
+                    } else {
+                        secretRevealed = true
+                    }
+                } label: {
+                    HStack(spacing: 12) {
+                        TintIcon(systemImage: "key.fill", color: .ocOrange)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(verbatim: "Secret")
+                                .font(.callout.weight(.medium))
+                                .foregroundStyle(.primary)
+                            Text(secretRevealed ? secret : String(repeating: "•", count: 24))
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        Spacer()
+                        Image(systemName: secretRevealed ? "doc.on.doc" : "eye")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+
+            if canWrite {
+                Button {
+                    showRotate = true
+                } label: {
+                    Label("轮换密钥", systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+        } header: {
+            Text("集成密钥")
+        } footer: {
+            Text("sitekey 嵌进网页组件，secret 用于服务端 siteverify 校验——secret 请勿泄露。点按可复制。")
+        }
+        .glassRow()
+    }
+
+    // MARK: - 配置
+
+    private var configSection: some View {
+        Section {
+            LabeledContent("模式", value: TurnstileMode(apiValue: widget.mode).label)
+            if widget.domains.isEmpty {
+                LabeledContent("域名", value: String(localized: "任意主机名"))
+            } else {
+                ForEach(widget.domains, id: \.self) { domain in
+                    LabeledContent("域名") {
+                        Text(domain).font(.callout.monospaced())
+                    }
+                }
+            }
+            if let region = widget.region {
+                LabeledContent("区域", value: region == "china" ? String(localized: "中国") : String(localized: "全球"))
+            }
+            if widget.botFightMode == true {
+                LabeledContent("Bot Fight Mode", value: String(localized: "已开启"))
+            }
+        } header: {
+            Text("配置")
+        } footer: {
+            Text("组件在所列域名及其子域生效；域名留空表示任意主机名均可使用。")
+        }
+        .glassRow()
+    }
+
+    // MARK: - 危险操作
+
+    private var dangerSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showDelete = true
+            } label: {
+                Label("删除组件", systemImage: "trash")
+            }
+        }
+        .glassRow()
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Turnstile/TurnstileEditorSheet.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Turnstile/TurnstileEditorSheet.swift
@@ -1,0 +1,144 @@
+//
+//  TurnstileEditorSheet.swift
+//  Orange Cloud
+//
+//  Turnstile 组件新建 / 编辑表单（sheet，叶子页）。
+//  region 创建后不可改；offlabel / ephemeral_id 是 ENT 专属不开放；
+//  clearance_level 编辑时原样回写，避免 PUT 丢配置。
+//
+
+import SwiftUI
+
+struct TurnstileEditorSheet: View {
+
+    let viewModel: TurnstileViewModel
+    let existing: TurnstileWidget?
+    var onSaved: ((TurnstileWidget) -> Void)? = nil
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var mode: TurnstileMode
+    @State private var domainsText: String
+    @State private var botFightMode: Bool
+    @State private var region = "world"
+
+    init(viewModel: TurnstileViewModel, existing: TurnstileWidget?, onSaved: ((TurnstileWidget) -> Void)? = nil) {
+        self.viewModel = viewModel
+        self.existing = existing
+        self.onSaved = onSaved
+        _name = State(initialValue: existing?.name ?? "")
+        _mode = State(initialValue: TurnstileMode(apiValue: existing?.mode ?? "managed"))
+        _domainsText = State(initialValue: (existing?.domains ?? []).joined(separator: "\n"))
+        _botFightMode = State(initialValue: existing?.botFightMode ?? false)
+    }
+
+    private var isEditing: Bool { existing != nil }
+
+    /// 每行一个域名，去空白去空行去重（保序）
+    private var domains: [String] {
+        var seen = Set<String>()
+        return domainsText
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+            && domains.count <= 10
+            && !viewModel.isSaving
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("名称") {
+                    TextField("如：官网登录页", text: $name)
+                }
+
+                Section {
+                    Picker("模式", selection: $mode) {
+                        ForEach(TurnstileMode.allCases) { Text($0.label).tag($0) }
+                    }
+                } footer: {
+                    Text(mode.detail)
+                }
+
+                Section {
+                    TextEditor(text: $domainsText)
+                        .font(.callout.monospaced())
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .frame(minHeight: 90)
+                } header: {
+                    Text("域名")
+                } footer: {
+                    if domains.count > 10 {
+                        Text("最多 10 个域名（当前 \(domains.count) 个）。").foregroundStyle(.red)
+                    } else {
+                        Text("每行一个主机名或 IP，子域自动生效；留空表示任意主机名均可使用。")
+                    }
+                }
+
+                Section {
+                    Toggle("Bot Fight Mode", isOn: $botFightMode)
+                } footer: {
+                    Text("对疑似机器人的请求发放高算力挑战，加大自动化攻击成本。")
+                }
+
+                if !isEditing {
+                    Section {
+                        Picker("区域", selection: $region) {
+                            Text("全球").tag("world")
+                            Text("中国").tag("china")
+                        }
+                    } footer: {
+                        Text("创建后不可更改。")
+                    }
+                }
+
+                if let error = viewModel.error {
+                    Section { Text(error).font(.footnote).foregroundStyle(.red) }
+                }
+            }
+            .navigationTitle(isEditing ? String(localized: "编辑组件") : String(localized: "新建组件"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        if viewModel.isSaving { ProgressView() } else { Text("保存").fontWeight(.semibold) }
+                    }
+                    .disabled(!canSave)
+                }
+            }
+            .interactiveDismissDisabled(viewModel.isSaving)
+        }
+    }
+
+    private func save() async {
+        viewModel.error = nil
+        let input = TurnstileWidgetInput(
+            name: name.trimmingCharacters(in: .whitespaces),
+            mode: mode.rawValue,
+            domains: domains,
+            botFightMode: botFightMode,
+            region: isEditing ? nil : region,
+            clearanceLevel: existing?.clearanceLevel   // 原样回写，避免 PUT 丢配置
+        )
+        let saved: TurnstileWidget?
+        if let existing {
+            saved = await viewModel.update(sitekey: existing.sitekey, input: input)
+        } else {
+            saved = await viewModel.create(input: input)
+        }
+        if let saved {
+            onSaved?(saved)
+            dismiss()
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Turnstile/TurnstileListView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Turnstile/TurnstileListView.swift
@@ -1,0 +1,155 @@
+//
+//  TurnstileListView.swift
+//  Orange Cloud
+//
+//  Turnstile 人机验证：widget 列表 / 新建 / 编辑 / 密钥轮换 / 删除。
+//  读 challenge-widgets.read，写操作按 challenge-widgets.write 门控。
+//
+//  导航：入口在概览页「网络」岛（DashboardRoute.turnstile），列表行点击继续 push 详情，
+//  详情由宿主栈根 .navigationDestination(for: TurnstileWidget.self) 解析——
+//  本链路全值式，eager 形态在 iOS 17.0 会卡死（见 DashboardView 注释）。
+//
+
+import SwiftUI
+
+struct TurnstileListView: View {
+
+    @Environment(SessionStore.self) private var session
+    @Environment(AuthManager.self) private var auth
+    @State private var viewModel: TurnstileViewModel
+    @State private var showCreate = false
+    @State private var showDenied = false
+    @State private var widgetToDelete: TurnstileWidget?
+
+    init(session: SessionStore) {
+        _viewModel = State(initialValue: TurnstileViewModel(
+            service: session.turnstileService,
+            accountId: session.selectedAccount?.id ?? ""
+        ))
+    }
+
+    private var canWrite: Bool { auth.hasScope("challenge-widgets.write") }
+
+    var body: some View {
+        Group {
+            if viewModel.widgets.isEmpty && viewModel.isLoading {
+                SkeletonList(rows: 4)
+            } else if viewModel.widgets.isEmpty {
+                ContentUnavailableView {
+                    Label("没有 Turnstile 组件", systemImage: "checkmark.shield")
+                } description: {
+                    Text("Turnstile 是 Cloudflare 的免费人机验证，替代传统验证码。新建组件后把 sitekey 嵌进你的网站即可。")
+                } actions: {
+                    if canWrite {
+                        Button("新建组件") { showCreate = true }
+                            .buttonStyle(.borderedProminent)
+                            .tint(Color.ocOrangePressed)
+                            .fontWeight(.bold)
+                    }
+                }
+            } else {
+                List(viewModel.widgets) { widget in
+                    NavigationLink(value: widget) {
+                        TurnstileRow(widget: widget)
+                    }
+                    .glassRow()
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            if canWrite { widgetToDelete = widget } else { showDenied = true }
+                        } label: {
+                            Label("删除", systemImage: "trash")
+                        }
+                    }
+                }
+                .scrollContentBackground(.hidden)
+                .refreshable { await viewModel.load() }
+            }
+        }
+        .background { SkyBackground() }
+        .navigationTitle("Turnstile")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("新建", systemImage: "plus") {
+                    if canWrite { showCreate = true } else { showDenied = true }
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                RefreshButton(
+                    isLoading: viewModel.isLoading,
+                    failed: viewModel.error != nil,
+                    action: { Task { await viewModel.load() } }
+                )
+            }
+        }
+        .sheet(isPresented: $showCreate) {
+            TurnstileEditorSheet(viewModel: viewModel, existing: nil)
+        }
+        .task { if !viewModel.loaded { await viewModel.load() } }
+        .confirmationDialog(
+            widgetToDelete.map { String(localized: "删除组件「\($0.name)」？") } ?? "",
+            isPresented: .init(
+                get: { widgetToDelete != nil },
+                set: { if !$0 { widgetToDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("删除", role: .destructive) {
+                if let widget = widgetToDelete {
+                    Task { await viewModel.delete(widget) }
+                }
+            }
+        } message: {
+            Text("嵌在网站上的该组件将立即失效，此操作不可撤销。")
+        }
+        .alert("权限不足", isPresented: $showDenied) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("当前授权未包含 Turnstile 编辑权限（challenge-widgets.write）。\n请在设置中重新授权以启用此功能。")
+        }
+        .alert("出错了", isPresented: .init(
+            get: { viewModel.error != nil && !viewModel.isLoading },
+            set: { if !$0 { viewModel.error = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+}
+
+// MARK: - 列表行
+
+private struct TurnstileRow: View {
+
+    let widget: TurnstileWidget
+
+    var body: some View {
+        HStack(spacing: 12) {
+            TintIcon(systemImage: "checkmark.shield", color: .ocOrange)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(widget.name)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                Text(widget.sitekey)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(TurnstileMode(apiValue: widget.mode).label)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.ocOrangeText)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.ocOrange.opacity(0.14), in: Capsule())
+                Text(widget.domains.isEmpty
+                     ? String(localized: "任意主机名")
+                     : String(localized: "\(widget.domains.count) 个域名"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerSecretsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerSecretsView.swift
@@ -425,7 +425,7 @@ private struct WorkerBulkImportSheet: View {
                     .pickerStyle(.segmented)
                 } footer: {
                     Text(target == .secret
-                         ? String(localized: "作为密钥写入，逐个保存；同名将被覆盖，保存后不可读取。")
+                         ? String(localized: "作为密钥一次性写入；同名将被覆盖，保存后不可读取。")
                          : String(localized: "作为明文变量一次性写入；同名将被覆盖，不影响其它绑定。"))
                 }
 


### PR DESCRIPTION
iOS 2.1.0，build 40（MARKETING_VERSION / CURRENT_PROJECT_VERSION 各 12 处已核对一致）。

- Turnstile 人机验证管理（概览「网络」岛入口，Pro 闸门，值式导航挂栈根）
- R2 SQL 查询控制台（CFAPIClient.postExternalJSON 独立主机；计费提示 + 500 行截断）
- Workers 密钥批量导入改走 secrets-bulk 原子 PATCH
- 缓存规则 vary 只读保护 + JA3/JA4 芯片（含 String(localized:) 修正）
- Localizable.xcstrings 13 语 45 新键、What's New 生成物

xcodebuild 全 scheme 编译通过，无版本不匹配 warning。在 #91 之后合并。