### PR TITLE
feat(web): /guides 新增《Cloudflare DNS 改动为什么还没生效》

### DIFF
--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -50,6 +50,11 @@ const RELATED: RelatedLink[] = [
 		note: "Proxying is what makes caching possible — here is why most pages still are not cached.",
 	},
 	{
+		href: "/guides/why-is-my-cloudflare-dns-change-not-working",
+		label: "Why isn\u2019t my Cloudflare DNS change working yet?",
+		note: "Flipping the cloud is a record change like any other \u2014 here is which cache decides how long it takes.",
+	},
+	{
 		href: "https://developers.cloudflare.com/dns/proxy-status/",
 		label: "Cloudflare docs: Proxy status",
 		note: "The official reference for proxied and DNS-only records, including limitations and use cases.",

--- a/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
@@ -1,0 +1,407 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import DnsCacheLayers from "@/components/guides/DnsCacheLayers";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("why-is-my-cloudflare-dns-change-not-working");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_FAQ = "https://developers.cloudflare.com/dns/faq/";
+const DOCS_TTL = "https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/";
+const DOCS_ISSUES = "https://developers.cloudflare.com/dns/troubleshooting/dns-issues/";
+const DOCS_PENDING = "https://developers.cloudflare.com/dns/zone-setups/troubleshooting/pending-nameservers/";
+const DOCS_FULL_TROUBLE = "https://developers.cloudflare.com/dns/zone-setups/full-setup/troubleshooting/";
+const DOCS_NS_TTL = "https://developers.cloudflare.com/dns/nameservers/nameserver-options/#nameserver-ttl";
+const DOCS_PROXY = "https://developers.cloudflare.com/dns/proxy-status/";
+const DOCS_STATUS = "https://developers.cloudflare.com/dns/zone-setups/reference/domain-status/";
+const DOCS_DNSSEC = "https://developers.cloudflare.com/dns/dnssec/";
+const PURGE_CF = "https://one.one.one.one/purge-cache/";
+const PURGE_GOOGLE = "https://dns.google/cache";
+const RFC_2308 = "https://datatracker.ietf.org/doc/html/rfc2308";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "How long does a Cloudflare DNS change take to take effect?",
+		a: "Cloudflare publishes the change on its own nameservers globally within five minutes, and usually much less. Everything longer than that is a cache somewhere else expiring — most often a recursive resolver still holding the previous record for the length of its TTL.",
+	},
+	{
+		q: "Why does my new DNS record still return NXDOMAIN?",
+		a: "Because a resolver asked for that hostname before it existed and cached the empty answer. The length of that negative cache comes from the MINIMUM field of your zone's SOA record, not from the TTL of the record you just created, so lowering the record's TTL does not shorten the wait.",
+	},
+	{
+		q: "Does lowering the TTL make a DNS change apply faster?",
+		a: "Only if you lower it before making the change. Resolvers that already cached the old record keep it for the old TTL, so the new, shorter value is only honoured once that entry expires. Lower the TTL a day ahead of a planned migration, then change the record.",
+	},
+	{
+		q: "How do I check whether Cloudflare has the new record?",
+		a: "Query a Cloudflare authoritative nameserver directly with dig @hera.ns.cloudflare.com example.com A, substituting one of the nameservers assigned to your zone. That bypasses every resolver cache, so it shows what Cloudflare is actually publishing right now.",
+	},
+	{
+		q: "Why does dig still show an old IP address after I changed a proxied record?",
+		a: "It does not — a proxied record is answered with Cloudflare anycast addresses, never with your origin IP. If dig returns your server's real address, that hostname is set to DNS only, or the answer you are looking at came from a cache that predates the change.",
+	},
+	{
+		q: "Does flushing my DNS cache fix a DNS change that has not applied?",
+		a: "Only when your own machine is the layer holding the stale answer. Flushing clears your operating system and browser caches, but the recursive resolver upstream of you — your ISP's, or a public one — keeps its copy until its own TTL runs out.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "Why a proxied record never returns your origin IP — and why that changes what dig can tell you.",
+	},
+	{
+		href: "/guides/why-is-cloudflare-not-caching-my-site",
+		label: "Why is Cloudflare not caching my site?",
+		note: "The other kind of stale answer: the one Cloudflare itself is serving from cache.",
+	},
+	{
+		href: DOCS_ISSUES,
+		label: "Cloudflare docs: General DNS issues",
+		note: "The official walkthrough, including the negative-caching case and the dig commands for it.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function DnsChangeGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="Waiting is the standard advice, and it is usually the wrong advice — because the thing you are waiting for is not Cloudflare. Four layers can hold the old answer, and each one has a different fix."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						Cloudflare publishes zone changes globally in under five minutes. If a change still is not live,
+						something is holding the old answer: a record TTL, a negatively cached <code>NXDOMAIN</code>, or
+						a delegation that never moved.
+					</p>
+				</div>
+
+				<p>
+					&ldquo;DNS propagation&rdquo; describes something that does not happen. No record is pushed out to
+					the world&rsquo;s resolvers. Authoritative nameservers hold the current answer and wait to be asked;
+					every other machine in the chain keeps a copy for as long as it was told to. So the delay you are
+					sitting through is never Cloudflare publishing the change — Cloudflare&rsquo;s own documentation
+					puts that at{" "}
+					<a href={DOCS_FAQ} target="_blank" rel="noopener noreferrer">
+						within five minutes, usually much less
+					</a>
+					. It is a cache expiring, and which cache decides what you should do about it.
+				</p>
+
+				<h2 id="layers">Four places the old answer can be sitting</h2>
+				<DnsCacheLayers />
+				<p>
+					A lookup walks down this stack and stops at the first layer that already has an answer. Restarting
+					your browser fixes exactly one of these layers. Waiting fixes another. The bottom two are not caches
+					at all and never fix themselves — a delegation that points at the wrong nameservers will still be
+					wrong tomorrow.
+				</p>
+
+				<h2 id="ask-authoritative">Start by asking the authoritative nameserver</h2>
+				<p>
+					Before diagnosing anything, find out what Cloudflare is actually publishing. Querying a Cloudflare
+					nameserver directly skips every cache above it:
+				</p>
+				<pre>
+					<code>dig @1.1.1.1 example.com NS +short{"\n"}dig @hera.ns.cloudflare.com www.example.com A</code>
+				</pre>
+				<p>
+					Use whichever nameserver names the first command returns for your zone. The answer splits the
+					problem cleanly in two:
+				</p>
+				<ul>
+					<li>
+						<strong>The new value is there.</strong> Cloudflare has done its part. The remaining wait is a
+						cache above it, and the sections below cover which one.
+					</li>
+					<li>
+						<strong>The new value is not there, or the query fails.</strong> The record was not saved as you
+						think it was, the hostname does not match exactly, or your zone is not delegated to these
+						nameservers at all. Skip to{" "}
+						<a href="#delegation">the delegation section</a>.
+					</li>
+				</ul>
+
+				<h2 id="ttl">Case one: the TTL has not run out</h2>
+				<p>
+					A resolver holding the previous record keeps it for the TTL it was handed <em>at the time it
+					cached it</em>. That is the single most misunderstood point here: editing the TTL now has no effect
+					on a copy that is already cached. The values Cloudflare allows:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Record</th>
+								<th scope="col">TTL</th>
+								<th scope="col">Worst-case wait</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Proxied (orange cloud)</th>
+								<td>Auto, fixed at 300 seconds, not editable</td>
+								<td>5 minutes</td>
+							</tr>
+							<tr>
+								<th scope="row">DNS only, Auto</th>
+								<td>300 seconds</td>
+								<td>5 minutes</td>
+							</tr>
+							<tr>
+								<th scope="row">DNS only, custom</th>
+								<td>60 seconds to 1 day (30 seconds on Enterprise)</td>
+								<td>Whatever you set — up to 24 hours</td>
+							</tr>
+							<tr>
+								<th scope="row">Nameserver (NS) TTL</th>
+								<td>86,400 seconds by default</td>
+								<td>24 hours</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Two consequences worth internalising. First, proxied records are{" "}
+					<a href={DOCS_TTL} target="_blank" rel="noopener noreferrer">
+						pinned to five minutes
+					</a>{" "}
+					precisely so Cloudflare can move its anycast addresses without stranding anyone — which means an
+					orange-clouded hostname can never be more than five minutes stale. Second, the{" "}
+					<a href={DOCS_NS_TTL} target="_blank" rel="noopener noreferrer">
+						nameserver TTL
+					</a>{" "}
+					is a separate 24-hour figure, so a zone that has just moved to Cloudflare can look inconsistent for
+					a full day even when every record is correct.
+				</p>
+
+				<h2 id="negative-cache">Case two: the resolver cached &ldquo;this does not exist&rdquo;</h2>
+				<p>
+					This is the failure that sends people in circles. You add a brand-new subdomain, it returns{" "}
+					<code>NXDOMAIN</code>, you lower the TTL, you flush your cache, you wait — and nothing changes.
+				</p>
+				<p>
+					The reason is <strong>negative caching</strong>. When a resolver is asked for a hostname that has no
+					records, it caches the absence, so it does not have to ask again immediately. If anything queried
+					your hostname before you created it — a monitoring check, a certificate probe, your own impatient
+					browser — that empty answer is now stored. Per{" "}
+					<a href={RFC_2308} target="_blank" rel="noopener noreferrer">
+						RFC 2308
+					</a>
+					, its lifetime comes from the <code>MINIMUM</code> field of your zone&rsquo;s <code>SOA</code>{" "}
+					record, and Cloudflare&rsquo;s{" "}
+					<a href={DOCS_ISSUES} target="_blank" rel="noopener noreferrer">
+						troubleshooting guidance
+					</a>{" "}
+					spells out what follows from that:
+				</p>
+				<ul>
+					<li>Lowering the new record&rsquo;s TTL changes nothing, because the entry being served is not your record.</li>
+					<li>Flushing locally changes nothing, because the entry lives in the resolver upstream of you.</li>
+					<li>
+						Different resolvers queried the name at different moments and apply different limits, which is
+						exactly why the result looks like it is &ldquo;propagating&rdquo; unevenly.
+					</li>
+				</ul>
+				<p>You can watch the countdown rather than guess at it:</p>
+				<pre>
+					<code>dig +noall +answer +authority newhost.example.com</code>
+				</pre>
+				<p>
+					If the answer section is empty and the authority section returns your <code>SOA</code>, the number
+					beside it is how many seconds remain before that resolver will ask again. To stop waiting on the two
+					big public resolvers, purge the name directly at{" "}
+					<a href={PURGE_CF} target="_blank" rel="noopener noreferrer">
+						1.1.1.1
+					</a>{" "}
+					and{" "}
+					<a href={PURGE_GOOGLE} target="_blank" rel="noopener noreferrer">
+						8.8.8.8
+					</a>
+					. The habit that prevents all of this: create the record first, and only then point anything at the
+					hostname.
+				</p>
+
+				<h2 id="delegation">Case three: the zone is not really delegated to Cloudflare</h2>
+				<p>
+					If the authoritative query in the first step came back empty or failed, no amount of waiting will
+					help. Check what the parent zone publishes, rather than what your registrar&rsquo;s control panel
+					claims:
+				</p>
+				<pre>
+					<code>dig +trace example.com NS +noall +authority +nodnssec</code>
+				</pre>
+				<p>The usual causes, all of them things you have to go and fix:</p>
+				<ol>
+					<li>
+						<strong>The nameservers do not match exactly.</strong> Each zone is assigned a specific pair,
+						and re-adding a deleted domain gets a fresh pair. A previously working set may no longer be the
+						right one, and typos like <code>cloudfare.com</code> are common enough that Cloudflare{" "}
+						<a href={DOCS_PENDING} target="_blank" rel="noopener noreferrer">
+							calls them out by name
+						</a>
+						.
+					</li>
+					<li>
+						<strong>Extra nameservers are still listed.</strong> The registrar should list the Cloudflare
+						nameservers and nothing else.
+					</li>
+					<li>
+						<strong>A stale DS record is still published.</strong> DNSSEC from your previous provider blocks
+						the delegation and produces <code>SERVFAIL</code> until{" "}
+						<a href={DOCS_DNSSEC} target="_blank" rel="noopener noreferrer">
+							the old DS record is removed
+						</a>{" "}
+						and its TTL at the parent has expired — commonly 24 to 48 hours for most top-level domains.
+					</li>
+					<li>
+						<strong>The registrar has not published the change yet.</strong> Some take{" "}
+						<a href={DOCS_FULL_TROUBLE} target="_blank" rel="noopener noreferrer">
+							up to 24 hours
+						</a>
+						. This one really is a wait — but confirm it with <code>dig +trace</code> rather than assuming.
+					</li>
+				</ol>
+				<p>
+					A zone sitting in <strong>Pending Nameserver Update</strong> is Cloudflare telling you it cannot see
+					the delegation either; the{" "}
+					<a href={DOCS_STATUS} target="_blank" rel="noopener noreferrer">
+						zone status reference
+					</a>{" "}
+					explains what each state means, including the <strong>Moved</strong> state that eventually deletes
+					the zone.
+				</p>
+
+				<h2 id="proxied">When DNS is correct and the site is still wrong</h2>
+				<p>
+					One case looks like a DNS delay and is not one at all. A{" "}
+					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">proxied record</Link> is answered with
+					Cloudflare anycast addresses, never with your server&rsquo;s address — so if you change the origin
+					IP behind a proxied hostname, <em>the DNS answer does not change</em>. There is nothing for a
+					resolver to re-fetch, and <code>dig</code> cannot confirm the change either way. The new origin
+					takes effect at the edge within the same few minutes Cloudflare needs to publish it.
+				</p>
+				<p>
+					Toggling proxy status is the opposite case, and it is asymmetric. Turning the proxy{" "}
+					<strong>off</strong> replaces a record whose TTL was pinned at 300 seconds, so it settles in about
+					five minutes. Turning it <strong>on</strong> has to wait out the DNS-only TTL that was in force
+					before — which, if someone set it to a day, means a day of visitors still reaching your origin
+					directly. Lower that TTL first, then flip the switch. The{" "}
+					<a href={DOCS_PROXY} target="_blank" rel="noopener noreferrer">
+						proxy status reference
+					</a>{" "}
+					covers what else changes with it.
+				</p>
+
+				<h2 id="planned">Making the next change painless</h2>
+				<ol>
+					<li>
+						Lower the TTL on the records you are about to change to 60 or 300 seconds, and do it at least
+						one old-TTL period in advance.
+					</li>
+					<li>Wait out the old TTL. Until it expires, resolvers are still handing out the long one.</li>
+					<li>Make the change, then verify against an authoritative nameserver before testing anywhere else.</li>
+					<li>
+						Create records before anything queries their hostnames, so no negative cache entry is ever
+						created.
+					</li>
+					<li>Once the change is stable, raise the TTL back up — long TTLs are good for everyone the rest of the time.</li>
+				</ol>
+				<p>
+					None of this needs a fourth tool: <code>dig</code>, the record itself, and knowing which of the four
+					layers you are talking to will resolve nearly every &ldquo;my DNS change is not working&rdquo;
+					report.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/components/guides/DnsCacheLayers.tsx
+++ b/apps/web/src/components/guides/DnsCacheLayers.tsx
@@ -1,0 +1,89 @@
+/**
+ * DNS 应答的四层缓存图：浏览器/系统 → 递归解析器 → 父区委派 → Cloudflare 权威。
+ * 上三层都可能拿着旧答案，最底下那层永远是当前值——文章的核心论点。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function DnsCacheLayers() {
+	const box = (y: number) => ({ x: 30, y, width: 300, height: 54, rx: 14 });
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 400"
+				role="img"
+				aria-label="Four layers sit between a visitor and the answer to a DNS query. From the top: your browser and operating system, the recursive resolver used by the visitor, the parent zone delegation at the registry, and Cloudflare's authoritative nameservers at the bottom. Only the bottom layer always holds the current record; the three layers above it can all serve a stale answer."
+				className="mx-auto block h-auto w-full max-w-[420px]"
+			>
+				<title>Where a stale DNS answer can be held</title>
+
+				<defs>
+					<marker id="dns-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+
+				{/* 上三层：任何一层都可能压着旧答案 */}
+				<rect
+					x="14"
+					y="8"
+					width="332"
+					height="286"
+					rx="20"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.35"
+					strokeDasharray="4 5"
+				/>
+				<text x="180" y="28" textAnchor="middle" fontSize="11" fill="var(--t-tertiary)" letterSpacing="0.6">
+					CAN HOLD A STALE ANSWER
+				</text>
+
+				{/* 1 · 浏览器与系统 */}
+				<rect {...box(40)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="72" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Your browser and OS
+				</text>
+				<text x="180" y="88" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					flushable, but only for you
+				</text>
+
+				{/* 2 · 递归解析器：绝大多数「没生效」都停在这一层 */}
+				<rect {...box(136)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="168" textAnchor="middle" fontSize="14" fontWeight="600" fill="var(--t-primary)">
+					Recursive resolver (ISP, 1.1.1.1)
+				</text>
+				<text x="180" y="184" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					holds the TTL — or a cached NXDOMAIN
+				</text>
+
+				{/* 3 · 父区委派 */}
+				<rect {...box(234)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="266" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Parent zone delegation
+				</text>
+				<text x="180" y="282" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					NS records; registrar edits can lag
+				</text>
+
+				{/* 4 · 权威：唯一永远是当前值的一层 */}
+				<rect {...box(334)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="366" textAnchor="middle" fontSize="14" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare authoritative nameservers
+				</text>
+				<text x="180" y="382" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					updated globally within five minutes
+				</text>
+
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#dns-arrow)" fill="none">
+					<path d="M180 98 L180 130" />
+					<path d="M180 194 L180 228" />
+					<path d="M180 292 L180 328" />
+				</g>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				A query stops at the first layer that already has an answer — which is why the fix depends on which layer
+				is holding it.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -79,6 +79,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-20",
 		readingTime: "8 min read",
 	},
+	{
+		slug: "why-is-my-cloudflare-dns-change-not-working",
+		h1: "Why Isn\u2019t My Cloudflare DNS Change Working Yet?",
+		title: "Cloudflare DNS Change Not Working? Propagation Explained",
+		description:
+			"Cloudflare publishes zone changes globally within five minutes. The wait is a cache: a record TTL, a negatively cached NXDOMAIN, or a stale delegation.",
+		blurb:
+			"Nothing propagates \u2014 caches expire. Which of the four layers is holding your old answer, and why lowering the TTL cannot fix a cached NXDOMAIN.",
+		updated: "2026-08-21",
+		readingTime: "8 min read",
+	},
 ];
 
 export const GUIDES_ZH: GuideMeta[] = [


### PR DESCRIPTION
## 选题依据

真实搜索问句「Cloudflare DNS change not working / how long does DNS propagation take」，且四条门槛全满足：

1. 用户在搜「怎么回事 / 为什么还没生效」，不是我们想讲什么；
2. DNS 是 App 覆盖的核心能力（Zone/DNS 全功能，免费层就有）；
3. 每条论断都能在 Cloudflare 官方文档当前版本核实（链接见下）；
4. 与已有四篇不重复，并与《What does the orange cloud mean in Cloudflare?》做了**双向内链**。

切入角度：「DNS 传播」这件事本身不存在——权威侧五分钟内全球生效，剩下的等待都是某一层缓存在过期。文章按四层拆解，每层对应不同的处理方式。

## 核对官方文档时修正 / 放弃了哪些论断

| 动笔前的想法 | 核对后 |
|---|---|
| 笼统写「DNS 生效要 24–48 小时」 | 改为官方口径：[zone 改动五分钟内全球生效，通常远快于此](https://developers.cloudflare.com/dns/faq/)。24 小时是**注册商发布委派**的上限，不是记录改动 |
| 只打算写「调低 TTL 让改动更快生效」 | 补上关键限定：只有**提前**调低才有用；已缓存的副本按旧 TTL 走。这条现在单独成一条 FAQ |
| 想把 NXDOMAIN 归因为 TTL | [官方明确](https://developers.cloudflare.com/dns/troubleshooting/dns-issues/)负缓存时长由 zone 的 SOA `MINIMUM` 决定（[RFC 2308](https://datatracker.ietf.org/doc/html/rfc2308)），**与新记录的 TTL 无关**，本地 flush 也无效。这是全文最有价值的一段 |
| 打算写 DNS-only 记录 TTL「最低 60 秒」 | [TTL 文档](https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/)：非企业版 60 秒、企业版 30 秒，Auto = 300 秒；代理记录固定 300 秒且不可编辑 |
| 以为 NS 记录 TTL 跟随记录 TTL | [是独立设置](https://developers.cloudflare.com/dns/nameservers/nameserver-options/#nameserver-ttl)，默认 86400 秒——刚迁到 Cloudflare 的 zone 因此可能整整一天表现不一致 |
| 放弃：写「改了源站 IP 要等 DNS 生效」 | 对**代理记录**是错的——应答始终是 anycast 地址，改源站 IP 时 [DNS 应答根本不变](https://developers.cloudflare.com/dns/proxy-status/)，没有任何解析器缓存参与。改成了单独一节，并指出开关代理是**不对称**的（关代理等 300 秒，开代理要等原 DNS-only TTL，可能是一天） |

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（仅环境性 proxy env 提示） |
| 2 | `npx vitest run` | ✅ 19 文件 / 133 测试全绿 |
| 3 | `npx eslint` 新增改动文件 | ✅ exit 0，无 error |
| 4 | 新 URL 返回 200 | ⚠️ **`preview_start` 在无人值守会话下被禁用**，改为核对 build 产物：`.next/server/app/en/guides/…/.meta` 无 status 字段（=200），`zh-Hans` 等其它语言为 404，与 `GUIDE_LOCALE` 门控预期一致。合并部署后已 curl 线上确认 |
| 5 | canonical 自引用 + hreflang 只有 en / x-default | ✅ 脚本断言通过 |
| 6 | JSON-LD 可 `json.loads` + FAQ 逐字出现在可见正文 | ✅ 2 个 block 全部解析成功；6 条问答逐字命中（脚本断言，非肉眼） |
| 7 | 标题层级无跳级 | ✅ 唯一 h1，无 h(n)→h(n+2) |
| 8 | 375px 无横向溢出 | ✅ `.table-wrap` / `.prose pre` 均 `overflow-x: auto`；同一 GuideShell 的线上文章实测 `scrollWidth == clientWidth == 375`。本页结构相同且最宽原子更窄 |
| 9 | 外链全部 2xx/3xx | ✅ 12 条全部 200 |
| 10 | 词数 1000–1800 | ✅ 1562 词 |

## 其它

- 正文内 Orange Cloud 提及 **0 处**（仅 GuideShell 页脚那张卡，与既有文章完全一致：整页计数 31，与 `why-is-cloudflare-not-caching-my-site` 相同）
- 新增 `DnsCacheLayers.tsx` 内联 SVG：走主题 CSS 变量、竖版、`role="img"` + `aria-label` + `<title>`
- 未新增任何 JS 依赖，未改首页 / 隐私 / 条款，未生成非英语版本