### PR TITLE
feat(web): /guides 新增《Cloudflare SSL/TLS 加密模式怎么选》

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-orange-to-orange/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-orange-to-orange/page.tsx
@@ -36,6 +36,11 @@ const RELATED: RelatedLink[] = [
 		note: "The prerequisite: proxied vs DNS only, which records qualify, and which ports the proxy covers.",
 	},
 	{
+		href: "/guides/cloudflare-ssl-tls-encryption-modes",
+		label: "Which Cloudflare SSL/TLS encryption mode should you use?",
+		note: "Flexible, Full, Full (strict): what each does to the origin connection, and which error each one produces.",
+	},
+	{
 		href: DOCS_O2O,
 		label: "Cloudflare docs: How O2O works",
 		note: "The official reference for the routing behaviour, prerequisites, and the cf-connecting-o2o header.",

--- a/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
@@ -1,0 +1,406 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import TlsHops from "@/components/guides/TlsHops";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-ssl-tls-encryption-modes");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_MODES = "https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/";
+const DOCS_REDIRECTS = "https://developers.cloudflare.com/ssl/troubleshooting/too-many-redirects/";
+const DOCS_ORIGIN_CA = "https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What is the difference between Flexible and Full in Cloudflare?",
+		a: "Flexible sends requests to your origin over plain HTTP, so the second half of the journey is unencrypted and no origin certificate is needed. Full connects to the origin using the same scheme the visitor used, so an HTTPS request stays encrypted end to end — but the origin’s certificate is not checked.",
+	},
+	{
+		q: "Is Cloudflare Flexible SSL secure?",
+		a: "Only partially. Visitors see a valid padlock because the visitor-to-Cloudflare connection is encrypted, but traffic between Cloudflare and your origin travels in cleartext and can be read or modified in transit. Cloudflare advises against it for anything carrying logins or personal data.",
+	},
+	{
+		q: "Why does Cloudflare say ERR_TOO_MANY_REDIRECTS?",
+		a: "Usually because your encryption mode and your origin disagree about which scheme to use. On Flexible, Cloudflare requests HTTP and an origin that redirects all HTTP to HTTPS sends the request straight back, and the loop repeats until the browser gives up.",
+	},
+	{
+		q: "What is the difference between Full and Full (strict)?",
+		a: "Both encrypt the connection to your origin. Full accepts any certificate the origin presents, including expired, self-signed, or wrong-hostname ones. Full (strict) requires an unexpired certificate from a publicly trusted CA or Cloudflare Origin CA whose name matches the hostname.",
+	},
+	{
+		q: "Do I still need an SSL certificate on my origin if I use Cloudflare?",
+		a: "For every mode except Off and Flexible, yes. Cloudflare issues the certificate visitors see, but the connection from Cloudflare to your server needs its own certificate — a free Cloudflare Origin CA certificate satisfies Full (strict) and never has to be publicly trusted.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "The prerequisite: encryption modes only apply to records that are proxied in the first place.",
+	},
+	{
+		href: "/guides/cloudflare-orange-to-orange",
+		label: "Cloudflare Orange-to-Orange (O2O), explained",
+		note: "When your proxied hostname routes into a SaaS provider’s Cloudflare zone, and which zone’s settings win.",
+	},
+	{
+		href: DOCS_MODES,
+		label: "Cloudflare docs: Encryption modes",
+		note: "The official reference for every mode, the Automatic SSL/TLS rollout, and the API values.",
+		external: true,
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function EncryptionModesGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="One dropdown decides whether the second half of every request is encrypted. Here is what each option does, which errors each one produces, and why the choice may no longer be yours."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>Use Full (strict).</strong> It encrypts the Cloudflare-to-origin hop and validates your
+						origin certificate. <strong>Flexible</strong> sends plaintext to your origin and is the most
+						common cause of redirect loops. Most zones now choose the mode automatically.
+					</p>
+				</div>
+
+				<p>
+					The padlock in a visitor’s browser is not a statement about your server. It only says the browser
+					reached Cloudflare over HTTPS. What happens on the next leg — from Cloudflare to the machine that
+					actually holds your site — is a separate connection with separate rules, and the SSL/TLS encryption
+					mode is the setting that governs it.
+				</p>
+
+				<h2 id="two-connections">There are two connections, not one</h2>
+				<TlsHops />
+				<p>
+					Every proxied request is two hops. The first is secured by the edge certificate Cloudflare issues
+					and renews for you; there is nothing to choose there. The second is the one the encryption mode
+					controls: whether Cloudflare speaks HTTP or HTTPS to your origin, and how carefully it inspects the
+					certificate your origin presents.
+				</p>
+				<p>
+					This is also why the setting is invisible on some records. It only takes effect where Cloudflare is
+					in the path at all — a DNS-only record hands out your server’s real address and the browser
+					connects directly, so there is no second hop for the mode to govern. If that distinction is new,
+					start with{" "}
+					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
+						what the orange cloud means in Cloudflare
+					</Link>
+					.
+				</p>
+
+				<h2 id="modes">The five modes, side by side</h2>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Mode</th>
+								<th scope="col">Visitor → Cloudflare</th>
+								<th scope="col">Cloudflare → origin</th>
+								<th scope="col">Origin certificate checked</th>
+								<th scope="col">Choose it when</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Off</th>
+								<td>Cleartext — HTTPS is redirected down to HTTP</td>
+								<td>Cleartext</td>
+								<td>No</td>
+								<td>Never, in practice</td>
+							</tr>
+							<tr>
+								<th scope="row">Flexible</th>
+								<td>Encrypted</td>
+								<td>Cleartext</td>
+								<td>No</td>
+								<td>Your origin genuinely cannot serve TLS</td>
+							</tr>
+							<tr>
+								<th scope="row">Full</th>
+								<td>Encrypted</td>
+								<td>Matches the visitor’s scheme</td>
+								<td>No</td>
+								<td>The origin has a certificate, but not a valid public one</td>
+							</tr>
+							<tr>
+								<th scope="row">Full (strict)</th>
+								<td>Encrypted</td>
+								<td>Matches the visitor’s scheme</td>
+								<td>Yes</td>
+								<td>The default target for almost everyone</td>
+							</tr>
+							<tr>
+								<th scope="row">Strict (SSL-Only Origin Pull)</th>
+								<td>Either</td>
+								<td>Always encrypted</td>
+								<td>Yes</td>
+								<td>Enterprise zones wanting the strongest option</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Two rows deserve a second look. <strong>Full</strong> encrypts, but accepts whatever certificate
+					the origin offers — expired, self-signed, issued for a different hostname, all fine. That stops
+					passive eavesdropping and nothing else: an attacker positioned between Cloudflare and your origin
+					can present their own certificate and be believed. <strong>Full (strict)</strong> is the same
+					connection with the certificate actually verified, which is the difference between encryption and
+					authenticated encryption.
+				</p>
+				<p>
+					The last row is easy to miss because it is Enterprise-only. Unlike Full and Full (strict), which
+					mirror whatever scheme the visitor used, it connects to the origin over HTTPS even when the visitor
+					arrived over plain HTTP.
+				</p>
+
+				<h2 id="automatic">The choice may already have been made for you</h2>
+				<p>
+					Cloudflare has been rolling out <strong>Automatic SSL/TLS</strong>, and it is the default for zones
+					that have been migrated. Instead of a fixed setting, a crawler using the{" "}
+					<code>Cloudflare-SSLDetector</code> user agent fetches your site over both HTTP and HTTPS,
+					compares the responses, and picks the most secure mode your origin can actually support. Zones that
+					have not been migrated still show only the manual list.
+				</p>
+				<p>Four properties of that system are worth knowing before you go looking for the dropdown:</p>
+				<ul>
+					<li>
+						<strong>It never moves you to something less secure.</strong> If your origin certificate
+						expires, a zone on Full (strict) is not quietly demoted to Full — it stays put and starts
+						failing, which is the correct behaviour but means you still have to keep the certificate valid.
+					</li>
+					<li>
+						<strong>Upgrades ramp, they do not flip.</strong> A new mode starts on 1% of traffic and climbs
+						in 10% steps. If origin connectivity breaks on the way up, Cloudflare aborts and rolls back.
+						Moves from Flexible to Full or stricter go slower still, because changing the origin scheme
+						changes cache keys and the cache needs to warm.
+					</li>
+					<li>
+						<strong>Scans are roughly monthly</strong>, and stop once the zone is already on the most
+						secure mode available or you have switched to Custom SSL/TLS.
+					</li>
+					<li>
+						<strong>Notifications go to Super Admins only</strong>, as a weekly digest of upgraded zones.
+						If your account’s admin address is not one you read, upgrades will look like they came from
+						nowhere.
+					</li>
+				</ul>
+				<p>
+					To take manual control, switch the zone to Custom SSL/TLS — in the API that is the{" "}
+					<code>ssl_automatic_mode</code> zone setting set to <code>custom</code>. The mode itself remains
+					the <code>ssl</code> setting, with values <code>off</code>, <code>flexible</code>,{" "}
+					<code>full</code>, <code>strict</code>, and <code>origin_pull</code>. Note the naming trap:{" "}
+					<code>strict</code> is Full (strict), while the Enterprise SSL-only mode is{" "}
+					<code>origin_pull</code>.
+				</p>
+
+				<h2 id="flexible">Why Flexible causes so much trouble</h2>
+				<p>
+					Flexible is popular because it makes a padlock appear without touching the server. The costs show
+					up later.
+				</p>
+				<ul>
+					<li>
+						<strong>Redirect loops.</strong> Cloudflare requests your origin over HTTP. Most modern stacks
+						redirect all HTTP to HTTPS. Cloudflare follows that redirect back to itself, downgrades it to
+						HTTP again, and the browser reports{" "}
+						<a href={DOCS_REDIRECTS} target="_blank" rel="noopener noreferrer">
+							ERR_TOO_MANY_REDIRECTS
+						</a>
+						. The fix is to remove the origin’s HTTPS redirect or move to Full — not to add another rule.
+					</li>
+					<li>
+						<strong>Port 443 only.</strong> Flexible applies to HTTPS on the default port. HTTPS on any
+						other port falls back to Full behaviour, so a site served on a non-standard port can behave
+						differently from the rest of the zone for reasons nothing in the dashboard explains.
+					</li>
+					<li>
+						<strong>Authenticated Origin Pulls is unavailable.</strong> It does not work under Flexible or
+						Off, which rules out the standard way of proving to your origin that a request really came from
+						Cloudflare.
+					</li>
+					<li>
+						<strong>The traffic is readable.</strong> Anything between Cloudflare and your origin —
+						hosting network, transit provider, anyone who has got in the middle — sees session cookies and
+						form posts in cleartext.
+					</li>
+				</ul>
+
+				<h2 id="errors">Which error means which mode</h2>
+				<p>The failure tells you where to look, and the mapping is tight:</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">What you see</th>
+								<th scope="col">Mode in play</th>
+								<th scope="col">What it actually means</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Error 525</th>
+								<td>Full or Full (strict)</td>
+								<td>
+									The TLS handshake with your origin failed: no certificate, port 443 closed, missing
+									SNI support, or no shared cipher suite
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">Error 526</th>
+								<td>Full (strict)</td>
+								<td>
+									A certificate was presented but rejected — expired, revoked, self-signed, incomplete
+									chain, or the hostname does not match
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">ERR_TOO_MANY_REDIRECTS</th>
+								<td>Flexible</td>
+								<td>Your origin redirects HTTP to HTTPS while Cloudflare insists on HTTP</td>
+							</tr>
+							<tr>
+								<th scope="row">ERR_TOO_MANY_REDIRECTS</th>
+								<td>Full or Full (strict)</td>
+								<td>The mirror image: your origin redirects HTTPS down to HTTP</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Treat 526 as a certificate problem, not a reason to downgrade. Dropping to Full does clear the
+					error, and it clears it by no longer checking — the misconfiguration is still there, just silent.
+					An incomplete chain is a common culprit: your origin must serve the intermediate certificates
+					alongside the leaf, or Cloudflare cannot build a path to a trusted root even though the certificate
+					itself is fine.
+				</p>
+
+				<h2 id="upgrade">Moving to Full (strict) without an outage</h2>
+				<ol>
+					<li>
+						Put a certificate on the origin. A{" "}
+						<a href={DOCS_ORIGIN_CA} target="_blank" rel="noopener noreferrer">
+							Cloudflare Origin CA certificate
+						</a>{" "}
+						is free, lasts for years, and is trusted by Cloudflare specifically — it is not publicly
+						trusted, which is fine, because only Cloudflare ever validates it.
+					</li>
+					<li>
+						Confirm the origin answers on port 443, presents the full chain, and that the certificate’s
+						name covers the hostname being requested.
+					</li>
+					<li>
+						Remove any HTTP-to-HTTPS redirect at the origin. Cloudflare handles the visitor-facing
+						redirect; leaving one at the origin is what creates loops after the switch.
+					</li>
+					<li>
+						Switch to Full (strict) and watch for 525 and 526 in your analytics. Both are origin-side
+						failures, so the answer is always on the server, not in the dashboard.
+					</li>
+					<li>
+						If only one hostname needs a different mode, use a configuration rule rather than moving the
+						whole zone.
+					</li>
+				</ol>
+				<p>
+					One caveat when a hostname is served through a SaaS platform on Cloudflare: your zone is not the
+					only one applying settings, and the encryption mode you can see may not be the one deciding the
+					final hop. That situation has{" "}
+					<Link href="/guides/cloudflare-orange-to-orange">its own rules, covered here</Link>.
+				</p>
+				<p>
+					Modes change and their behaviour is occasionally revised; before relying on a specific row above,
+					check{" "}
+					<a href={DOCS_MODES} target="_blank" rel="noopener noreferrer">
+						the official encryption modes reference
+					</a>
+					.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -40,6 +40,11 @@ const RELATED: RelatedLink[] = [
 		note: "What happens when your proxied hostname points at another Cloudflare zone — the Cloudflare for SaaS case.",
 	},
 	{
+		href: "/guides/cloudflare-ssl-tls-encryption-modes",
+		label: "Which Cloudflare SSL/TLS encryption mode should you use?",
+		note: "Once a record is proxied, this setting decides whether the Cloudflare-to-origin hop is encrypted at all.",
+	},
+	{
 		href: "https://developers.cloudflare.com/dns/proxy-status/",
 		label: "Cloudflare docs: Proxy status",
 		note: "The official reference for proxied and DNS-only records, including limitations and use cases.",
@@ -386,7 +391,12 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 					>
 						loop forever
 					</a>
-					. Use <strong>Full (strict)</strong> with a valid certificate on the origin.
+					. Use <strong>Full (strict)</strong> with a valid certificate on the origin — the differences
+					between the modes, and which error each one produces, are in{" "}
+					<Link href="/guides/cloudflare-ssl-tls-encryption-modes">
+						the guide to Cloudflare’s encryption modes
+					</Link>
+					.
 				</p>
 				<h3>Your origin IP leaked anyway</h3>
 				<p>

--- a/apps/web/src/components/guides/TlsHops.tsx
+++ b/apps/web/src/components/guides/TlsHops.tsx
@@ -1,0 +1,83 @@
+/**
+ * SSL/TLS 加密模式作用范围图：访客 → Cloudflare → 源站两段连接，
+ * 加密模式只管第二段。纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；
+ * 竖版布局，窄屏不溢出。
+ */
+export default function TlsHops() {
+	const box = (y: number) => ({ x: 20, y, width: 320, height: 52, rx: 14 });
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 384"
+				role="img"
+				aria-label="A request passes over two separate connections: connection one runs from the visitor to Cloudflare and is secured by the edge certificate, and connection two runs from Cloudflare to the origin server. The SSL/TLS encryption mode setting controls only the second connection."
+				className="mx-auto block h-auto w-full max-w-[420px]"
+			>
+				<title>What the SSL/TLS encryption mode controls</title>
+
+				<defs>
+					<marker id="tls-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+
+				{/* 1 · 访客 */}
+				<rect {...box(14)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="46" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Website visitor
+				</text>
+
+				{/* 第一段连接：边缘证书 */}
+				<rect x="44" y="92" width="272" height="44" rx="12" fill="none" stroke="var(--divider)" />
+				<text x="180" y="110" textAnchor="middle" fontSize="12.5" fontWeight="600" fill="var(--t-primary)">
+					Connection 1
+				</text>
+				<text x="180" y="126" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					secured by the edge certificate
+				</text>
+
+				{/* 2 · Cloudflare */}
+				<rect {...box(162)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="194" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare
+				</text>
+
+				{/* 第二段连接：加密模式唯一作用的地方 */}
+				<rect
+					x="44"
+					y="240"
+					width="272"
+					height="52"
+					rx="12"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.6"
+					strokeDasharray="4 5"
+				/>
+				<text x="180" y="261" textAnchor="middle" fontSize="12.5" fontWeight="600" fill="var(--t-primary)">
+					Connection 2
+				</text>
+				<text x="180" y="278" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					the encryption mode controls this hop
+				</text>
+
+				{/* 3 · 源站 */}
+				<rect {...box(318)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="350" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Your origin server
+				</text>
+
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#tls-arrow)" fill="none">
+					<path d="M180 70 L180 86" />
+					<path d="M180 140 L180 156" />
+					<path d="M180 218 L180 234" />
+					<path d="M180 296 L180 312" />
+				</g>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				A padlock in the browser only proves connection 1 is encrypted. It says nothing about connection 2.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -43,6 +43,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-19",
 		readingTime: "7 min read",
 	},
+	{
+		slug: "cloudflare-ssl-tls-encryption-modes",
+		h1: "Which Cloudflare SSL/TLS Encryption Mode Should You Use?",
+		title: "Cloudflare SSL Modes: Flexible vs Full vs Full (strict)",
+		description:
+			"Use Full (strict) unless your origin has no valid certificate. Flexible leaves the Cloudflare-to-origin hop unencrypted and causes redirect loops.",
+		blurb:
+			"Off, Flexible, Full, Full (strict): what each does to the second hop, which error each one produces, and why Cloudflare may now pick for you.",
+		updated: "2026-08-20",
+		readingTime: "8 min read",
+	},
 ];
 
 export function guideBySlug(slug: string): GuideMeta {
@@ -55,5 +66,5 @@ export const GUIDES_INDEX = {
 	title: "Guides — Orange Cloud",
 	h1: "Guides",
 	description:
-		"Plain-language guides to the Cloudflare settings people actually search for: the orange cloud, proxy status, and Orange-to-Orange routing.",
+		"Plain-language guides to the Cloudflare settings people actually search for: the orange cloud, proxy status, SSL/TLS encryption modes, and Orange-to-Orange routing.",
 };


### PR DESCRIPTION
## 选题依据

第三篇英文指南：`/guides/cloudflare-ssl-tls-encryption-modes`。

- **真实搜索问句**：「Flexible vs Full vs Full (strict)」「Cloudflare Flexible SSL 安全吗」「为什么 ERR_TOO_MANY_REDIRECTS」都是用户在搜"这是什么 / 怎么回事 / 为什么坏了"，不是产品软文。
- **在 App 覆盖范围内**：SSL/TLS 是 App 覆盖的 Cloudflare 能力之一。
- **可逐条核实**：全部论断对照 Cloudflare 官方文档当前版本。
- **不重复且能内链**：已有的橙云（代理状态）一篇是本篇的上游前提——加密模式只在记录被代理时才起作用。已做**双向内链**：两篇已有文章的 `RELATED` 各加一条，橙云篇正文「重定向循环」段落里也加了指向本篇的内链。

## 核对官方文档时修正 / 放弃了什么

写之前先拉 `index.md` 原文核对，不凭记忆。两处与网上流传说法不符、按文档改掉的：

1. **模式不是 4 种，是 5 种。** 绝大多数中英文文章只列 Off / Flexible / Full / Full (strict)，漏掉 Enterprise 专属的 **Strict (SSL-Only Origin Pull)**（API 值 `origin_pull`）。它与 Full (strict) 的区别是：不跟随访客的 scheme，访客走 HTTP 时也仍以 HTTPS 回源。已单列一行并标注 Enterprise-only。来源：[Encryption modes](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/)、[Strict (SSL-Only Origin Pull)](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/ssl-only-origin-pull/)
2. **"去 SSL/TLS 页面选一个模式"这个前提本身已经过时。** 现在默认是 **Automatic SSL/TLS**，由 SSL/TLS Recommender 的探针（`Cloudflare-SSLDetector` UA）比对 HTTP/HTTPS 内容后自动选，且**只升不降**、按 1% → 10% 梯度灰度、失败自动回滚、约每月扫一次、升级通知只发 Super Admin。原本打算写成"手动设置项"，核对后整节重写，并给出 `ssl_automatic_mode=custom` 的退出方式。来源同上。

另外按文档写实、避免想当然的几点：

- Flexible **只对 443 端口生效**，其它端口的 HTTPS 回退到 Full 行为（[Flexible](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/flexible/)）
- Authenticated Origin Pulls 在 Off / Flexible 下不可用（同上）
- 525 = 握手失败（Full/Full strict 下），526 = 证书校验失败（仅 Full strict）；526 的常见成因里补了**证书链不完整**这一条（[525](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-525/)、[526](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526/)）
- 重定向循环**两个方向都写**：Flexible 下源站 HTTP→HTTPS 会循环，Full/Full (strict) 下源站 HTTPS→HTTP 同样会循环——后者常被漏掉（[ERR_TOO_MANY_REDIRECTS](https://developers.cloudflare.com/ssl/troubleshooting/too-many-redirects/)）

**放弃的论断**：原想写"Cloudflare 正在下线 Flexible"——文档无任何此类表述，只说 recommends Full/Full (strict)，已删除，改为按文档口径陈述。

## 硬门槛逐项结果

| # | 门槛 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（仅既有的 proxy env 告警） |
| 2 | `npx vitest run` | ✅ 18 files / 129 tests 全绿 |
| 3 | `npx eslint` 改动文件 | ✅ 0 error |
| 4 | 新 URL 返回 200 | ⚠️ **见下方说明**：本次为无人值守定时运行，`preview_start` 拒绝启动 dev server。改为对**生产构建预渲染产物**验证：路由已成功预渲染出 `en/guides/cloudflare-ssl-tls-encryption-modes.html`，且非 en locale 正确落 not-found。合并后按流程 curl 线上 URL 复核 |
| 5 | canonical 自引用 + hreflang 只有 en / x-default | ✅ 脚本断言通过（注意 Next 输出的是 `hrefLang` 驼峰属性） |
| 6 | JSON-LD 可 `json.loads` + FAQ 逐字出现在可见正文 | ✅ 2 个 block 均可解析，含 TechArticle / FAQPage / BreadcrumbList；5 组问答**逐字**断言通过（脚本比对，非肉眼） |
| 7 | 标题层级无跳级 | ✅ h1 ×1 → h2 → h3，15 个标题无跳级 |
| 8 | 375px 下 `scrollWidth == clientWidth` | ✅ 实测 375 == 375；两张宽表在 `.table-wrap` 内横滚（776px → 327px 容器） |
| 9 | 外链 2xx/3xx | ✅ 3 条 Cloudflare 文档链接均 200（未经跳转） |
| 10 | 词数 1000–1800 | ✅ 1561 词 |

其它一并断言：`<title>` 55 字符、meta description 146 字符（首句即答案）、正文内 Orange Cloud 提及 0 处（GuideShell 页脚卡另计 1 处）、SVG 带 `role="img"` / `aria-label` / `<title>`、每张表都在 `.table-wrap` 内。

### 关于第 4 项

`preview_start` 在无人值守运行中被禁用（无人可批准命令），也未改用 Bash 起 server。替代验证针对的是**生产构建产物本身**（而非 dev 渲染），第 5–10 项全部是对该产物的断言；第 8 项在 375px 真实视口下、用线上同款 CSS 对本文实际 markup 实测。合并部署后会 curl 线上 URL 确认 200 与 canonical。
