### PR TITLE
feat(web): 新增 /guides 板块与两篇英文指南

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-orange-to-orange/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-orange-to-orange/page.tsx
@@ -1,0 +1,391 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import O2OFlow from "@/components/guides/O2OFlow";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-orange-to-orange");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_O2O = "https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/";
+const DOCS_COMPAT = "https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What does orange to orange mean in Cloudflare?",
+		a: "It describes a request that passes through two Cloudflare zones instead of one: your own proxied hostname routes into a SaaS provider’s zone that also runs on Cloudflare. Both zones are “orange”, hence orange-to-orange.",
+	},
+	{
+		q: "Does O2O work with an A record?",
+		a: "No. O2O is triggered by a proxied CNAME record that matches a custom hostname on the provider’s zone. Apex proxying, which uses A records pointing at the provider’s addresses, does not enable O2O.",
+	},
+	{
+		q: "Which zone’s settings win in an O2O setup?",
+		a: "Your zone runs first and its settings generally override the provider’s. The provider’s zone then applies its own configuration to whatever your zone forwarded, so a request has to survive both.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "The prerequisite: proxied vs DNS only, which records qualify, and which ports the proxy covers.",
+	},
+	{
+		href: DOCS_O2O,
+		label: "Cloudflare docs: How O2O works",
+		note: "The official reference for the routing behaviour, prerequisites, and the cf-connecting-o2o header.",
+		external: true,
+	},
+	{
+		href: DOCS_COMPAT,
+		label: "Cloudflare docs: O2O product compatibility",
+		note: "The authoritative per-product table this guide summarises. Check it before changing anything.",
+		external: true,
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function OrangeToOrangeGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="Two Cloudflare zones, one request. Here is what triggers it, how the request actually travels, and which zone’s configuration wins."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>Orange-to-Orange (O2O) is a request that crosses two Cloudflare zones.</strong> Your
+						proxied hostname points at a SaaS platform that also runs on Cloudflare, so your settings are
+						applied first and the provider’s second, before the request reaches their origin.
+					</p>
+				</div>
+
+				<p>
+					If you run a Shopify store, a Webflow site, or any platform built on Cloudflare for SaaS, and your
+					own domain is on Cloudflare too, you are probably in an orange to orange setup — whether or not
+					anyone told you. It explains a class of confusing behaviour: a cache rule that does nothing, a
+					redirect that loops, a WAF rule that fires in a dashboard you cannot see.
+				</p>
+
+				<h2 id="prerequisite">First, the orange cloud</h2>
+				<p>
+					In Cloudflare, a DNS record marked with the orange cloud is <em>proxied</em>: queries return
+					Cloudflare anycast addresses and HTTP traffic passes through Cloudflare before it reaches an
+					origin. A gray cloud means DNS only. O2O is simply what happens when both ends of that path are
+					orange. If any of that is unfamiliar, start with{" "}
+					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
+						what the orange cloud means in Cloudflare
+					</Link>
+					.
+				</p>
+
+				<h2 id="when">When O2O happens</h2>
+				<p>All of the following have to be true at once:</p>
+				<ul>
+					<li>
+						Your SaaS provider uses{" "}
+						<a
+							href="https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Cloudflare for SaaS
+						</a>{" "}
+						and has created your hostname as a <strong>custom hostname</strong> in their zone.
+					</li>
+					<li>Your domain’s authoritative DNS is Cloudflare — you have your own zone.</li>
+					<li>
+						That zone holds a <strong>CNAME record matching the custom hostname</strong>, pointing at the
+						target the provider gave you, and it is <strong>proxied</strong>.
+					</li>
+					<li>The two zones sit in <strong>different Cloudflare accounts</strong>.</li>
+				</ul>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Type</th>
+								<th scope="col">Name</th>
+								<th scope="col">Target</th>
+								<th scope="col">Proxy status</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>CNAME</td>
+								<td>shop</td>
+								<td>customers.saasprovider.example</td>
+								<td>Proxied</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Two things that do <em>not</em> produce O2O: an A record pointing at the provider’s addresses
+					(apex proxying is not CNAME-based, so it never triggers O2O), and a gray-clouded CNAME — that is
+					an ordinary custom hostname, where only the provider’s zone has any say. O2O also refuses to chain
+					further: traffic that has entered one custom-hostname zone will not be routed onward into
+					another.
+				</p>
+
+				<h2 id="flow">How the request actually travels</h2>
+				<O2OFlow />
+				<ol>
+					<li>
+						A visitor resolves your hostname. Because your record is proxied, they get Cloudflare anycast
+						addresses and connect to the nearest Cloudflare data centre.
+					</li>
+					<li>
+						<strong>Your zone processes the request first.</strong> Your WAF rules, cache configuration,
+						redirects, and Workers run here, on your plan, visible in your analytics.
+					</li>
+					<li>
+						The request is handed to the <strong>provider’s zone inside Cloudflare’s network</strong> — it
+						does not exit to the public internet and come back. On the way in, Cloudflare stamps the
+						request with the header <code>cf-connecting-o2o: 1</code>, which is how the provider (in their
+						origin or a Worker) can tell O2O traffic apart.
+					</li>
+					<li>
+						<strong>The provider’s zone processes it second</strong>, applying their security and caching
+						configuration, and then forwards it to their origin — the servers that actually render your
+						store or site.
+					</li>
+				</ol>
+
+				<h2 id="who-wins">Which zone’s configuration wins</h2>
+				<p>
+					The governing rule from Cloudflare is short: <strong>settings on your zone override settings on
+					the provider’s zone</strong>. In practice a request has to survive both, and each product falls
+					into one of four buckets.
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Where it takes effect</th>
+								<th scope="col">Products</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Both zones — yours first, theirs second</th>
+								<td>
+									Access, WAF custom rules, WAF managed rules, Bot Management, Browser Integrity Check,
+									Security Level, Waiting Room, Client-side Security (Page Shield), Image resizing, IPv6
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">Your zone only</th>
+								<td>API Shield, Zaraz</td>
+							</tr>
+							<tr>
+								<th scope="row">Provider’s zone only</th>
+								<td>
+									Argo Smart Routing, Load Balancing, Origin Rules — your zone can still use Argo and
+									Load Balancing for hostnames that are not on O2O
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">Neither</th>
+								<td>Spectrum, WebSockets, Rocket Loader, China Network</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>Several products work on your side but deserve care before you touch them:</p>
+				<ul>
+					<li>
+						<strong>Cache.</strong> Supported, and generally discouraged for HTML. Your provider very
+						likely caches outside Cloudflare, so caching in your zone invites stale or out-of-sync
+						content. Caching hostnames that do <em>not</em> route to the provider is fine.
+					</li>
+					<li>
+						<strong>Workers, Page Rules, Transform Rules, Rate Limiting.</strong> All run in your zone, and
+						all can block or distort traffic on the O2O hostname if the rule matches it. Scope rules to
+						hostnames you actually own end to end.
+					</li>
+					<li>
+						<strong>Polish.</strong> Only optimises cached assets, so if your zone bypasses cache for
+						provider-bound traffic there is nothing for it to optimise.
+					</li>
+					<li>
+						<strong>DNS.</strong> Keep the records that make the setup work. Deleting the CNAME does not
+						just break routing — it tells the provider you are gone, and the custom hostname moves to a
+						removed state.
+					</li>
+					<li>
+						<strong>HTTP/2 prioritization and IPv6 compatibility</strong> depend on matching settings
+						across the two zones to behave as expected.
+					</li>
+				</ul>
+				<p>
+					This summary compresses Cloudflare’s per-product table; before you rely on any single row, check{" "}
+					<a href={DOCS_COMPAT} target="_blank" rel="noopener noreferrer">
+						the official compatibility list
+					</a>
+					, which is updated as products change.
+				</p>
+
+				<h2 id="detect">How to tell whether a hostname is on O2O</h2>
+				<p>
+					There is no zone setting or API field that reports “O2O is on” — it is per-request routing
+					behaviour that falls out of your DNS configuration. So you check the inputs:
+				</p>
+				<ul>
+					<li>
+						<strong>Your DNS.</strong> Is the record a CNAME, pointing at a target the provider gave you,
+						and proxied? For some providers the Cloudflare dashboard even shows their icon next to the
+						record.
+					</li>
+					<li>
+						<strong>Resolution.</strong> <code>dig +short shop.example.com</code> returns Cloudflare
+						anycast addresses rather than the provider’s — expected, and confirms the record is proxied.
+					</li>
+					<li>
+						<strong>The provider’s side.</strong> If you are the SaaS provider, look for{" "}
+						<code>cf-connecting-o2o: 1</code> on inbound requests, at your origin or in a Worker. That
+						header is set only on requests entering your zone through O2O.
+					</li>
+					<li>
+						<strong>Your analytics.</strong> Traffic for that hostname shows up in your own zone’s HTTP
+						analytics, because your zone genuinely sees the request first.
+					</li>
+				</ul>
+
+				<h2 id="failures">What goes wrong</h2>
+				<h3>Certificates stop renewing after you enable Always Use HTTPS</h3>
+				<p>
+					A classic, and documented for{" "}
+					<a
+						href="https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Shopify in particular
+					</a>
+					. Providers often validate certificates over HTTP-01, which requires{" "}
+					<code>/.well-known/acme-challenge/*</code> to be reachable over plain HTTP. Always Use HTTPS
+					redirects that path too, so validation fails and the certificate is never issued or renewed. Use a
+					redirect rule that enforces HTTPS while excluding the ACME path instead.
+				</p>
+				<h3>Redirect loops or blank pages after adding a rule</h3>
+				<p>
+					Look at what your own zone applies to that hostname: a Page Rule, Transform Rule, Redirect, or
+					Worker that matches the O2O subdomain. Your zone runs first, so a rewrite or redirect there is
+					applied to traffic the provider expects to receive untouched.
+				</p>
+				<h3>Cache hit rate is far lower than expected</h3>
+				<p>
+					If the provider’s zone has Bot Management enabled, its <code>__cf_bm</code> cookie comes back in a{" "}
+					<code>Set-Cookie</code> response header — and a response with <code>Set-Cookie</code> is not
+					cached by default in your zone. The result is an eyeball-facing zone that caches far less than you
+					planned.
+				</p>
+				<h3>A feature you enabled seems to do nothing</h3>
+				<p>
+					Check the bucket table above. Load Balancing, Origin Rules, Argo Smart Routing, WebSockets and
+					Spectrum are not yours to control on an O2O hostname; that configuration belongs to the provider.
+				</p>
+				<h3>The provider cannot activate your custom hostname</h3>
+				<p>
+					If your zone is on an Enterprise plan with a zone hold enabled, activation is refused and the
+					provider sees an error saying the hostname belongs to a held zone. Release the hold temporarily
+					(including the subdomain option, if you are onboarding a subdomain) and retry.
+				</p>
+				<h3>Error 1014</h3>
+				<p>
+					A cross-account CNAME to another Cloudflare zone is banned unless the target owner is using
+					Cloudflare for SaaS. If you see{" "}
+					<a
+						href="https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Error 1014
+					</a>
+					, the hostname was never onboarded on the provider’s side — that is not an O2O configuration
+					problem, it is a missing custom hostname.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/page.tsx
+++ b/apps/web/src/app/[locale]/guides/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import HorizonArc from "@/components/HorizonArc";
+import { GUIDES, GUIDES_INDEX, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: GUIDES_INDEX.title,
+	description: GUIDES_INDEX.description,
+	alternates: {
+		canonical: "/guides",
+		languages: { en: "/guides", "x-default": "/guides" },
+	},
+	openGraph: {
+		title: GUIDES_INDEX.title,
+		description: GUIDES_INDEX.description,
+		url: "/guides",
+		siteName: "Orange Cloud",
+		type: "website",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: "Orange Cloud" }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: GUIDES_INDEX.title,
+		description: GUIDES_INDEX.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function GuidesIndexPage({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	// 指南只有英文版：其它语言前缀不提供内容，避免稀薄的机翻页与软 404
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = {
+		"@context": "https://schema.org",
+		"@type": "CollectionPage",
+		name: GUIDES_INDEX.h1,
+		description: GUIDES_INDEX.description,
+		url: `${SITE_URL}/guides`,
+		inLanguage: "en",
+		hasPart: GUIDES.map((guide) => ({
+			"@type": "TechArticle",
+			headline: guide.h1,
+			url: `${SITE_URL}/guides/${guide.slug}`,
+		})),
+	};
+
+	return (
+		<div className="guides theme-light sky-band band-dawn dawn-glow flex min-h-screen flex-col overflow-x-clip">
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<SiteHeader hideLocaleSwitcher />
+			<main className="relative mx-auto w-full max-w-[760px] flex-1 px-6 pb-20 pt-32">
+				<h1 className="f-display text-[34px] font-bold t-primary sm:text-[40px]">{GUIDES_INDEX.h1}</h1>
+				<p className="mt-4 max-w-[56ch] text-[17px] leading-relaxed t-secondary">
+					{GUIDES_INDEX.description}
+				</p>
+				<HorizonArc className="mt-9" />
+
+				<div className="mt-10 grid gap-4">
+					{GUIDES.map((guide) => (
+						<Link
+							key={guide.slug}
+							href={`/guides/${guide.slug}`}
+							className="glass r-island block p-6 no-underline transition-transform duration-150 ease-out hover:scale-[1.008] active:scale-[0.995]"
+						>
+							<h2 className="f-display text-[21px] font-bold leading-snug t-primary">{guide.h1}</h2>
+							<p className="mt-2.5 text-[15px] leading-relaxed t-secondary">{guide.blurb}</p>
+							<p className="mt-4 text-[13px] t-tertiary">{guide.readingTime}</p>
+						</Link>
+					))}
+				</div>
+			</main>
+			<SiteFooter />
+		</div>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -1,0 +1,446 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("what-is-the-orange-cloud-in-cloudflare");
+const PATH = `/guides/${guide.slug}`;
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What does the orange cloud mean in Cloudflare?",
+		a: "It means that DNS record is proxied. Cloudflare answers queries for the hostname with its own anycast IP addresses, so HTTP and HTTPS requests reach Cloudflare first and your Cloudflare settings — caching, WAF, rules — apply before the request is passed to your origin server.",
+	},
+	{
+		q: "What’s the difference between the orange cloud and the grey cloud?",
+		a: "The orange cloud proxies traffic through Cloudflare; the gray cloud — spelled grey outside the US, and labelled DNS only in the dashboard — does not. A gray-clouded record returns your origin IP address, so visitors connect straight to your server, and no caching, WAF, or HTTP analytics apply to those requests.",
+	},
+	{
+		q: "Should the orange cloud be on or off?",
+		a: "On for any A, AAAA, or CNAME record that serves your website or API over HTTP/HTTPS. Off for mail hostnames, domain-verification records, SSH and other non-HTTP services, and endpoints a third party has to reach at your real IP address.",
+	},
+	{
+		q: "Why can’t I turn on the orange cloud for my MX record?",
+		a: "Only A, AAAA, and CNAME records can be proxied. MX, TXT, NS, SRV, and every other type stay DNS only, because Cloudflare’s proxy handles HTTP and HTTPS traffic and has no anycast address to substitute for those record types.",
+	},
+	{
+		q: "Does the orange cloud hide my origin IP?",
+		a: "For that hostname, yes — queries return Cloudflare anycast addresses instead of your server’s address. It does not help if another record in the same zone, such as a mail, FTP, or legacy subdomain record, still publishes the same origin IP.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/cloudflare-orange-to-orange",
+		label: "Cloudflare Orange-to-Orange (O2O), explained",
+		note: "What happens when your proxied hostname points at another Cloudflare zone — the Cloudflare for SaaS case.",
+	},
+	{
+		href: "https://developers.cloudflare.com/dns/proxy-status/",
+		label: "Cloudflare docs: Proxy status",
+		note: "The official reference for proxied and DNS-only records, including limitations and use cases.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+const API_EXAMPLE = `curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/$RECORD_ID" \\
+  --request PATCH \\
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \\
+  --json '{"proxied": true}'`;
+
+export default async function OrangeCloudGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="One toggle in the Cloudflare dashboard decides whether your traffic goes through Cloudflare at all. Here is exactly what it changes."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>The orange cloud means a DNS record is proxied.</strong> Cloudflare answers queries for
+						that hostname with its own anycast IP addresses, and HTTP/HTTPS traffic passes through
+						Cloudflare on the way to your server. The gray cloud means DNS only: traffic goes straight to
+						your origin.
+					</p>
+				</div>
+
+				<p>
+					In the Cloudflare dashboard, every A, AAAA, and CNAME record has a small cloud icon next to it.
+					Orange means <em>proxied</em>. Gray — spelled grey in much of the world, and often searched that
+					way — means <em>DNS only</em>. It looks like a cosmetic toggle and it
+					is not: it decides whether Cloudflare is a CDN and firewall in front of your site, or merely the
+					place where your DNS records happen to live.
+				</p>
+
+				<h2 id="orange-vs-gray">Orange cloud vs gray cloud</h2>
+				<p>
+					The difference starts one step earlier than most people expect — at the DNS answer itself, before
+					any HTTP request exists.
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">&nbsp;</th>
+								<th scope="col">Orange cloud (proxied)</th>
+								<th scope="col">Gray cloud (DNS only)</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">DNS answer</th>
+								<td>Cloudflare anycast IP addresses</td>
+								<td>Your origin IP address</td>
+							</tr>
+							<tr>
+								<th scope="row">Traffic path</th>
+								<td>Visitor → Cloudflare → origin</td>
+								<td>Visitor → origin</td>
+							</tr>
+							<tr>
+								<th scope="row">Origin IP</th>
+								<td>Not published in DNS for that name</td>
+								<td>Published to anyone who queries</td>
+							</tr>
+							<tr>
+								<th scope="row">CDN caching</th>
+								<td>Yes</td>
+								<td>No</td>
+							</tr>
+							<tr>
+								<th scope="row">WAF, DDoS mitigation, bot rules</th>
+								<td>Applied at the edge</td>
+								<td>Not applied to HTTP traffic</td>
+							</tr>
+							<tr>
+								<th scope="row">Cloudflare TLS certificate</th>
+								<td>Cloudflare terminates TLS for visitors</td>
+								<td>Your origin serves its own certificate</td>
+							</tr>
+							<tr>
+								<th scope="row">Rules, Redirects, Workers routes</th>
+								<td>Run on the request</td>
+								<td>Never see the request</td>
+							</tr>
+							<tr>
+								<th scope="row">Analytics</th>
+								<td>Full HTTP/HTTPS analytics</td>
+								<td>DNS query analytics only</td>
+							</tr>
+							<tr>
+								<th scope="row">TTL</th>
+								<td>Fixed at Auto (300 s)</td>
+								<td>Whatever you set</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					One consequence is worth spelling out: a gray-clouded record publishes your server’s real address,
+					which is what makes “I moved to Cloudflare and still got hit directly” possible. Cloudflare can
+					only protect requests it actually receives.
+				</p>
+
+				<h2 id="which-records">Which records can be orange-clouded</h2>
+				<p>
+					Only <strong>A</strong>, <strong>AAAA</strong>, and <strong>CNAME</strong> records — the record
+					types that resolve a name to an address. MX, TXT, NS, SRV, CAA and the rest are always DNS only,
+					and the dashboard will not offer you a toggle for them. The reason is structural rather than
+					arbitrary: proxying works by handing out Cloudflare anycast addresses instead of yours, and there
+					is nothing to substitute in a TXT or MX record.
+				</p>
+				<p>Three behaviours that surprise people:</p>
+				<ul>
+					<li>
+						<strong>Mixed records on the same name are treated as proxied.</strong> If one A record for{" "}
+						<code>www</code> is orange and another is gray, Cloudflare proxies both.
+					</li>
+					<li>
+						<strong>Proxying is inherited along a CNAME chain.</strong> If a name anywhere in the chain is
+						proxied, the request is proxied.
+					</li>
+					<li>
+						<strong>Some CNAME targets are blocked from proxying on purpose.</strong> DKIM and validation
+						targets such as <code>dkim.amazonses.com</code>, <code>acm-validations.aws</code>, or
+						subdomains of <code>onmicrosoft.com</code> cannot be orange-clouded, because a proxied answer
+						would break the very check they exist for.
+					</li>
+				</ul>
+				<p>
+					Pointing a proxied record at a hostname in a <em>different</em> Cloudflare account is also
+					refused — that is{" "}
+					<a
+						href="https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Error 1014, CNAME Cross-User Banned
+					</a>
+					, unless the owner of the target has onboarded your hostname through Cloudflare for SaaS. That
+					sanctioned version is{" "}
+					<Link href="/guides/cloudflare-orange-to-orange">Orange-to-Orange routing</Link>.
+				</p>
+
+				<h2 id="ports">The proxy only covers certain HTTP and HTTPS ports</h2>
+				<p>
+					This is the single biggest trap for newcomers. The orange cloud is an HTTP/HTTPS reverse proxy,
+					not a general network tunnel. By default it handles these ports:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Protocol</th>
+								<th scope="col">Ports proxied by default</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">HTTP</th>
+								<td>
+									<code>80</code>, <code>8080</code>, <code>8880</code>, <code>2052</code>,{" "}
+									<code>2082</code>, <code>2086</code>, <code>2095</code>
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">HTTPS</th>
+								<td>
+									<code>443</code>, <code>2053</code>, <code>2083</code>, <code>2087</code>,{" "}
+									<code>2096</code>, <code>8443</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Everything outside that list — SSH on 22, RDP on 3389, SMTP on 25, a database port, a game
+					server, a dev server on 3000 — is not proxied. The hostname now resolves to Cloudflare, and
+					Cloudflare has no reason to forward a connection on those ports to your machine, so the
+					connection simply fails. Gray-cloud that hostname, or put it behind{" "}
+					<a
+						href="https://developers.cloudflare.com/spectrum/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Cloudflare Spectrum
+					</a>
+					, which does handle arbitrary TCP and UDP.
+				</p>
+				<p>
+					Note also that the alternate ports (<code>2052</code>, <code>2053</code>, <code>2082</code>,{" "}
+					<code>2083</code>, <code>2086</code>, <code>2087</code>, <code>2095</code>, <code>2096</code>,{" "}
+					<code>8880</code>, <code>8443</code>) are proxied but <em>not cached</em> by default. If you serve
+					a site on 8443 and wonder why the cache hit rate is zero, that is why.
+				</p>
+
+				<h2 id="when-gray">When the gray cloud is the right answer</h2>
+				<p>Reach for DNS only whenever the service on the other end is not plain HTTP/HTTPS to your own origin:</p>
+				<ul>
+					<li>
+						<strong>Mail.</strong> MX records cannot be proxied at all, and a hostname used for mail
+						delivery (<code>mail.example.com</code>) should stay gray. Cloudflare does not proxy SMTP on
+						port 25, so proxying the mail host points senders at Cloudflare and delivery stops.
+					</li>
+					<li>
+						<strong>Domain verification.</strong> Verification CNAMEs and TXT records must return the
+						exact value the third party expects; a proxied answer returns Cloudflare addresses and
+						verification fails.
+					</li>
+					<li>
+						<strong>Non-HTTP services.</strong> SSH, RDP, FTP, game servers, anything on a port outside
+						the list above.
+					</li>
+					<li>
+						<strong>Sites hosted on a SaaS platform</strong> that terminates its own TLS — Wix,
+						Squarespace, Webflow and similar — unless that platform is explicitly integrated with
+						Cloudflare. Two proxies both terminating TLS and both redirecting to HTTPS is how you get
+						certificate errors and redirect loops.
+					</li>
+					<li>
+						<strong>Endpoints validated by IP.</strong> If a partner allowlists your server’s address for
+						webhooks or API calls, proxying replaces it with Cloudflare’s.
+					</li>
+				</ul>
+				<p>
+					A rule of thumb: <em>if the hostname serves web traffic on a standard port and you control the
+					origin, orange-cloud it. Everything else stays gray.</em>
+				</p>
+
+				<h2 id="troubleshooting">When the toggle causes an error</h2>
+				<p>Most orange-cloud incidents look like one of these.</p>
+				<h3>SSH or a custom port stopped working right after you switched</h3>
+				<p>
+					Expected. That port is not proxied. Move the service to its own hostname and gray-cloud that
+					hostname, keeping the web hostname orange.
+				</p>
+				<h3>Mail stopped being delivered</h3>
+				<p>
+					Check whether the hostname your MX record points to is proxied. Give mail its own DNS-only
+					hostname rather than sharing the web hostname. (Cloudflare does try to save you here: if an MX
+					record points at a proxied name, it dynamically prepends <code>_dc-mx</code> to the answer so mail
+					bypasses the proxy — a safety net, not a design to rely on.)
+				</p>
+				<h3>522, 521, or 524 errors appeared</h3>
+				<p>
+					These only exist because traffic is now proxied: Cloudflare is reaching your origin and not
+					getting a usable answer. A 521 means the origin refused the connection, 522 means it timed out —
+					both usually a firewall that does not allow{" "}
+					<a href="https://www.cloudflare.com/ips/" target="_blank" rel="noopener noreferrer">
+						Cloudflare’s IP ranges
+					</a>
+					, or an origin that is down. A 524 means the origin accepted the connection but took longer than
+					the proxy read timeout to respond.
+				</p>
+				<h3>Redirect loop or certificate error appeared</h3>
+				<p>
+					Usually the{" "}
+					<a
+						href="https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						SSL/TLS encryption mode
+					</a>
+					: with <strong>Flexible</strong>, Cloudflare talks to your origin over plain HTTP, and an origin
+					that redirects HTTP to HTTPS will{" "}
+					<a
+						href="https://developers.cloudflare.com/ssl/troubleshooting/too-many-redirects/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						loop forever
+					</a>
+					. Use <strong>Full (strict)</strong> with a valid certificate on the origin.
+				</p>
+				<h3>Your origin IP leaked anyway</h3>
+				<p>
+					Look for the other records in the same zone — <code>mail</code>, <code>ftp</code>, <code>cpanel</code>,
+					a forgotten staging subdomain — that still point at the same server. Also remember that while a
+					newly added domain is still pending activation (up to 24 hours), records behave as DNS only even
+					when marked proxied; rotating the origin IP after activation closes that window.
+				</p>
+				<h3>Your app now sees Cloudflare addresses as the visitor IP</h3>
+				<p>
+					Expected: the origin’s peer is Cloudflare. Read the real client address from the{" "}
+					<code>CF-Connecting-IP</code> header (or <code>X-Forwarded-For</code>) instead of the socket.
+				</p>
+
+				<h2 id="how-to-switch">How to switch it</h2>
+				<p>
+					<strong>In the dashboard:</strong> open your domain, go to <strong>DNS → Records</strong>, select{" "}
+					<strong>Edit</strong> on the record, and click the cloud under <strong>Proxy status</strong>. It
+					takes effect at Cloudflare immediately, though resolvers may hold the previous answer for up to
+					five minutes.
+				</p>
+				<p>
+					<strong>Over the API:</strong> proxy status is the <code>proxied</code> boolean on the DNS record.
+					A partial update is enough:
+				</p>
+				<pre>
+					<code>{API_EXAMPLE}</code>
+				</pre>
+				<p>
+					<strong>From your phone:</strong> that toggle is the reason this site exists —{" "}
+					<Link href="/">Orange Cloud</Link> is a native iOS and Android client for Cloudflare, and flipping
+					proxy status is one tap in the DNS list.
+				</p>
+
+				<h2 id="both-orange">What if both ends are orange?</h2>
+				<p>
+					If your proxied record points at a hostname that is itself proxied by Cloudflare — typically a
+					SaaS platform using Cloudflare for SaaS, such as a Shopify store on your own domain — the request
+					crosses two Cloudflare zones, and both sets of settings apply in a defined order. Cloudflare calls
+					this Orange-to-Orange, or O2O, and it has its own rules about which zone wins:{" "}
+					<Link href="/guides/cloudflare-orange-to-orange">
+						Cloudflare Orange-to-Orange (O2O), explained
+					</Link>
+					.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -381,3 +381,150 @@ body {
 	background: linear-gradient(180deg, #120d0a 0%, #0a0a0e 100%);
 	--demo-glow: radial-gradient(circle, rgba(244, 129, 32, 0.15) 0%, rgba(244, 129, 32, 0) 70%);
 }
+
+/* ---------- 指南长文排版（/guides）
+   正文按长文阅读优化：行宽 ~68 字符、层级清晰、表格与代码块自带横滚。
+   颜色全部走主题 token，亮/暗两套都成立 ---------- */
+
+.prose {
+	font-size: 17px;
+	line-height: 1.72;
+	color: var(--t-primary);
+}
+.prose > * + * {
+	margin-top: 1.1em;
+}
+.prose h2 {
+	font-family: ui-rounded, -apple-system, system-ui, sans-serif;
+	font-size: 26px;
+	font-weight: 700;
+	letter-spacing: 0.2px;
+	line-height: 1.28;
+	margin-top: 2.1em;
+	scroll-margin-top: 88px;
+}
+.prose h3 {
+	font-size: 19px;
+	font-weight: 650;
+	line-height: 1.4;
+	margin-top: 1.9em;
+}
+.prose h2 + *,
+.prose h3 + * {
+	margin-top: 0.7em;
+}
+.prose strong {
+	font-weight: 650;
+}
+.prose ul,
+.prose ol {
+	padding-inline-start: 1.3em;
+}
+.prose ul {
+	list-style: disc;
+}
+.prose ol {
+	list-style: decimal;
+}
+.prose li + li {
+	margin-top: 0.5em;
+}
+.prose li::marker {
+	color: var(--oc-orange);
+}
+.prose a {
+	color: var(--link);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+	text-decoration-thickness: 0.06em;
+	text-decoration-color: color-mix(in srgb, var(--link) 45%, transparent);
+}
+.prose a:hover {
+	text-decoration-color: var(--link);
+}
+.theme-light {
+	/* 品牌橙原色在浅底上仅 ~2.4:1，正文链接改用同色系深值（≥4.5:1） */
+	--link: #a85a08;
+	--code-bg: rgba(31, 18, 8, 0.06);
+}
+.theme-dark {
+	--link: #ffa657;
+	--code-bg: rgba(255, 255, 255, 0.08);
+}
+.prose code {
+	font-family: ui-monospace, "SF Mono", Menlo, monospace;
+	font-size: 0.88em;
+	background: var(--code-bg);
+	border-radius: 6px;
+	padding: 0.12em 0.4em;
+}
+.prose pre {
+	overflow-x: auto;
+	background: var(--code-bg);
+	border-radius: 14px;
+	padding: 16px 18px;
+	font-size: 13.5px;
+	line-height: 1.6;
+}
+.prose pre code {
+	background: none;
+	padding: 0;
+	font-size: inherit;
+}
+.prose blockquote {
+	border-inline-start: 2px solid var(--oc-orange);
+	padding-inline-start: 16px;
+	color: var(--t-secondary);
+}
+
+/* 表格：整体横向可滚，避免窄屏撑破版心 */
+.table-wrap {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+}
+.prose table {
+	width: 100%;
+	min-width: 480px;
+	border-collapse: collapse;
+	font-size: 15px;
+	line-height: 1.5;
+}
+.prose th,
+.prose td {
+	text-align: start;
+	vertical-align: top;
+	padding: 11px 14px;
+	border-bottom: 0.5px solid var(--divider);
+}
+.prose thead th {
+	font-weight: 650;
+	border-bottom: 1px solid var(--divider);
+	white-space: nowrap;
+}
+.prose tbody th {
+	font-weight: 600;
+}
+.prose tbody tr:last-child th,
+.prose tbody tr:last-child td {
+	border-bottom: none;
+}
+.prose .table-wrap table {
+	margin: 0;
+}
+
+/* 文内玻璃岛（答案框 / 提示） */
+.prose .note {
+	font-size: 15.5px;
+	line-height: 1.65;
+}
+.prose .note > * + * {
+	margin-top: 0.7em;
+}
+
+/* 键盘焦点在天色背景上始终可见（只作用于指南板块，不动既有页面） */
+.guides a:focus-visible,
+.guides button:focus-visible {
+	outline: 2px solid var(--oc-orange);
+	outline-offset: 2px;
+	border-radius: 4px;
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { routing } from "@/i18n/routing";
+import { GUIDES, GUIDE_LOCALE } from "@/lib/guides/guides";
 
 const SITE_URL = "https://o-c.do";
 
@@ -11,11 +12,22 @@ function urlFor(locale: string, path: string) {
 export default function sitemap(): MetadataRoute.Sitemap {
 	const pages = ["", "/privacy", "/terms", "/contact"];
 
-	return pages.map((path) => ({
+	const localized: MetadataRoute.Sitemap = pages.map((path) => ({
 		url: urlFor(routing.defaultLocale, path) || SITE_URL,
 		lastModified: new Date(),
 		alternates: {
 			languages: Object.fromEntries(routing.locales.map((locale) => [locale, urlFor(locale, path)])),
 		},
 	}));
+
+	// 指南板块只有英文版：不列 alternates，避免指向不存在的语言版本
+	const guides: MetadataRoute.Sitemap = [
+		{ url: urlFor(GUIDE_LOCALE, "/guides"), lastModified: new Date(GUIDES[0].updated) },
+		...GUIDES.map((guide) => ({
+			url: urlFor(GUIDE_LOCALE, `/guides/${guide.slug}`),
+			lastModified: new Date(guide.updated),
+		})),
+	];
+
+	return [...localized, ...guides];
 }

--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -1,9 +1,11 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 
 /** 页脚：纯内容、不带天色——颜色全部取自所在 theme 上下文 */
 export default async function SiteFooter() {
 	const t = await getTranslations("footer");
+	// 指南板块目前只有英文版，只在英文页脚露出入口（也是 /guides 的抓取入口）
+	const locale = await getLocale();
 
 	return (
 		<footer className="relative">
@@ -14,6 +16,11 @@ export default async function SiteFooter() {
 				<div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
 					<p className="text-[13px] t-secondary">{t("copyright")}</p>
 					<nav className="flex items-center gap-6 text-[13px]">
+						{locale === "en" && (
+							<Link href="/guides" className="link-quiet">
+								Guides
+							</Link>
+						)}
 						<Link href="/privacy" className="link-quiet">
 							{t("privacy")}
 						</Link>

--- a/apps/web/src/components/SiteHeader.tsx
+++ b/apps/web/src/components/SiteHeader.tsx
@@ -7,8 +7,13 @@ import { APP_STORE_URL, APP_STORE_COMING } from "./AppStoreBadge";
 export const GITHUB_URL = "https://github.com/chen2he/orange-cloud";
 export const KOFI_URL = "https://ko-fi.com/chen2he";
 
-/** 顶部导航：绝对定位浮在天色上，不做 sticky */
-export default async function SiteHeader() {
+/** 顶部导航：绝对定位浮在天色上，不做 sticky。
+ *  hideLocaleSwitcher：指南文章只有英文版，切语言会落到 404，故在这些页面隐藏切换器。 */
+export default async function SiteHeader({
+	hideLocaleSwitcher = false,
+}: {
+	hideLocaleSwitcher?: boolean;
+} = {}) {
 	const t = await getTranslations("header");
 
 	return (
@@ -26,7 +31,7 @@ export default async function SiteHeader() {
 					<span className="f-display text-[17px] font-bold t-primary">Orange Cloud</span>
 				</Link>
 				<div className="flex items-center gap-3">
-					<LocaleSwitcher label={t("language")} />
+					{!hideLocaleSwitcher && <LocaleSwitcher label={t("language")} />}
 					<a
 						href={GITHUB_URL}
 						aria-label="GitHub"

--- a/apps/web/src/components/guides/GuideShell.tsx
+++ b/apps/web/src/components/guides/GuideShell.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from "react";
+import { Link } from "@/i18n/navigation";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import HorizonArc from "@/components/HorizonArc";
+import Stars from "@/components/Stars";
+import { APP_STORE_URL } from "@/components/AppStoreBadge";
+
+export type RelatedLink = {
+	href: string;
+	label: string;
+	note: string;
+	external?: boolean;
+};
+
+/**
+ * 指南文章外壳：沿用首页「一天」的天色叙事——
+ * 晨（标题）→ 昼（正文）→ 黄昏（延伸阅读）→ 日落缝 → 夜（产品 + 页脚）。
+ * 正文版心 760px（约 68 字符/行），为长文阅读而非营销页留白。
+ */
+export default function GuideShell({
+	title,
+	lede,
+	updated,
+	readingTime,
+	related,
+	children,
+}: {
+	title: string;
+	lede: string;
+	updated: string;
+	readingTime: string;
+	related: RelatedLink[];
+	children: ReactNode;
+}) {
+	const updatedLabel = new Date(`${updated}T00:00:00Z`).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+		timeZone: "UTC",
+	});
+
+	return (
+		<>
+			<div className="guides theme-light">
+				{/* —— 标题 · 清晨 —— */}
+				<section className="sky-band band-dawn dawn-glow overflow-hidden">
+					<SiteHeader hideLocaleSwitcher />
+					<div className="relative mx-auto w-full max-w-[760px] px-6 pb-12 pt-32">
+						<nav aria-label="Breadcrumb" className="text-[13px]">
+							<ol className="flex flex-wrap items-center gap-2 t-secondary">
+								<li>
+									<Link href="/guides" className="link-quiet underline underline-offset-2">
+										Guides
+									</Link>
+								</li>
+								<li aria-hidden="true">/</li>
+								<li className="t-tertiary">{title}</li>
+							</ol>
+						</nav>
+						<h1 className="f-display mt-4 text-[34px] font-bold leading-[1.15] t-primary sm:text-[40px]">
+							{title}
+						</h1>
+						<p className="mt-4 text-[18px] leading-relaxed t-secondary">{lede}</p>
+						<p className="mt-5 text-[13px] t-tertiary">
+							Updated {updatedLabel} · {readingTime}
+						</p>
+						<HorizonArc className="mt-10" />
+					</div>
+				</section>
+
+				{/* —— 正文 · 白昼 —— */}
+				<section className="sky-band band-morning">
+					<article className="prose mx-auto w-full max-w-[760px] px-6 pb-20 pt-10">{children}</article>
+				</section>
+
+				{/* —— 延伸阅读 · 黄昏 —— */}
+				<section className="sky-band band-dusk">
+					<div className="mx-auto w-full max-w-[760px] px-6 py-16">
+						<h2 className="f-display text-[24px] font-bold t-primary">Keep reading</h2>
+						<div className="mt-6 grid gap-3">
+							{related.map((item) =>
+								item.external ? (
+									<a
+										key={item.href}
+										href={item.href}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="glass r-island block p-5 no-underline"
+									>
+										<span className="block text-[16px] font-semibold t-primary">{item.label} ↗</span>
+										<span className="mt-1.5 block text-[14px] leading-relaxed t-secondary">{item.note}</span>
+									</a>
+								) : (
+									<Link key={item.href} href={item.href} className="glass r-island block p-5 no-underline">
+										<span className="block text-[16px] font-semibold t-primary">{item.label}</span>
+										<span className="mt-1.5 block text-[14px] leading-relaxed t-secondary">{item.note}</span>
+									</Link>
+								),
+							)}
+						</div>
+					</div>
+				</section>
+			</div>
+
+			{/* —— 日落缝：把页面从昼带入夜 —— */}
+			<div className="guides band-sunset relative h-[180px] overflow-hidden" aria-hidden="true">
+				<div
+					className="absolute left-1/2 top-[46%] h-[130px] w-[760px] max-w-[160vw] -translate-x-1/2 -translate-y-1/2"
+					style={{
+						borderRadius: "50%",
+						background: "radial-gradient(50% 50% at 50% 50%, rgba(255,200,130,0.5) 0%, rgba(255,170,90,0) 70%)",
+					}}
+				/>
+				<div
+					className="absolute left-1/2 top-[46%] h-7 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full"
+					style={{ background: "#FFDCAC", boxShadow: "0 0 40px 13px rgba(255,180,100,0.65)" }}
+				/>
+			</div>
+
+			{/* —— 产品 + 页脚 · 夜 —— */}
+			<div className="guides theme-dark">
+				<section className="sky-band band-night relative">
+					<Stars />
+					<div className="relative mx-auto w-full max-w-[760px] px-6 pt-16">
+						<div className="glass r-island p-7 sm:p-8">
+							<h2 className="f-display text-[22px] font-bold t-primary">Manage this from your phone</h2>
+							<p className="mt-2.5 text-[15px] leading-relaxed t-secondary">
+								Orange Cloud is a native iOS and Android client for Cloudflare. Sign in with Cloudflare
+								OAuth and flip proxy status, edit DNS records, and read traffic analytics from anywhere.
+							</p>
+							<a href={APP_STORE_URL} className="cta-store mt-6 text-[15px]">
+								Get Orange Cloud
+							</a>
+						</div>
+					</div>
+					<div className="relative mt-12">
+						<SiteFooter />
+					</div>
+				</section>
+			</div>
+		</>
+	);
+}

--- a/apps/web/src/components/guides/O2OFlow.tsx
+++ b/apps/web/src/components/guides/O2OFlow.tsx
@@ -1,0 +1,91 @@
+/**
+ * O2O 请求流转图：访客 → 客户 zone → SaaS 提供方 zone → 提供方源站。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function O2OFlow() {
+	const box = (y: number) => ({ x: 30, y, width: 300, height: 54, rx: 14 });
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 408"
+				role="img"
+				aria-label="Request flow in an Orange-to-Orange setup: a visitor request reaches the customer's Cloudflare zone first, is routed inside Cloudflare to the SaaS provider's zone with the cf-connecting-o2o header set, and is then sent to the SaaS provider's origin server."
+				className="mx-auto block h-auto w-full max-w-[420px]"
+			>
+				<title>Orange-to-Orange request flow</title>
+
+				{/* Cloudflare 网络：两个 zone 在同一张网内，请求不出网再回来 */}
+				<rect
+					x="14"
+					y="98"
+					width="332"
+					height="212"
+					rx="20"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.35"
+					strokeDasharray="4 5"
+				/>
+				<text x="180" y="118" textAnchor="middle" fontSize="11" fill="var(--t-tertiary)" letterSpacing="0.6">
+					INSIDE CLOUDFLARE
+				</text>
+
+				{/* 1 · 访客 */}
+				<rect {...box(20)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="52" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Website visitor
+				</text>
+				<text x="180" y="68" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					resolves shop.example.com
+				</text>
+
+				{/* 2 · 客户 zone */}
+				<rect {...box(130)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="162" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Your zone (example.com)
+				</text>
+				<text x="180" y="178" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					your settings apply first
+				</text>
+
+				{/* 3 · SaaS 提供方 zone */}
+				<rect {...box(232)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="264" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					SaaS provider zone
+				</text>
+				<text x="180" y="280" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					provider settings apply second
+				</text>
+
+				{/* 4 · 提供方源站 */}
+				<rect {...box(342)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="374" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					SaaS provider origin
+				</text>
+				<text x="180" y="390" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					the platform that serves your store
+				</text>
+
+				<defs>
+					<marker id="o2o-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#o2o-arrow)" fill="none">
+					<path d="M180 74 L180 124" />
+					<path d="M180 184 L180 226" />
+					<path d="M180 286 L180 336" />
+				</g>
+
+				{/* 进入提供方 zone 时被打上的标记头 */}
+				<text x="188" y="212" fontSize="11.5" fill="var(--t-secondary)" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace">
+					cf-connecting-o2o: 1
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				Both hops happen inside Cloudflare’s network — the request does not leave and come back.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -1,0 +1,59 @@
+/**
+ * 指南板块（/guides）的清单——目前只有英文版：
+ * 这批查询（orange cloud / orange-to-orange）几乎全是英文，
+ * 不为不存在的语言写 hreflang，避免稀薄内容与软 404。
+ */
+export const GUIDE_LOCALE = "en";
+
+export type GuideMeta = {
+	slug: string;
+	/** 页面 H1 */
+	h1: string;
+	/** <title>（≤60 字符） */
+	title: string;
+	/** meta description（≤155 字符），首句即答案 */
+	description: string;
+	/** 索引页上的一句话摘要 */
+	blurb: string;
+	/** ISO 日期，用于 sitemap lastmod 与文章页「Updated」 */
+	updated: string;
+	readingTime: string;
+};
+
+export const GUIDES: GuideMeta[] = [
+	{
+		slug: "what-is-the-orange-cloud-in-cloudflare",
+		h1: "What Does the Orange Cloud Mean in Cloudflare?",
+		title: "Cloudflare Orange Cloud: Proxied vs DNS Only, Explained",
+		description:
+			"The orange cloud means a DNS record is proxied through Cloudflare. The gray cloud means DNS only. What changes, which records qualify, when to use each.",
+		blurb:
+			"Proxied vs DNS only: what the toggle actually changes, which record types and ports it covers, and how to read the errors it causes.",
+		updated: "2026-08-19",
+		readingTime: "8 min read",
+	},
+	{
+		slug: "cloudflare-orange-to-orange",
+		h1: "Cloudflare Orange-to-Orange (O2O), Explained",
+		title: "Cloudflare Orange-to-Orange (O2O), Explained",
+		description:
+			"Orange-to-Orange is when a proxied hostname routes through two Cloudflare zones — yours and your SaaS provider's. How requests flow and which zone's settings win.",
+		blurb:
+			"Two Cloudflare zones, one request: how O2O routing works with Cloudflare for SaaS, which zone each setting applies in, and what breaks.",
+		updated: "2026-08-19",
+		readingTime: "7 min read",
+	},
+];
+
+export function guideBySlug(slug: string): GuideMeta {
+	const guide = GUIDES.find((g) => g.slug === slug);
+	if (!guide) throw new Error(`Unknown guide: ${slug}`);
+	return guide;
+}
+
+export const GUIDES_INDEX = {
+	title: "Guides — Orange Cloud",
+	h1: "Guides",
+	description:
+		"Plain-language guides to the Cloudflare settings people actually search for: the orange cloud, proxy status, and Orange-to-Orange routing.",
+};

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,7 +1,26 @@
 import createMiddleware from "next-intl/middleware";
+import { NextResponse, type NextRequest } from "next/server";
 import { routing } from "./i18n/routing";
+import { GUIDE_LOCALE } from "./lib/guides/guides";
 
-export default createMiddleware(routing);
+const handleI18n = createMiddleware(routing);
+
+const GUIDES_PREFIX = "/guides";
+
+export default function middleware(request: NextRequest) {
+	const { pathname } = request.nextUrl;
+
+	// 指南板块目前只有英文版：跳过语言协商，否则中文浏览器打开 /guides 会被
+	// 重定向到 /zh-Hant/guides（不存在，落 404）。这里内部改写到 /en/…，
+	// 对外 URL 保持无前缀——与 as-needed 下默认语言的行为一致。
+	if (pathname === GUIDES_PREFIX || pathname.startsWith(`${GUIDES_PREFIX}/`)) {
+		const url = request.nextUrl.clone();
+		url.pathname = `/${GUIDE_LOCALE}${pathname}`;
+		return NextResponse.rewrite(url);
+	}
+
+	return handleI18n(request);
+}
 
 export const config = {
 	// 排除 OAuth 回调（/oauth/callback 必须原样直达 route handler）、


### PR DESCRIPTION
## 背景

Search Console（`sc-domain:o-c.do`，2026-06-01 → 08-19）显示两组查询给官网带来展示但几乎零点击——排名是靠域名和品牌名白捡的，站上没有一个页面在回答问题：

- `orange cloud` 420 次展示 / CTR 4.05% / 均排 9.1，落地页是产品首页，答非所问
- `what is orange cloud in cloudflare`、`cloudflare orange cloud meaning`、`cloudflare orange proxy` 等问句型长尾**全部零点击**
- `orange to orange` 主题簇 25 次展示 **0 点击**、排名 12–28，站上一个字都没提过

## 改动

- `/guides` 索引 + 两篇英文长文，技术论断逐条核对 Cloudflare 官方文档当前版本：
  - `what-is-the-orange-cloud-in-cloudflare`（1645 词）
  - `cloudflare-orange-to-orange`（1381 词，含请求流转 SVG 图）
- 版式沿用首页晨昏语言（晨 → 昼 → 黄昏 → 日落缝 → 夜），正文版心 760px 为长文优化；正文链接改用深橙 `#a85a08`（浅底上 4.61:1），表格自带横滚，焦点环限定 `.guides` 不动既有页面
- 结构化数据 `TechArticle` + `FAQPage` + `BreadcrumbList`；FAQ 可见文案与 JSON-LD 同源，逐字一致
- canonical 自引用，hreflang 只列真实存在的 `en`；sitemap 三条新 URL 带 `lastmod`、不列 alternates
- **middleware**：`/guides*` 跳过语言协商直接内部改写到 `/en/…`。否则中文浏览器打开英文 URL 会被重定向到 `/zh-Hant/guides` 落 404——这条不修，整个板块的流量作废
- 指南只有英文版：非 en 前缀 404、页脚入口只在英文露出、文章页隐藏语言切换器

## 核对官方文档后修正的技术点

- MX 不是「一代理就废」：MX 本身不可代理，且 MX 指向被代理主机名时 CF 会动态给应答加 `_dc-mx` 让邮件绕过代理
- 端口表按当前 Network ports 页重新取值，并补上多数文章漏掉的一点：其中 10 个端口默认**不缓存**
- 「隐藏源站 IP」加了两个限定：只对该记录成立；且 zone 激活前（最长 24h）代理不生效，官方因此建议激活后轮换源站 IP
- O2O 补两个前置条件：两个 zone 必须**分属不同 CF 账号**、且只认 CNAME（apex proxying 用 A 记录，永不触发）
- O2O 识别方法**删掉了「查响应头」**：`cf-connecting-o2o: 1` 是打在进入提供方 zone 的**请求**上，客户侧 curl 不到；官方也明说没有任何 API 字段 / zone 设置能反映 O2O
- 优先级表**去掉 SSL/TLS 模式**：官方兼容表里没有这一项，宁可不写

## 验证

构建无新增告警、129 个测试通过、ESLint 干净；三个 URL 均 200，canonical / hreflang / sitemap 正确；FAQ JSON-LD 与可见文本逐字一致（脚本断言）；标题层级无跳级、表格有表头、正文对比度 19:1、链接 4.61:1 且带下划线、键盘焦点环已验；375px 下无页面级横向滚动。已部署上线（Version 6bb93ff5）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)