### PR TITLE
feat(web): /guides 开出简体中文栏目，首篇《Cloudflare Tunnel 内网穿透》

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-tunnel-neiwang-chuantou/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-tunnel-neiwang-chuantou/page.tsx
@@ -1,0 +1,459 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import TunnelFlow from "@/components/guides/TunnelFlow";
+import { guideBySlug, guidePath, GUIDE_LOCALE_ZH } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-tunnel-neiwang-chuantou", GUIDE_LOCALE_ZH);
+const PATH = guidePath(GUIDE_LOCALE_ZH, `/guides/${guide.slug}`);
+
+const DOCS_TUNNEL = "https://developers.cloudflare.com/tunnel/";
+const DOCS_SETUP = "https://developers.cloudflare.com/tunnel/setup/";
+const DOCS_ROUTING = "https://developers.cloudflare.com/tunnel/routing/";
+const DOCS_CONFIG = "https://developers.cloudflare.com/tunnel/configuration/";
+const DOCS_TROUBLE = "https://developers.cloudflare.com/tunnel/troubleshooting/";
+const DOCS_LOCAL = "https://developers.cloudflare.com/tunnel/advanced/local-management/create-local-tunnel/";
+const DOCS_DOWNLOADS = "https://developers.cloudflare.com/tunnel/downloads/";
+const DOCS_1033 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1033/";
+const DOCS_413 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-413/";
+const DOCS_ACCESS =
+	"https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/";
+const DOCS_CHINA = "https://developers.cloudflare.com/china-network/";
+const TERMS_APP_SERVICES = "https://www.cloudflare.com/service-specific-terms-application-services/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "Cloudflare Tunnel 是免费的吗？",
+		a: "隧道本身在所有套餐上都可用，免费方案就能建、能跑、能绑自己的域名，流量也不额外计费。真正会拦住你的不是价格，而是套餐限制：免费与 Pro 方案单次请求体上限 100 MB，超过返回 413；同时 Cloudflare 的服务条款不允许在免费、Pro、Business 的 CDN 上提供视频，或提供比例失衡的图片、音频与大文件。",
+	},
+	{
+		q: "用 Cloudflare Tunnel 做内网穿透需要备案吗？",
+		a: "Cloudflare 的免费方案不使用中国大陆境内节点，大陆访客的请求会绕到境外数据中心，因此不涉及在 Cloudflare 侧办理 ICP 备案。但备案义务看的是你自己的服务器和业务：如果服务跑在境内主机上并对公众提供，相关法规仍然适用，不会因为流量经过境外 CDN 而消失。要用 Cloudflare 的大陆节点则需要 China Network，那是企业级方案，并且要求域名已完成 ICP 备案。",
+	},
+	{
+		q: "Cloudflare Tunnel 和 frp、ngrok 有什么区别？",
+		a: "frp 需要你自己准备一台有公网 IP 的服务器做中转，带宽、可用性、被扫描后的防护全归你管。Cloudflare Tunnel 把中转那一端换成了 Cloudflare 的全球网络，你不用买服务器，请求进来时还顺带过一遍缓存、WAF 和 DDoS 防护。代价是你要接受它的规则：域名必须托管在 Cloudflare，请求体大小、内容类型都有限制，非 HTTP 协议还要求访问端也装 cloudflared。",
+	},
+	{
+		q: "访问域名报 1033 错误怎么办？",
+		a: "1033 的意思是 Cloudflare 找不到一个健康的 cloudflared 实例来接收流量，问题几乎都在你这一侧，而不是域名或 DNS。先在仪表盘的 Networking → Tunnels 里看隧道状态：Inactive 表示隧道建好了但连接器从没跑起来，Down 表示进程停了，Degraded 表示还在服务但有连接失败。再看 cloudflared 日志里是不是卡在 7844 端口的连接上。",
+	},
+	{
+		q: "能用 Cloudflare Tunnel 把 NAS 挂出去看电影吗？",
+		a: "技术上能跑通，但这正是 Cloudflare 服务条款明确限制的用法——免费、Pro、Business 方案的 CDN 不得用于提供视频或比例失衡的大文件。个人偶尔取一份文件通常不会有人过问，把它当成长期的影音外链或公网网盘则是在赌，Cloudflare 保留停用 CDN 的权利。上传方向还另有一道 100 MB 的硬限制。",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides",
+		label: "全部中文指南",
+		note: "Cloudflare 的其它设置项：代理状态、回源、缓存与证书。",
+	},
+	{
+		href: DOCS_SETUP,
+		label: "Cloudflare 官方文档：Tunnel 快速上手",
+		note: "本文所有步骤的原始出处，含仪表盘与 API 两条路径。",
+		external: true,
+	},
+	{
+		href: DOCS_TROUBLE,
+		label: "Cloudflare 官方文档：Tunnel 故障排查",
+		note: "连接类报错的完整清单，含各种日志原文与对应处理。",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "这篇有错？告诉我们",
+		note: "勘误和提问都欢迎，每一封都会看。",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { "zh-Hans": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "zh_CN",
+		images: [{ url: "/og/zh-Hans.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/zh-Hans.jpg"],
+	},
+};
+
+export default async function TunnelGuideZh({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE_ZH) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "zh-Hans",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/zh-Hans.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "指南", item: `${SITE_URL}${guidePath(GUIDE_LOCALE_ZH, "/guides")}` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				locale={GUIDE_LOCALE_ZH}
+				title={guide.h1}
+				lede="不用公网 IP，不用端口映射，也不用 DDNS。代价是要接受 Cloudflare 的几条硬限制——先把它们看清楚，再决定要不要把家里那台机器挂上去。"
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						Cloudflare Tunnel 靠内网里的 <code>cloudflared</code>{" "}
+						主动向 Cloudflare 建立一条出站连接，公网请求沿着这条连接回到你的服务。所以它不需要公网 IP，也不需要在路由器上开放任何入站端口。前提只有一个：域名托管在
+						Cloudflare。
+					</p>
+				</div>
+
+				<p>
+					家宽拿不到公网 IP、拿到了也是随时会变的动态地址、路由器在运营商的大内网后面——这是国内做内网穿透绕不开的起点。传统解法是租一台有公网
+					IP 的小服务器跑 frp，把中转这件事自己扛下来。Cloudflare Tunnel 换了个思路：中转交给 Cloudflare
+					的全球网络，你这边只跑一个客户端进程。
+				</p>
+				<p>
+					这条路确实省事，但它不是万能的替代品。下面按「怎么通 — 怎么配 — 有哪些坑」的顺序过一遍，重点放在那些通常要踩过才知道的边界上。
+				</p>
+
+				<h2 id="how-it-works">连接方向反过来了，所以不需要公网 IP</h2>
+				<p>
+					关键差别只有一个字：方向。端口映射也好、frp 也好，本质都是让公网能主动「敲」到你家的某个入口；而{" "}
+					<code>cloudflared</code> 是从内网往外敲 Cloudflare 的门。
+				</p>
+				<TunnelFlow />
+				<p>
+					按官方文档的说法，<code>cloudflared</code> 会向 Cloudflare 建立四条长连接，分布在至少两个数据中心上，任意一条断掉服务都不中断。这些连接走
+					7844 端口，优先用 QUIC（UDP），握手不成功会自动回落到 HTTP/2（TCP）。绝大多数家用网络默认放行出站流量，所以这一步通常什么都不用配。
+				</p>
+				<p>
+					连接建立之后，流量是双向的：公网访客的请求先落在 Cloudflare 的边缘节点，过一遍缓存、WAF 和 DDoS 防护，再沿着这条已有的隧道下发给{" "}
+					<code>cloudflared</code>，由它转交给本机（或内网里另一台机器）上的服务。你的服务器从头到尾没有对外暴露过一个端口，扫描器也就无从下手。细节见{" "}
+					<a href={DOCS_TUNNEL} target="_blank" rel="noopener noreferrer">
+						Cloudflare Tunnel 文档
+					</a>
+					。
+				</p>
+
+				<h2 id="three-shapes">先选形态：三种隧道差别很大</h2>
+				<p>「Cloudflare Tunnel」这个名字底下其实有三种用法，选错了会白折腾半天。</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">形态</th>
+								<th scope="col">怎么建</th>
+								<th scope="col">适合</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Quick Tunnel</th>
+								<td>
+									一条命令 <code>cloudflared tunnel --url http://localhost:8080</code>，不用账号、不用域名，随机分配一个{" "}
+									<code>trycloudflare.com</code> 子域
+								</td>
+								<td>临时给人看一眼本地开发环境。官方明确说它只用于测试：并发上限 200，且不支持 SSE</td>
+							</tr>
+							<tr>
+								<th scope="row">远程管理</th>
+								<td>仪表盘里建，配置存在 Cloudflare，机器上只跑一条带 token 的服务</td>
+								<td>绝大多数人该选这个。换机器、加路由都在网页上点，本机不留配置文件</td>
+							</tr>
+							<tr>
+								<th scope="row">本地管理</th>
+								<td>
+									<code>cloudflared tunnel create</code> 加一份 <code>config.yml</code>，凭证落在本机
+								</td>
+								<td>要把配置纳入版本管理或用 Ansible、Terraform 批量下发时</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					下面的步骤按远程管理隧道来写。想走配置文件那条路，参考官方的{" "}
+					<a href={DOCS_LOCAL} target="_blank" rel="noopener noreferrer">
+						本地管理隧道文档
+					</a>
+					，两者的网络行为完全一样，只是配置存放位置不同。
+				</p>
+
+				<h2 id="setup">五分钟配完一条隧道</h2>
+				<p>动手前确认三件事：域名的 DNS 已经托管在 Cloudflare；有一台能上网的机器（NAS、软路由、树莓派、云主机都行）；这台机器能出站访问 7844 端口。</p>
+				<ol>
+					<li>
+						仪表盘进 <strong>Networking → Tunnels</strong>，点 <strong>Create Tunnel</strong>，起个名字。
+					</li>
+					<li>
+						选好机器的操作系统和架构，把页面给出的安装命令复制到机器上执行。Linux 上通常就是{" "}
+						<code>sudo cloudflared service install &lt;TOKEN&gt;</code>；Docker 用户可以直接跑官方镜像。各平台的安装包见{" "}
+						<a href={DOCS_DOWNLOADS} target="_blank" rel="noopener noreferrer">
+							下载页
+						</a>
+						。
+					</li>
+					<li>
+						回到页面，隧道状态变成 <strong>Healthy</strong> 就说明连上了。
+					</li>
+					<li>
+						在 <strong>Routes</strong> 里点 <strong>Add route</strong>，选 <strong>Published application</strong>，填公开域名（比如{" "}
+						<code>nas.example.com</code>）和本地服务地址（比如 <code>http://localhost:8080</code>）。服务在内网另一台机器上就填那台机器的内网
+						IP。
+					</li>
+				</ol>
+				<p>
+					保存之后 Cloudflare 会自动建好 DNS 记录：一条指向{" "}
+					<code>&lt;隧道 UUID&gt;.cfargotunnel.com</code> 的 CNAME。这个子域只对同一个 Cloudflare
+					账号下的 DNS 记录生效，别人就算知道了你的隧道 UUID，也没法在自己账号里建记录来蹭这条隧道。
+				</p>
+				<p>
+					一条隧道可以挂多个域名，各自映射到不同的本地服务，全部共用同一条连接。相关规则见{" "}
+					<a href={DOCS_ROUTING} target="_blank" rel="noopener noreferrer">
+						路由文档
+					</a>
+					。
+				</p>
+
+				<h3 id="non-http">SSH、远程桌面这些非 HTTP 协议</h3>
+				<p>
+					隧道能转的不止网页。下面这些服务类型都可以映射到公开域名，但有一条共同前提：访问端也要装{" "}
+					<code>cloudflared</code>，用 <code>cloudflared access</code> 建立连接——浏览器直接打开是不行的。
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">类型</th>
+								<th scope="col">写法</th>
+								<th scope="col">访问端要求</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">HTTP / HTTPS</th>
+								<td>
+									<code>http://localhost:8000</code>
+								</td>
+								<td>浏览器直接访问</td>
+							</tr>
+							<tr>
+								<th scope="row">SSH</th>
+								<td>
+									<code>ssh://localhost:22</code>
+								</td>
+								<td>
+									客户端跑 <code>cloudflared access ssh</code>
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">RDP</th>
+								<td>
+									<code>rdp://localhost:3389</code>
+								</td>
+								<td>客户端装 cloudflared</td>
+							</tr>
+							<tr>
+								<th scope="row">SMB</th>
+								<td>
+									<code>smb://localhost:445</code>
+								</td>
+								<td>客户端装 cloudflared</td>
+							</tr>
+							<tr>
+								<th scope="row">任意 TCP</th>
+								<td>
+									<code>tcp://localhost:2222</code>
+								</td>
+								<td>
+									客户端跑 <code>cloudflared access tcp</code>，长连接场景官方建议改用私有网络方案
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					注意这张表里没有 UDP。游戏联机、部分 VoIP 这类纯 UDP 的场景，公网发布这条路走不通，得改用 Cloudflare One 的私有网络加 WARP
+					客户端，那是另一套东西了。
+				</p>
+
+				<h2 id="limits">动手之前，先认下这几条硬限制</h2>
+				<p>这一节是本文最值得先读的部分。绝大多数「用了半年突然出问题」的故事，根源都在这里。</p>
+				<h3 id="limit-upload">单次上传 100 MB</h3>
+				<p>
+					免费和 Pro 方案的请求体上限是 100 MB，Business 是 200 MB，超过就返回{" "}
+					<code>413</code>。这个限制作用在整个 Cloudflare 代理层上，隧道自然也跑不掉。挂 NAS 想往上传大文件、或者自建 Git 仓库推大提交，都会撞上它。规避办法只有分片上传、把域名改成灰云直连（那就失去了穿透的意义），或者升级套餐。细节见{" "}
+					<a href={DOCS_413} target="_blank" rel="noopener noreferrer">
+						413 错误说明
+					</a>
+					。
+				</p>
+				<h3 id="limit-terms">视频与大文件受服务条款限制</h3>
+				<p>
+					Cloudflare 的{" "}
+					<a href={TERMS_APP_SERVICES} target="_blank" rel="noopener noreferrer">
+						应用服务专项条款
+					</a>
+					里写明：免费、Pro、Business 方案的 CDN 不得用于提供视频，或提供比例失衡的图片、音频及其他大文件，否则 Cloudflare
+					有权停用 CDN 服务。把隧道当影音站或公网网盘用，就是踩在这一条上。自用偶尔取个文件是一回事，长期跑流量是另一回事。
+				</p>
+				<h3 id="limit-china">大陆访客走的是境外节点</h3>
+				<p>
+					这是国内用户最容易失望的一点：免费方案不使用中国大陆境内的数据中心，大陆访客的请求会被路由到香港、日本、新加坡等地的节点，延迟和稳定性都受跨境链路影响。要用境内节点得上{" "}
+					<a href={DOCS_CHINA} target="_blank" rel="noopener noreferrer">
+						Cloudflare China Network
+					</a>
+					，那是与京东云合作的企业级方案，并且要求域名已完成 ICP 备案。所以：如果你的访客全在国内、又对延迟敏感，一台国内小服务器加 frp
+					可能仍然更合适。反过来，如果只是自己在外面偶尔连回家，绕一圈境外完全能接受。
+				</p>
+				<h3 id="limit-compliance">合规这件事跟隧道无关</h3>
+				<p>
+					流量绕经境外不等于业务出境。服务跑在境内主机上、面向公众提供，该守的规矩一条都不会少。个人自用（连自己的 NAS、远程桌面回家）和对公众开放的站点，是两件性质不同的事，别混为一谈。
+				</p>
+
+				<h2 id="access">别让 NAS 裸奔：加一道 Access</h2>
+				<p>
+					隧道解决的是「能连上」，不解决「谁能连」。域名一旦生效，全世界都能打开它，剩下的防线只有你那个服务自己的登录页——而家用 NAS
+					和各种自建面板的登录页，通常经不起自动化扫描。
+				</p>
+				<p>
+					Cloudflare Access 可以在流量到达你的服务之前先拦一道：在 <strong>Zero Trust → Access controls → Applications</strong>{" "}
+					里新建一个 self-hosted 应用，填上刚才那个域名，然后加一条 Allow 策略，比如只允许某个邮箱后缀、或者某几个具体邮箱。没有匹配到策略的请求根本走不进隧道。
+				</p>
+				<p>
+					要留意的是：一个没有任何策略的应用会拒绝所有请求。加了应用一定记得配至少一条 Allow 策略，否则你自己也进不去。配置方法见{" "}
+					<a href={DOCS_ACCESS} target="_blank" rel="noopener noreferrer">
+						self-hosted 应用文档
+					</a>
+					。
+				</p>
+
+				<h2 id="errors">四个最常撞上的报错</h2>
+				<h3 id="error-1033">1033：找不到健康的连接器</h3>
+				<p>
+					这是隧道类问题里最常见的一个，意思是 Cloudflare 收到了请求，却找不到活着的 <code>cloudflared</code>{" "}
+					来接。先去仪表盘看隧道状态，对照处理：
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">状态</th>
+								<th scope="col">含义</th>
+								<th scope="col">怎么办</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Healthy</th>
+								<td>四条连接都在，正常服务</td>
+								<td>问题不在隧道，查路由映射和服务本身</td>
+							</tr>
+							<tr>
+								<th scope="row">Inactive</th>
+								<td>隧道建好了，但连接器从来没跑起来过</td>
+								<td>去机器上装并启动 cloudflared</td>
+							</tr>
+							<tr>
+								<th scope="row">Down</th>
+								<td>之前连过，现在进程停了</td>
+								<td>看机器是否关机、服务是否崩溃、网络是否变动</td>
+							</tr>
+							<tr>
+								<th scope="row">Degraded</th>
+								<td>还在服务，但有连接失败</td>
+								<td>查 cloudflared 日志和防火墙对 7844 的放行</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					还有一种情况：隧道删了或停了，DNS 记录却还留着。官方路由文档里说这时访客会看到{" "}
+					<code>1016</code>，而 <a href={DOCS_1033} target="_blank" rel="noopener noreferrer">1033 的说明页</a>{" "}
+					描述的是找不到健康实例。两个错误码指向的是同一件事的两个阶段，看到哪个都先查隧道状态。
+				</p>
+				<h3 id="error-7844">连不上 7844 端口</h3>
+				<p>
+					日志里出现 <code>failed to dial to edge with quic</code> 或者 <code>DialContext error: dial tcp ... i/o timeout</code>
+					，说明出站被挡了。只有 UDP 被挡时，<code>cloudflared</code> 会自己退回 HTTP/2，服务还能用，只是性能差一些；UDP 和 TCP
+					都被挡则完全连不上。排查用 <code>nc -vz -w 3 198.41.200.43 7844</code> 试一下（IP 换成日志里那个），必要时用{" "}
+					<code>--protocol http2</code> 强制走 TCP。完整清单在{" "}
+					<a href={DOCS_CONFIG} target="_blank" rel="noopener noreferrer">
+						配置文档
+					</a>
+					里。
+				</p>
+				<h3 id="error-dns">edge discovery 解析失败</h3>
+				<p>
+					报错写着 <code>error looking up Cloudflare edge IPs</code>，是本机的 DNS 解析器返不回{" "}
+					<code>cloudflared</code> 用来发现边缘节点的 SRV 记录。用{" "}
+					<code>dig SRV _v2-origintunneld._tcp.argotunnel.com</code> 验一下，再加 <code>@1.1.1.1</code>{" "}
+					对比：如果只有公共解析器能出结果，把机器的 DNS 换掉即可。这种情况在容器里尤其常见。
+				</p>
+				<h3 id="error-installed">cloudflared service is already installed</h3>
+				<p>
+					一台机器上只能有一个 <code>cloudflared</code> 系统服务。想再发布一个服务，正确做法是给现有隧道加一条路由，而不是再建一条隧道。确实要重来就先{" "}
+					<code>sudo cloudflared service uninstall</code>。同理，保存公开域名时提示{" "}
+					<code>An A, AAAA, or CNAME record with that host already exists</code>，是这个子域已经有 DNS 记录了，换个子域或先删掉旧记录。
+				</p>
+
+				<h2 id="faq">常见问题</h2>
+				{FAQ.map((item, i) => (
+					<div key={item.q}>
+						<h3 id={`faq-${i + 1}`}>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/page.tsx
+++ b/apps/web/src/app/[locale]/guides/page.tsx
@@ -5,68 +5,100 @@ import { Link } from "@/i18n/navigation";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import HorizonArc from "@/components/HorizonArc";
-import { GUIDES, GUIDES_INDEX, GUIDE_LOCALE } from "@/lib/guides/guides";
+import {
+	GUIDE_LOCALE,
+	GUIDE_LOCALE_ZH,
+	guidePath,
+	guidesFor,
+	guidesIndexFor,
+	isGuideLocale,
+} from "@/lib/guides/guides";
 
 const SITE_URL = "https://o-c.do";
 
-export const metadata: Metadata = {
-	metadataBase: new URL(SITE_URL),
-	title: GUIDES_INDEX.title,
-	description: GUIDES_INDEX.description,
-	alternates: {
-		canonical: "/guides",
-		languages: { en: "/guides", "x-default": "/guides" },
-	},
-	openGraph: {
-		title: GUIDES_INDEX.title,
-		description: GUIDES_INDEX.description,
-		url: "/guides",
-		siteName: "Orange Cloud",
-		type: "website",
-		locale: "en_US",
-		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: "Orange Cloud" }],
-	},
-	twitter: {
-		card: "summary_large_image",
-		title: GUIDES_INDEX.title,
-		description: GUIDES_INDEX.description,
-		images: ["/og/en.jpg"],
-	},
+/** 索引页两语并列，文章不互译，故只有这一页写 hreflang */
+const INDEX_LANGUAGES = {
+	en: "/guides",
+	"zh-Hans": `/${GUIDE_LOCALE_ZH}/guides`,
+	"x-default": "/guides",
 };
+
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+	const { locale } = await params;
+	if (!isGuideLocale(locale)) return {};
+	const index = guidesIndexFor(locale);
+	const path = guidePath(locale, "/guides");
+	const og = locale === GUIDE_LOCALE_ZH ? "/og/zh-Hans.jpg" : "/og/en.jpg";
+
+	return {
+		metadataBase: new URL(SITE_URL),
+		title: index.title,
+		description: index.description,
+		alternates: { canonical: path, languages: INDEX_LANGUAGES },
+		openGraph: {
+			title: index.title,
+			description: index.description,
+			url: path,
+			siteName: "Orange Cloud",
+			type: "website",
+			locale: locale === GUIDE_LOCALE_ZH ? "zh_CN" : "en_US",
+			images: [{ url: og, width: 1280, height: 640, alt: "Orange Cloud" }],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: index.title,
+			description: index.description,
+			images: [og],
+		},
+	};
+}
 
 export default async function GuidesIndexPage({ params }: { params: Promise<{ locale: string }> }) {
 	const { locale } = await params;
-	// 指南只有英文版：其它语言前缀不提供内容，避免稀薄的机翻页与软 404
-	if (locale !== GUIDE_LOCALE) notFound();
+	// 指南只有英文与简体中文两套：其它语言前缀不提供内容，避免稀薄的机翻页与软 404
+	if (!isGuideLocale(locale)) notFound();
 	setRequestLocale(locale);
+
+	const index = guidesIndexFor(locale);
+	const guides = guidesFor(locale);
 
 	const jsonLd = {
 		"@context": "https://schema.org",
 		"@type": "CollectionPage",
-		name: GUIDES_INDEX.h1,
-		description: GUIDES_INDEX.description,
-		url: `${SITE_URL}/guides`,
-		inLanguage: "en",
-		hasPart: GUIDES.map((guide) => ({
+		name: index.h1,
+		description: index.description,
+		url: `${SITE_URL}${guidePath(locale, "/guides")}`,
+		inLanguage: locale === GUIDE_LOCALE_ZH ? "zh-Hans" : "en",
+		hasPart: guides.map((guide) => ({
 			"@type": "TechArticle",
 			headline: guide.h1,
-			url: `${SITE_URL}/guides/${guide.slug}`,
+			url: `${SITE_URL}${guidePath(locale, `/guides/${guide.slug}`)}`,
 		})),
 	};
+
+	const otherLocale = locale === GUIDE_LOCALE ? GUIDE_LOCALE_ZH : GUIDE_LOCALE;
+	const otherLabel = otherLocale === GUIDE_LOCALE_ZH ? "中文指南" : "Guides in English";
 
 	return (
 		<div className="guides theme-light sky-band band-dawn dawn-glow flex min-h-screen flex-col overflow-x-clip">
 			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 			<SiteHeader hideLocaleSwitcher />
 			<main className="relative mx-auto w-full max-w-[760px] flex-1 px-6 pb-20 pt-32">
-				<h1 className="f-display text-[34px] font-bold t-primary sm:text-[40px]">{GUIDES_INDEX.h1}</h1>
-				<p className="mt-4 max-w-[56ch] text-[17px] leading-relaxed t-secondary">
-					{GUIDES_INDEX.description}
+				<h1 className="f-display text-[34px] font-bold t-primary sm:text-[40px]">{index.h1}</h1>
+				<p className="mt-4 max-w-[56ch] text-[17px] leading-relaxed t-secondary">{index.description}</p>
+				<p className="mt-4 text-[14px] t-tertiary">
+					<a href={guidePath(otherLocale, "/guides")} className="link-quiet underline underline-offset-2">
+						{otherLabel} →
+					</a>
 				</p>
 				<HorizonArc className="mt-9" />
 
 				<div className="mt-10 grid gap-4">
-					{GUIDES.map((guide) => (
+					{guides.map((guide) => (
 						<Link
 							key={guide.slug}
 							href={`/guides/${guide.slug}`}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 import { routing } from "@/i18n/routing";
-import { GUIDES, GUIDE_LOCALE } from "@/lib/guides/guides";
+import { GUIDE_LOCALES, guidePath, guidesFor } from "@/lib/guides/guides";
 
 const SITE_URL = "https://o-c.do";
 
@@ -20,14 +20,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		},
 	}));
 
-	// 指南板块只有英文版：不列 alternates，避免指向不存在的语言版本
-	const guides: MetadataRoute.Sitemap = [
-		{ url: urlFor(GUIDE_LOCALE, "/guides"), lastModified: new Date(GUIDES[0].updated) },
-		...GUIDES.map((guide) => ({
-			url: urlFor(GUIDE_LOCALE, `/guides/${guide.slug}`),
-			lastModified: new Date(guide.updated),
-		})),
-	];
+	// 指南板块只有英文与简体中文两套，且文章各写各的：
+	// 只有索引页互为 alternates，文章不列，避免指向不存在的语言版本
+	const guides: MetadataRoute.Sitemap = GUIDE_LOCALES.flatMap((locale) => {
+		const list = guidesFor(locale);
+		return [
+			{
+				url: `${SITE_URL}${guidePath(locale, "/guides")}`,
+				lastModified: new Date(list[0].updated),
+				alternates: {
+					languages: Object.fromEntries(
+						GUIDE_LOCALES.map((l) => [l, `${SITE_URL}${guidePath(l, "/guides")}`]),
+					),
+				},
+			},
+			...list.map((guide) => ({
+				url: `${SITE_URL}${guidePath(locale, `/guides/${guide.slug}`)}`,
+				lastModified: new Date(guide.updated),
+			})),
+		];
+	});
 
 	return [...localized, ...guides];
 }

--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -4,8 +4,9 @@ import { Link } from "@/i18n/navigation";
 /** 页脚：纯内容、不带天色——颜色全部取自所在 theme 上下文 */
 export default async function SiteFooter() {
 	const t = await getTranslations("footer");
-	// 指南板块目前只有英文版，只在英文页脚露出入口（也是 /guides 的抓取入口）
+	// 指南板块有英文与简体中文两套，只在这两种页脚露出入口（也是 /guides 的抓取入口）
 	const locale = await getLocale();
+	const guidesLabel = locale === "zh-Hans" ? "指南" : "Guides";
 
 	return (
 		<footer className="relative">
@@ -16,9 +17,9 @@ export default async function SiteFooter() {
 				<div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
 					<p className="text-[13px] t-secondary">{t("copyright")}</p>
 					<nav className="flex items-center gap-6 text-[13px]">
-						{locale === "en" && (
+						{(locale === "en" || locale === "zh-Hans") && (
 							<Link href="/guides" className="link-quiet">
-								Guides
+								{guidesLabel}
 							</Link>
 						)}
 						<Link href="/privacy" className="link-quiet">

--- a/apps/web/src/components/guides/GuideShell.tsx
+++ b/apps/web/src/components/guides/GuideShell.tsx
@@ -5,6 +5,7 @@ import SiteFooter from "@/components/SiteFooter";
 import HorizonArc from "@/components/HorizonArc";
 import Stars from "@/components/Stars";
 import { APP_STORE_URL } from "@/components/AppStoreBadge";
+import { GUIDE_LOCALE, type GuideLocale } from "@/lib/guides/guides";
 
 export type RelatedLink = {
 	href: string;
@@ -12,6 +13,30 @@ export type RelatedLink = {
 	note: string;
 	external?: boolean;
 };
+
+/** 外壳自身的固定文案：每个语言版本的指南各自独立成篇，不做逐句互译 */
+const SHELL_COPY = {
+	en: {
+		breadcrumb: "Guides",
+		updated: (date: string, readingTime: string) => `Updated ${date} · ${readingTime}`,
+		keepReading: "Keep reading",
+		appTitle: "Manage this from your phone",
+		appBody:
+			"Orange Cloud is a native iOS and Android client for Cloudflare. Sign in with Cloudflare OAuth and flip proxy status, edit DNS records, and read traffic analytics from anywhere.",
+		appCta: "Get Orange Cloud",
+		dateLocale: "en-US",
+	},
+	"zh-Hans": {
+		breadcrumb: "指南",
+		updated: (date: string, readingTime: string) => `更新于 ${date} · 阅读时间 ${readingTime}`,
+		keepReading: "延伸阅读",
+		appTitle: "在手机上管好 Cloudflare",
+		appBody:
+			"Orange Cloud 是 Cloudflare 的第三方 iOS / Android 客户端，用 Cloudflare 官方 OAuth 登录，随手切代理状态、改 DNS 记录、看隧道状态和流量分析。",
+		appCta: "下载 Orange Cloud",
+		dateLocale: "zh-CN",
+	},
+} as const;
 
 /**
  * 指南文章外壳：沿用首页「一天」的天色叙事——
@@ -24,6 +49,7 @@ export default function GuideShell({
 	updated,
 	readingTime,
 	related,
+	locale = GUIDE_LOCALE,
 	children,
 }: {
 	title: string;
@@ -31,9 +57,11 @@ export default function GuideShell({
 	updated: string;
 	readingTime: string;
 	related: RelatedLink[];
+	locale?: GuideLocale;
 	children: ReactNode;
 }) {
-	const updatedLabel = new Date(`${updated}T00:00:00Z`).toLocaleDateString("en-US", {
+	const copy = SHELL_COPY[locale];
+	const updatedLabel = new Date(`${updated}T00:00:00Z`).toLocaleDateString(copy.dateLocale, {
 		year: "numeric",
 		month: "long",
 		day: "numeric",
@@ -51,7 +79,7 @@ export default function GuideShell({
 							<ol className="flex flex-wrap items-center gap-2 t-secondary">
 								<li>
 									<Link href="/guides" className="link-quiet underline underline-offset-2">
-										Guides
+										{copy.breadcrumb}
 									</Link>
 								</li>
 								<li aria-hidden="true">/</li>
@@ -62,9 +90,7 @@ export default function GuideShell({
 							{title}
 						</h1>
 						<p className="mt-4 text-[18px] leading-relaxed t-secondary">{lede}</p>
-						<p className="mt-5 text-[13px] t-tertiary">
-							Updated {updatedLabel} · {readingTime}
-						</p>
+						<p className="mt-5 text-[13px] t-tertiary">{copy.updated(updatedLabel, readingTime)}</p>
 						<HorizonArc className="mt-10" />
 					</div>
 				</section>
@@ -77,7 +103,7 @@ export default function GuideShell({
 				{/* —— 延伸阅读 · 黄昏 —— */}
 				<section className="sky-band band-dusk">
 					<div className="mx-auto w-full max-w-[760px] px-6 py-16">
-						<h2 className="f-display text-[24px] font-bold t-primary">Keep reading</h2>
+						<h2 className="f-display text-[24px] font-bold t-primary">{copy.keepReading}</h2>
 						<div className="mt-6 grid gap-3">
 							{related.map((item) =>
 								item.external ? (
@@ -124,13 +150,10 @@ export default function GuideShell({
 					<Stars />
 					<div className="relative mx-auto w-full max-w-[760px] px-6 pt-16">
 						<div className="glass r-island p-7 sm:p-8">
-							<h2 className="f-display text-[22px] font-bold t-primary">Manage this from your phone</h2>
-							<p className="mt-2.5 text-[15px] leading-relaxed t-secondary">
-								Orange Cloud is a native iOS and Android client for Cloudflare. Sign in with Cloudflare
-								OAuth and flip proxy status, edit DNS records, and read traffic analytics from anywhere.
-							</p>
+							<h2 className="f-display text-[22px] font-bold t-primary">{copy.appTitle}</h2>
+							<p className="mt-2.5 text-[15px] leading-relaxed t-secondary">{copy.appBody}</p>
 							<a href={APP_STORE_URL} className="cta-store mt-6 text-[15px]">
-								Get Orange Cloud
+								{copy.appCta}
 							</a>
 						</div>
 					</div>

--- a/apps/web/src/components/guides/TunnelFlow.tsx
+++ b/apps/web/src/components/guides/TunnelFlow.tsx
@@ -1,0 +1,107 @@
+/**
+ * 内网穿透的连接方向图：连接由内网的 cloudflared 主动向外建立，
+ * 公网侧从头到尾没有一个入站端口。纯 SVG、无 JS；配色走主题 token，
+ * 竖版布局，窄屏不溢出。
+ */
+export default function TunnelFlow() {
+	const box = (y: number) => ({ x: 30, y, width: 300, height: 54, rx: 14 });
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 400"
+				role="img"
+				aria-label="Cloudflare Tunnel 的连接方向：公网访客先到达 Cloudflare 全球网络，内网里的 cloudflared 主动从 7844 端口向 Cloudflare 建立出站连接，再把请求转给本机上的服务，整个过程不需要公网 IP，也不需要开放任何入站端口。"
+				className="mx-auto block h-auto w-full max-w-[420px]"
+			>
+				<title>Cloudflare Tunnel 的连接方向</title>
+
+				{/* 1 · 公网访客 */}
+				<rect {...box(16)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="48" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					公网访客
+				</text>
+				<text x="180" y="64" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					打开 nas.example.com
+				</text>
+
+				{/* 2 · Cloudflare 网络 */}
+				<rect {...box(112)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="144" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare 全球网络
+				</text>
+				<text x="180" y="160" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					缓存 · WAF · DDoS 防护在这一层生效
+				</text>
+
+				{/* 3 · 你的内网 */}
+				<rect
+					x="14"
+					y="196"
+					width="332"
+					height="196"
+					rx="20"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.35"
+					strokeDasharray="4 5"
+				/>
+				<text x="30" y="216" fontSize="11" fill="var(--t-tertiary)" letterSpacing="0.6">
+					你的内网 · 没有公网 IP
+				</text>
+
+				<rect {...box(228)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="260" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					cloudflared
+				</text>
+				<text x="180" y="276" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					装在 NAS / 软路由 / 任意一台机器上
+				</text>
+
+				<rect {...box(328)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="360" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					内网服务
+				</text>
+				<text x="180" y="376" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					http://localhost:8080
+				</text>
+
+				<defs>
+					<marker
+						id="tunnel-arrow"
+						viewBox="0 0 8 8"
+						refX="6"
+						refY="4"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto"
+					>
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#tunnel-arrow)" fill="none">
+					<path d="M180 74 L180 106" />
+					{/* 关键的一笔：箭头朝上，连接是从内网往外发起的 */}
+					<path d="M180 224 L180 172" />
+					<path d="M180 288 L180 322" />
+				</g>
+
+				<text x="194" y="186" fontSize="11.5" fill="var(--t-secondary)">
+					主动出站建连
+				</text>
+				<text
+					x="194"
+					y="202"
+					fontSize="11.5"
+					fill="var(--t-secondary)"
+					fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+				>
+					TCP/UDP 7844
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				连接只有一个方向：从内网往外。防火墙不必放行任何入站流量，也就不需要端口映射、DDNS 或公网 IP。
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -1,9 +1,23 @@
 /**
- * 指南板块（/guides）的清单——目前只有英文版：
- * 这批查询（orange cloud / orange-to-orange）几乎全是英文，
- * 不为不存在的语言写 hreflang，避免稀薄内容与软 404。
+ * 指南板块（/guides）的清单——按语言分列：
+ * 英文一套（/guides/…）、简体中文一套（/zh-Hans/guides/…）。
+ * 两套选题各自独立、互不翻译：英文追 orange cloud / O2O 这类英文查询，
+ * 中文追「内网穿透」「回源」这类中文查询。因此**不为文章写跨语言 hreflang**，
+ * 只有索引页两语并列（同一份栏目，两个语言版本）。
  */
 export const GUIDE_LOCALE = "en";
+export const GUIDE_LOCALE_ZH = "zh-Hans";
+export const GUIDE_LOCALES = [GUIDE_LOCALE, GUIDE_LOCALE_ZH] as const;
+export type GuideLocale = (typeof GUIDE_LOCALES)[number];
+
+export function isGuideLocale(locale: string): locale is GuideLocale {
+	return (GUIDE_LOCALES as readonly string[]).includes(locale);
+}
+
+/** 站内绝对路径：默认语言无前缀（与 next-intl 的 as-needed 一致） */
+export function guidePath(locale: GuideLocale, path: string) {
+	return locale === GUIDE_LOCALE ? path : `/${locale}${path}`;
+}
 
 export type GuideMeta = {
 	slug: string;
@@ -67,10 +81,28 @@ export const GUIDES: GuideMeta[] = [
 	},
 ];
 
-export function guideBySlug(slug: string): GuideMeta {
-	const guide = GUIDES.find((g) => g.slug === slug);
-	if (!guide) throw new Error(`Unknown guide: ${slug}`);
+export const GUIDES_ZH: GuideMeta[] = [
+	{
+		slug: "cloudflare-tunnel-neiwang-chuantou",
+		h1: "没有公网 IP，怎么用 Cloudflare Tunnel 做内网穿透？",
+		title: "Cloudflare Tunnel 内网穿透：没有公网 IP 也能用",
+		description:
+			"cloudflared 从内网主动向 Cloudflare 建立出站连接，所以不需要公网 IP，也不用在路由器上开放端口。本文讲清它与 frp 的差别、配置步骤，以及免费方案的真实限制。",
+		blurb:
+			"出站连接模型、三种隧道形态的取舍、五分钟配置流程，以及 100 MB 上传上限、视频类内容条款、大陆访问绕境外这些必须先知道的边界。",
+		updated: "2026-08-21",
+		readingTime: "约 9 分钟",
+	},
+];
+
+export function guideBySlug(slug: string, locale: GuideLocale = GUIDE_LOCALE): GuideMeta {
+	const guide = guidesFor(locale).find((g) => g.slug === slug);
+	if (!guide) throw new Error(`Unknown guide: ${locale} ${slug}`);
 	return guide;
+}
+
+export function guidesFor(locale: GuideLocale): GuideMeta[] {
+	return locale === GUIDE_LOCALE_ZH ? GUIDES_ZH : GUIDES;
 }
 
 export const GUIDES_INDEX = {
@@ -79,3 +111,14 @@ export const GUIDES_INDEX = {
 	description:
 		"Plain-language guides to the Cloudflare settings people actually search for: the orange cloud, proxy status, SSL/TLS encryption modes, and caching.",
 };
+
+export const GUIDES_INDEX_ZH = {
+	title: "Cloudflare 指南 — Orange Cloud",
+	h1: "Cloudflare 指南",
+	description:
+		"用人话讲清楚 Cloudflare 里那些真正被搜索的问题：内网穿透、代理状态、回源与缓存、SSL/TLS 加密模式。每篇都对着官方文档逐条核过。",
+};
+
+export function guidesIndexFor(locale: GuideLocale) {
+	return locale === GUIDE_LOCALE_ZH ? GUIDES_INDEX_ZH : GUIDES_INDEX;
+}


### PR DESCRIPTION
## 这是什么

`/guides` 从「只有英文」扩成按语言分列的两套：英文留在 `/guides`，简体中文在 `/zh-Hans/guides`。**两套选题各写各的、互不翻译**，只有索引页互为 hreflang（`en` ↔ `zh-Hans` ↔ `x-default`），文章级 `languages` 只自指——因为两语文章不是同一篇内容。

首篇中文文章：[没有公网 IP，怎么用 Cloudflare Tunnel 做内网穿透？](https://o-c.do/zh-Hans/guides/cloudflare-tunnel-neiwang-chuantou)

## 选题依据

「内网穿透」是中文技术圈长期高频的搜索需求，起点是国内家宽普遍拿不到公网 IP；Cloudflare Tunnel 又恰好是 App 已覆盖的能力（Tunnel 查看模块）。英文那套指南里没有对应文章，两边不重题。

面向大陆读者的差异化在于：文章专门写了国内环境下才会撞上的边界——免费方案不走大陆节点、备案义务与隧道无关、100 MB 上传上限、CDN 条款对视频与大文件的限制、UDP 不在公网发布的支持范围内。这些恰恰是社区里最常被误解的部分。

## 核对官方文档时修正 / 放弃的论断

全部论断对着 Cloudflare 现行文档逐条核过（`<url>/index.md` 取原文）：

- **文档已改版**：公网发布用的 Tunnel 在 2026 年从 Zero Trust 文档独立成 [/tunnel](https://developers.cloudflare.com/tunnel/)，凭记忆写的路径已全部作废，本文按新文档写。
- **Quick Tunnel 的限制**：官方明确写了「并发上限 200、不支持 SSE、仅供测试」，原本只打算写「仅供测试」，按文档补全。
- **1016 还是 1033**：路由文档说隧道停掉后访客看到 `1016`，而 1033 说明页描述的是「找不到健康的 cloudflared 实例」。没有替官方二选一，文中如实写出两处出入，让读者一律先查隧道状态。
- **服务条款**：老的 Self-Serve Agreement 第 2.8 条（非 HTML 内容限制）已不在协议正文里；现行出处是 [Service-Specific Terms](https://www.cloudflare.com/service-specific-terms-application-services/) 的 CDN 段落，文中按现行条款表述并链过去。
- **放弃的论断**：原打算写 Zero Trust 免费席位数，公开文档里核不到当前口径，直接删掉不写。
- **UDP**：路由文档的协议表里没有 UDP，文中据此说明公网发布不覆盖 UDP，并指向 Cloudflare One 私有网络方案，措辞留了余地。

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `pnpm build` | 通过，无新增告警 |
| 2 | `npx vitest run` | 19 files / 133 tests 全绿 |
| 3 | `npx eslint`（改动文件） | 0 error（SiteFooter 的 3 条 no-img-element 是既有 warning） |
| 4 | `npx tsc --noEmit` | 仅既有的 5 条 `node:sqlite` 类型缺失，无新增 |
| 5 | canonical / hreflang | `https://o-c.do/zh-Hans/guides/cloudflare-tunnel-neiwang-chuantou` 自引用；文章 hreflang 只有 `zh-Hans`；索引页 en / zh-Hans / x-default 三条 |
| 6 | JSON-LD | `TechArticle` + `FAQPage` + `BreadcrumbList` 均可解析；5 条 FAQ 的问与答逐字出现在渲染正文里（脚本断言） |
| 7 | 标题层级 | 单个 h1，h1 → h2 → h3 无跳级 |
| 8 | 横向溢出 | 375 / 768 / 1280 三档 `scrollWidth == clientWidth`（playwright webkit 离线量） |
| 9 | 外链存活 | 12 条全部 200 |
| 10 | 字数 | 正文 3072 汉字 |
| 11 | 语言门控 | `/en/guides/<slug>` 与 `/zh-Hant/guides/<slug>` 预渲染为 not-found 页 |

## 顺带

新增每日定时任务 `daily-guide-article-zh`（04:22，与英文那条 02:0x 错开），规则与英文版同源，另加了两条中文专属约束：正文 2000–3200 汉字、规避审查类题材不碰。