### PR TITLE
feat(web): /guides 新增《为什么 Cloudflare 没缓存我的站点》

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
@@ -50,6 +50,11 @@ const RELATED: RelatedLink[] = [
 		note: "When your proxied hostname routes into a SaaS provider’s Cloudflare zone, and which zone’s settings win.",
 	},
 	{
+		href: "/guides/why-is-cloudflare-not-caching-my-site",
+		label: "Why is Cloudflare not caching my site?",
+		note: "The origin scheme this setting picks is part of every cache key — what that means in practice.",
+	},
+	{
 		href: DOCS_MODES,
 		label: "Cloudflare docs: Encryption modes",
 		note: "The official reference for every mode, the Automatic SSL/TLS rollout, and the API values.",

--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -45,6 +45,11 @@ const RELATED: RelatedLink[] = [
 		note: "Once a record is proxied, this setting decides whether the Cloudflare-to-origin hop is encrypted at all.",
 	},
 	{
+		href: "/guides/why-is-cloudflare-not-caching-my-site",
+		label: "Why is Cloudflare not caching my site?",
+		note: "Proxying is what makes caching possible — here is why most pages still are not cached.",
+	},
+	{
 		href: "https://developers.cloudflare.com/dns/proxy-status/",
 		label: "Cloudflare docs: Proxy status",
 		note: "The official reference for proxied and DNS-only records, including limitations and use cases.",

--- a/apps/web/src/app/[locale]/guides/why-is-cloudflare-not-caching-my-site/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-cloudflare-not-caching-my-site/page.tsx
@@ -1,0 +1,463 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import CacheDecision from "@/components/guides/CacheDecision";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("why-is-cloudflare-not-caching-my-site");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_STATUSES = "https://developers.cloudflare.com/cache/concepts/cache-responses/";
+const DOCS_UNCACHED = "https://developers.cloudflare.com/cache/troubleshooting/investigating-uncached-responses/";
+const DOCS_DEFAULTS = "https://developers.cloudflare.com/cache/concepts/default-cache-behavior/";
+const DOCS_RULES = "https://developers.cloudflare.com/cache/how-to/cache-rules/";
+const DOCS_KEYS = "https://developers.cloudflare.com/cache/how-to/cache-keys/";
+const DOCS_ORIGIN_CC = "https://developers.cloudflare.com/cache/concepts/cache-control/";
+const DOCS_DEV_MODE = "https://developers.cloudflare.com/cache/reference/development-mode/";
+const DOCS_TRACE = "https://developers.cloudflare.com/rules/trace-request/";
+const DOCS_TIERED = "https://developers.cloudflare.com/cache/how-to/tiered-cache/";
+const DOCS_BYPASS_CHANGE =
+	"https://developers.cloudflare.com/changelog/post/2026-05-26-bypass-status-for-uncacheable-responses/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What does cf-cache-status: DYNAMIC mean?",
+		a: "It means Cloudflare decided the request was not eligible for caching before it ever looked in the cache, so the request went straight to your origin. The usual reason is that the file extension is not one Cloudflare caches by default — HTML and JSON are not — and no Cache Rule says otherwise.",
+	},
+	{
+		q: "Why is Cloudflare not caching my HTML pages?",
+		a: "Because Cloudflare decides eligibility by file extension, and HTML is deliberately excluded from the default list. Pages are served from your origin until you add a Cache Rule that marks them eligible for cache and gives them an edge TTL.",
+	},
+	{
+		q: "What is the difference between BYPASS and MISS in Cloudflare?",
+		a: "BYPASS means Cloudflare refused to store the response — it was eligible at request time, but something in the response, such as a Set-Cookie header or an oversized body, made it uncacheable. MISS means the response was cacheable and simply was not in that data center's cache yet, so the next request should be a HIT.",
+	},
+	{
+		q: "Why does Cloudflare keep returning MISS on every request?",
+		a: "Almost always because each request produces a different cache key. Query strings count toward the key by default, so tracking parameters, session IDs, or timestamps split one asset into thousands of entries that are never requested twice. Low-traffic assets can also be evicted between requests.",
+	},
+	{
+		q: "Does a Set-Cookie header stop Cloudflare from caching?",
+		a: "By default, yes — a response carrying Set-Cookie is not stored, and it reports BYPASS. You can override that by setting an explicit edge TTL in a Cache Rule that ignores origin cache-control, by having the origin send Cache-Control: private=“Set-Cookie”, or by stripping the header with a response header Transform Rule.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "The prerequisite: nothing is cached at all on a record that is set to DNS only.",
+	},
+	{
+		href: "/guides/cloudflare-ssl-tls-encryption-modes",
+		label: "Which Cloudflare SSL/TLS encryption mode should you use?",
+		note: "The mode decides the origin scheme, and the origin scheme is part of every cache key.",
+	},
+	{
+		href: DOCS_UNCACHED,
+		label: "Cloudflare docs: Investigate uncached responses",
+		note: "The official step-by-step diagnostic for DYNAMIC, BYPASS, and repeated MISS.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function NotCachingGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="Putting a site behind a proxy does not make it a cached site. One response header tells you which decision was made, at which moment, and therefore which setting is worth changing."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						Cloudflare caches by file extension, and HTML and JSON are not on the default list — so most
+						pages return <code>cf-cache-status: DYNAMIC</code> until a Cache Rule makes them eligible.{" "}
+						<code>BYPASS</code> means the origin response blocked caching instead.
+					</p>
+				</div>
+
+				<p>
+					The common assumption is that traffic routed through Cloudflare is cached traffic, and that a slow
+					page means the cache is broken. Neither is quite right. Static assets are cached by default, pages
+					are not, and there are several distinct ways a response can end up served from your server — each
+					with a different fix. Guessing between them is how people end up stacking rules that cancel each
+					other out.
+				</p>
+
+				<h2 id="read-the-header">Read the header before you change any setting</h2>
+				<p>
+					Every proxied response carries a <code>cf-cache-status</code> header, and it names the decision
+					that was made. Fetch the URL and look at it before touching the dashboard:
+				</p>
+				<pre>
+					<code>curl -sSI https://example.com/ | grep -iE &apos;^(cf-cache-status|age):&apos;</code>
+				</pre>
+				<p>
+					The <code>Age</code> header is a useful companion: it reports how many seconds the asset has been
+					sitting in cache, and it appears only on responses actually served from cache. If <code>Age</code>{" "}
+					is missing, the response came from your origin, whatever else the page appears to be doing. If the
+					headers are absent entirely, the hostname is probably not proxied at all — see{" "}
+					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
+						what the orange cloud means in Cloudflare
+					</Link>{" "}
+					for that case, because a DNS-only record never reaches a cache in the first place.
+				</p>
+
+				<h2 id="values">What each cf-cache-status value means</h2>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Value</th>
+								<th scope="col">What happened</th>
+								<th scope="col">Served from</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">HIT</th>
+								<td>The asset was in cache and still fresh</td>
+								<td>Cache</td>
+							</tr>
+							<tr>
+								<th scope="row">MISS</th>
+								<td>Cacheable, but not present in this data center yet</td>
+								<td>Origin</td>
+							</tr>
+							<tr>
+								<th scope="row">DYNAMIC</th>
+								<td>Judged not eligible for cache before any lookup happened</td>
+								<td>Origin</td>
+							</tr>
+							<tr>
+								<th scope="row">BYPASS</th>
+								<td>Eligible, but the response itself could not be stored</td>
+								<td>Origin</td>
+							</tr>
+							<tr>
+								<th scope="row">EXPIRED</th>
+								<td>A stale copy existed; fresh content was fetched</td>
+								<td>Origin</td>
+							</tr>
+							<tr>
+								<th scope="row">STALE</th>
+								<td>Expired copy served because the origin could not be reached</td>
+								<td>Cache</td>
+							</tr>
+							<tr>
+								<th scope="row">REVALIDATED</th>
+								<td>The origin confirmed the cached copy was unchanged</td>
+								<td>Cache</td>
+							</tr>
+							<tr>
+								<th scope="row">UPDATING</th>
+								<td>Expired copy served while a refresh runs in the background</td>
+								<td>Cache</td>
+							</tr>
+							<tr>
+								<th scope="row">NONE/UNKNOWN</th>
+								<td>The response was produced before cache was ever consulted</td>
+								<td>Neither</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					That last row catches people out. A Worker that answers without a subrequest, a blocked WAF
+					request, and a redirect rule all short-circuit ahead of the cache, so they are labelled{" "}
+					<code>NONE/UNKNOWN</code> rather than describing a cache outcome at all. The full reference lives
+					in the{" "}
+					<a href={DOCS_STATUSES} target="_blank" rel="noopener noreferrer">
+						cache responses documentation
+					</a>
+					.
+				</p>
+
+				<h2 id="two-decisions">Two decisions, not one</h2>
+				<CacheDecision />
+				<p>
+					<code>DYNAMIC</code> and <code>BYPASS</code> both mean &ldquo;not cached&rdquo;, and they are
+					routinely treated as the same problem. They are not. <code>DYNAMIC</code> is decided at{" "}
+					<strong>request time</strong>, from the URL and your rules, before the cache is consulted.{" "}
+					<code>BYPASS</code> is decided at <strong>response time</strong>, once your origin has answered and
+					its headers have been read. One is fixed in your Cloudflare configuration; the other is usually
+					fixed on your server.
+				</p>
+
+				<h2 id="dynamic">DYNAMIC: the request never reached the cache</h2>
+				<p>Four causes account for nearly all of them:</p>
+				<ul>
+					<li>
+						<strong>The extension is not on the default list.</strong> Eligibility is judged by file
+						extension, not MIME type, and the{" "}
+						<a href={DOCS_DEFAULTS} target="_blank" rel="noopener noreferrer">
+							default list
+						</a>{" "}
+						covers images, fonts, archives, CSS, and JS — but deliberately excludes HTML and JSON, since
+						pages and API responses are frequently personalised. A URL with no extension at all, such as{" "}
+						<code>/pricing</code>, falls in the same bucket.
+					</li>
+					<li>
+						<strong>A rule says bypass.</strong> A Cache Rule set to bypass, or a legacy configuration or
+						page rule with cache level set to bypass, produces <code>DYNAMIC</code> for everything it
+						matches. When several rules overlap,{" "}
+						<a href={DOCS_TRACE} target="_blank" rel="noopener noreferrer">
+							Rule Trace
+						</a>{" "}
+						shows which one actually applied instead of leaving you to reason about ordering.
+					</li>
+					<li>
+						<strong>The method is not GET or HEAD.</strong> Nothing else is cached, so a page whose content
+						arrives via POST cannot be cached no matter how it is configured.
+					</li>
+					<li>
+						<strong>
+							<a href={DOCS_DEV_MODE} target="_blank" rel="noopener noreferrer">
+								Development Mode
+							</a>{" "}
+							is on.
+						</strong>{" "}
+						It suspends caching zone-wide for three hours and returns <code>DYNAMIC</code> for every
+						response. It is the first thing to check when caching stopped working &ldquo;for no
+						reason&rdquo; earlier today.
+					</li>
+				</ul>
+
+				<h2 id="bypass">BYPASS: eligible, but the response said no</h2>
+				<p>
+					Here the request cleared eligibility and the answer from your origin is what prevented storage. The
+					usual culprits:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">In the response</th>
+								<th scope="col">Why it blocks caching</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">
+									<code>Set-Cookie</code>
+								</th>
+								<td>Treated as per-visitor by default, so the response is not stored</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<code>Cache-Control: no-store</code> or bare <code>private</code>
+								</th>
+								<td>Blocks storage regardless of plan or origin cache-control mode</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<code>Cache-Control: no-cache</code>, <code>max-age=0</code>
+								</th>
+								<td>
+									On Free, Pro, and Business these produce revalidation rather than a bypass; with
+									origin cache-control disabled, the default on Enterprise, they block it
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<code>Vary: *</code>
+								</th>
+								<td>Always bypasses, whatever else is configured</td>
+							</tr>
+							<tr>
+								<th scope="row">Body over the size limit</th>
+								<td>512 MB on Free, Pro, and Business; 5 GB by default on Enterprise</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									Request had <code>Authorization</code>
+								</th>
+								<td>
+									Cacheable only if the response also carries <code>public</code>,{" "}
+									<code>s-maxage</code>, or <code>must-revalidate</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Two of these are worth knowing precisely. First, whether <code>no-cache</code> blocks caching
+					depends on{" "}
+					<a href={DOCS_ORIGIN_CC} target="_blank" rel="noopener noreferrer">
+						origin cache-control
+					</a>
+					, which is enabled by default on Free, Pro, and Business plans and disabled by default on
+					Enterprise — so identical origin headers behave differently on different plans. Second, since{" "}
+					<a href={DOCS_BYPASS_CHANGE} target="_blank" rel="noopener noreferrer">
+						a change in May 2026
+					</a>
+					, responses Cloudflare refuses to cache report <code>BYPASS</code> consistently. Oversized files
+					used to report <code>MISS</code> forever, which was indistinguishable from a broken cache. Older
+					write-ups still describe the previous behaviour, and hit-rate figures from before and after the
+					change are not comparable.
+				</p>
+
+				<h2 id="repeated-miss">Repeated MISS: the cache key keeps changing</h2>
+				<p>
+					A first <code>MISS</code> in each data center is normal — that request is what populates the cache.
+					A URL that misses every time is a different symptom, and the cause is usually that no two requests
+					share a{" "}
+					<a href={DOCS_KEYS} target="_blank" rel="noopener noreferrer">
+						cache key
+					</a>
+					. The key is built from the origin scheme, host, path, and query string, so:
+				</p>
+				<ul>
+					<li>
+						<strong>Query strings fragment the cache.</strong> Every distinct query string is its own
+						entry. Campaign tags, session identifiers, and cache-busting timestamps turn one asset into
+						thousands of entries that are each requested once. Cache Rules can ignore or allow-list
+						specific parameters; sorting them only helps when the same parameters arrive in a different
+						order.
+					</li>
+					<li>
+						<strong>Custom keys can shard.</strong> Adding a cookie or header that varies per user to the
+						key does exactly what you asked and gives every user a private copy.
+					</li>
+					<li>
+						<strong>Vary multiplies entries.</strong> A high-cardinality header listed in the origin&rsquo;s{" "}
+						<code>Vary</code> stores a separate variant per value, and the hit rate collapses.
+					</li>
+					<li>
+						<strong>Low-traffic assets are evicted.</strong> If two consecutive requests to the same data
+						center both miss,{" "}
+						<a href={DOCS_TIERED} target="_blank" rel="noopener noreferrer">
+							Tiered Cache
+						</a>{" "}
+						is the usual answer for long-tail content.
+					</li>
+				</ul>
+				<p>
+					Before concluding the cache is broken, confirm both test requests reached the same location: the
+					last three characters of the <code>cf-ray</code> header identify the data center. Note also that
+					the scheme in the key is the one used to reach your origin, not the one the visitor used, which is
+					why{" "}
+					<Link href="/guides/cloudflare-ssl-tls-encryption-modes">changing the encryption mode</Link> forces
+					the cache to warm up again.
+				</p>
+
+				<h2 id="cache-html">Making pages cacheable on purpose</h2>
+				<ol>
+					<li>
+						Add a{" "}
+						<a href={DOCS_RULES} target="_blank" rel="noopener noreferrer">
+							Cache Rule
+						</a>{" "}
+						matching the paths you want cached, with eligibility set to yes and an explicit edge TTL. The
+						TTL matters: without one, the response falls back to whatever your origin&rsquo;s headers say.
+					</li>
+					<li>
+						Exclude anything personalised — carts, dashboards, admin paths, anything gated by a session
+						cookie — in the same rule expression rather than in a second rule bolted on afterwards.
+					</li>
+					<li>
+						Decide what should happen to <code>Set-Cookie</code>. An edge TTL that ignores origin
+						cache-control will strip it and cache the response, which is correct for anonymous pages and
+						actively dangerous for personalised ones.
+					</li>
+					<li>
+						Request the URL twice from the same client and confirm you see <code>HIT</code> with an{" "}
+						<code>Age</code> that climbs. A single request cannot tell you anything.
+					</li>
+				</ol>
+				<p>
+					Cache behaviour is revised more often than most Cloudflare settings — the bypass reporting change
+					above landed in 2026 — so before relying on a specific row here, check the{" "}
+					<a href={DOCS_UNCACHED} target="_blank" rel="noopener noreferrer">
+						current troubleshooting reference
+					</a>
+					.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/components/guides/CacheDecision.tsx
+++ b/apps/web/src/components/guides/CacheDecision.tsx
@@ -1,0 +1,102 @@
+/**
+ * 缓存判定图：请求先过「请求时是否可缓存」（否 → DYNAMIC），
+ * 再过「响应本身能不能存」（否 → BYPASS），最后才查缓存（MISS / HIT）。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function CacheDecision() {
+	const decision = (y: number) => ({ x: 8, y, width: 214, height: 62, rx: 14 });
+	const pill = (y: number) => ({ x: 252, y, width: 100, height: 40, rx: 12 });
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 412"
+				role="img"
+				aria-label="Cloudflare makes three checks in order. First, is the request eligible for cache at request time? If not, the status is DYNAMIC. Second, is the origin response cacheable? If not, the status is BYPASS. Third, is the asset already in this data center's cache? If not, the status is MISS; if it is, the status is HIT."
+				className="mx-auto block h-auto w-full max-w-[420px]"
+			>
+				<title>How Cloudflare arrives at each cf-cache-status value</title>
+
+				<defs>
+					<marker id="cache-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+
+				{/* 请求入口 */}
+				<rect x="8" y="10" width="214" height="44" rx="14" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="115" y="37" textAnchor="middle" fontSize="14" fontWeight="600" fill="var(--t-primary)">
+					Request reaches Cloudflare
+				</text>
+
+				{/* 判定一 · 请求时是否可缓存 */}
+				<rect {...decision(84)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="115" y="110" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Eligible for cache
+				</text>
+				<text x="115" y="128" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					at request time?
+				</text>
+				<rect {...pill(95)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="302" y="120" textAnchor="middle" fontSize="13" fontWeight="700" fill="var(--t-primary)">
+					DYNAMIC
+				</text>
+
+				{/* 判定二 · 响应本身能不能存 */}
+				<rect {...decision(176)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="115" y="202" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Origin response
+				</text>
+				<text x="115" y="220" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					cacheable?
+				</text>
+				<rect {...pill(187)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="302" y="212" textAnchor="middle" fontSize="13" fontWeight="700" fill="var(--t-primary)">
+					BYPASS
+				</text>
+
+				{/* 判定三 · 缓存里有没有 */}
+				<rect {...decision(268)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="115" y="294" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Already in this
+				</text>
+				<text x="115" y="312" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					data center&#39;s cache?
+				</text>
+				<rect {...pill(279)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="302" y="304" textAnchor="middle" fontSize="13" fontWeight="700" fill="var(--t-primary)">
+					MISS
+				</text>
+
+				{/* 命中 */}
+				<rect x="8" y="360" width="214" height="44" rx="14" fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="115" y="387" textAnchor="middle" fontSize="14" fontWeight="700" fill="var(--t-primary)">
+					HIT
+				</text>
+
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#cache-arrow)" fill="none">
+					<path d="M115 54 L115 80" />
+					<path d="M115 146 L115 172" />
+					<path d="M115 238 L115 264" />
+					<path d="M115 330 L115 356" />
+					<path d="M222 115 L248 115" />
+					<path d="M222 207 L248 207" />
+					<path d="M222 299 L248 299" />
+				</g>
+
+				<g fontSize="10.5" fill="var(--t-tertiary)">
+					<text x="124" y="164">yes</text>
+					<text x="124" y="256">yes</text>
+					<text x="124" y="348">yes</text>
+					<text x="235" y="108" textAnchor="middle">no</text>
+					<text x="235" y="200" textAnchor="middle">no</text>
+					<text x="235" y="292" textAnchor="middle">no</text>
+				</g>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				DYNAMIC and BYPASS look alike in a browser, but they are decided at different moments and have
+				different fixes.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -54,6 +54,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-20",
 		readingTime: "8 min read",
 	},
+	{
+		slug: "why-is-cloudflare-not-caching-my-site",
+		h1: "Why Is Cloudflare Not Caching My Site?",
+		title: "Why Isn't Cloudflare Caching My Site? cf-cache-status",
+		description:
+			"Cloudflare does not cache HTML or JSON by default. DYNAMIC means the request was never eligible; BYPASS means the origin response blocked caching.",
+		blurb:
+			"DYNAMIC, BYPASS and a MISS that never becomes a HIT are three different failures with three different fixes — read the header first.",
+		updated: "2026-08-20",
+		readingTime: "8 min read",
+	},
 ];
 
 export function guideBySlug(slug: string): GuideMeta {
@@ -66,5 +77,5 @@ export const GUIDES_INDEX = {
 	title: "Guides — Orange Cloud",
 	h1: "Guides",
 	description:
-		"Plain-language guides to the Cloudflare settings people actually search for: the orange cloud, proxy status, SSL/TLS encryption modes, and Orange-to-Orange routing.",
+		"Plain-language guides to the Cloudflare settings people actually search for: the orange cloud, proxy status, SSL/TLS encryption modes, and caching.",
 };


### PR DESCRIPTION
## 选题依据

四条门槛逐条对照：

1. **真实搜索问句**——"why is cloudflare not caching my site" / "cf-cache-status dynamic" / "cloudflare not caching html" 都是用户在排障时敲进搜索框的原话，不是我们想讲的东西。
2. **App 覆盖的能力**——缓存（Cache Rules / 清缓存）是 App 已有模块。
3. **可核实**——全部论断出自 Cloudflare 官方文档当前版本（多数页面 2026-08 更新）。
4. **不重复且能内链**——现有三篇讲代理状态 / O2O / SSL 模式，都没碰缓存；本篇与前者（DNS only 根本不进缓存）、后者（加密模式决定回源 scheme，而 scheme 是缓存键的一部分）双向内链。

文章主线是**「没缓存」其实是三种不同的失败**：`DYNAMIC`（请求时判定不可缓存）、`BYPASS`（响应本身存不下）、反复 `MISS`（缓存键每次都变）——三者修法完全不同，网上多数文章混为一谈。

## 核对官方文档时修正 / 放弃了哪些论断

| 原打算写 | 核对后 | 依据 |
|---|---|---|
| 超过大小上限的响应会反复报 `MISS` | **改掉**：2026-05-26 起统一报 `BYPASS`，`MISS` 只留给"可缓存但不在缓存里" | [changelog 2026-05-26](https://developers.cloudflare.com/changelog/post/2026-05-26-bypass-status-for-uncacheable-responses/) |
| `no-cache` / `max-age=0` 一律阻止缓存 | **改掉**：取决于 Origin Cache Control——Free/Pro/Business 默认开启时走 revalidate（`REVALIDATED`/`EXPIRED`），Enterprise 默认关闭才是阻止 | [cache-control](https://developers.cloudflare.com/cache/concepts/cache-control/)、[investigating-uncached-responses](https://developers.cloudflare.com/cache/troubleshooting/investigating-uncached-responses/) |
| 只缓存 `GET` | **改掉**：`GET` 与 `HEAD`（default-cache-behavior 只写 GET，排障页写 GET/HEAD，取后者更具体的口径） | [investigating-uncached-responses](https://developers.cloudflare.com/cache/troubleshooting/investigating-uncached-responses/) |
| 可缓存上限 = 上传上限（100 MB） | **改掉**：两回事——上传上限 100/200/500+ MB，可缓存上限 512 MB（Free/Pro/Business）、5 GB（Enterprise 默认） | [default-cache-behavior](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/) |
| 按 MIME 类型判定是否缓存 | **改掉**：按**文件扩展名**判定，不看 MIME | [default-cache-behavior](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/) |
| 缓存键里的 scheme = 访客用的 scheme | **改掉**：是 Cloudflare **回源**用的 scheme | [cache-keys / 排障页](https://developers.cloudflare.com/cache/how-to/cache-keys/) |
| 放弃：列举默认缓存扩展名全表 | **放弃**：官方是一张长表，照搬即抄文档；改为描述性归纳 + 外链 | — |
| 放弃：`private="<header>"`、Enterprise `Cache Level` 矩阵等边角 | **放弃**：分支太多，写进正文会喧宾夺主，只在 FAQ 点到 `private="Set-Cookie"` 一种可行解 | — |

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（仅既有 `middleware` 废弃告警 + 环境 proxy 提示） |
| 2 | `npx vitest run` | ✅ 19 files / 133 tests 全绿 |
| 3 | `npx eslint`（新增及改动文件） | ✅ 0 error |
| 4 | dev 服务器新 URL 200 | ⚠️ **本轮无法执行**：`preview_start` 在无人值守的定时任务里被禁止启动 dev server，且规程禁止用 Bash 跑 server。**替代验证**：直接对 `next build` 产出的预渲染 HTML（`.next/server/app/en/guides/…html`，正是线上要发的那份）做全部断言，并用 WebKit（playwright）真实渲染测量；非 en 前缀产出的是 404 页，locale 门控成立。合并后另有线上 curl 复核（见文末） |
| 5 | canonical 自引用 / hreflang | ✅ canonical = `https://o-c.do/guides/why-is-cloudflare-not-caching-my-site`；alternate 仅 `en` + `x-default`，均指向自身 |
| 6 | JSON-LD 可解析 + FAQ 逐字出现在可见正文 | ✅ 脚本断言：4 段 JSON-LD 全部 `json.loads` 通过（`SoftwareApplication`(布局自带) / `TechArticle` / `FAQPage` / `BreadcrumbList`）；5 条问 + 5 条答逐字命中渲染后 `innerText` |
| 7 | 标题层级无跳级 | ✅ h1 → h2×8 → h3×5 → h2×2，无跳级 |
| 8 | 375px 无横向溢出 | ✅ WebKit 实测 375/768/1280 三档 `scrollWidth == clientWidth`；宽表格在 `.table-wrap` 内横滚，代码块在 `.prose pre` 内横滚 |
| 9 | 外链 2xx/3xx | ✅ 正文 10 条 Cloudflare 文档链接 + 「Keep reading」1 条，逐条 curl 均 200 |
| 10 | 词数 1000–1800 | ✅ 渲染后正文 1585 词 |

## 其它

- 新增内联 SVG 组件 `CacheDecision.tsx`（走主题 CSS 变量、竖版、`role="img"` + `aria-label` + `<title>`），画三次判定如何分别落到 DYNAMIC / BYPASS / MISS / HIT。
- 全文 0 处提及 Orange Cloud 产品，GuideShell 页脚卡片那 1 处即全部。
- `/guides` 索引 meta description 顺带把已失效的「Orange-to-Orange routing」换成「caching」以覆盖新篇（147 字符）。
- 例子里的 `grep` 改成 `-iE`，避免 BSD grep 下 `\|` 行为不一致。
