### PR TITLE
feat(web): IndexNow 变更自动推送（清单与 sitemap 同源 + 端点降级）

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,15 +28,19 @@ What's wired up:
 - **`public/llms.txt`** — Markdown overview of the product, key pages, pricing, and the GitHub repo for AI retrieval ([spec](https://llmstxt.org)).
 - **`sitemap.ts`** emits all pages with full hreflang alternates; `generateMetadata` covers canonical, hreflang, Open Graph, Twitter card, and `itunes` app association.
 - **JSON-LD** (`SoftwareApplication`) in the locale layout — only the Bing/Copilot index-enrichment path is known to consume it, so it stays minimal.
-- **IndexNow key** at `public/ae4368227a78d73327c42c34949e9075.txt`. After publishing new content, ping:
+- **IndexNow** — changed pages are pushed to Bing (and Yandex / Seznam / Naver / Yep, which share the protocol) automatically:
+  - the URL list is generated from [`src/lib/site/urls.ts`](src/lib/site/urls.ts), the same source `sitemap.ts` reads. Each entry carries an `updated` date — **bump it when you change a page**, that date is both the sitemap `lastmod` and the "has this changed?" test;
+  - the daily cron in [`custom-worker.ts`](custom-worker.ts) (UTC 08:00) diffs that list against the `indexnow_urls` ledger in D1 and submits only what changed, then records it. Nothing changed → no outbound request;
+  - submissions go to `bing.com/indexnow` first, falling back to `api.indexnow.org` then `yandex.com/indexnow` — the protocol shares a submission with every participating engine, so the first 2xx is enough. **The neutral `api.indexnow.org` endpoint 429s from Cloudflare Workers egress IPs** (measured 2026-08-21: 429 for a single URL with no `Retry-After`, while the identical body from a residential IP got 202) — that's why it isn't first;
+  - the key file [`public/ae4368227a78d73327c42c34949e9075.txt`](public/ae4368227a78d73327c42c34949e9075.txt) is how search engines verify the domain. Don't delete or rename it.
+
+  To push immediately after publishing (instead of waiting for the cron), with the admin password:
 
   ```bash
-  curl -X POST "https://api.indexnow.org/indexnow" -H "Content-Type: application/json" -d '{
-    "host": "o-c.do",
-    "key": "ae4368227a78d73327c42c34949e9075",
-    "urlList": ["https://o-c.do/"]
-  }'
+  curl -X POST "https://o-c.do/api/indexnow" -H "Authorization: Bearer $ADMIN_PASSWORD"
   ```
+
+  `GET /api/indexnow` previews what would be submitted without sending anything; add `?force=1` to either to ignore the ledger and resubmit everything.
 
 One-time manual steps (dashboard accounts required): verify the domain in [Google Search Console](https://search.google.com/search-console) and [Bing Webmaster Tools](https://www.bing.com/webmasters), submit `https://o-c.do/sitemap.xml` in both, and optionally list `llms.txt` at [directory.llmstxt.cloud](https://directory.llmstxt.cloud) / [llmstxt.site](https://llmstxt.site).
 

--- a/apps/web/custom-worker.ts
+++ b/apps/web/custom-worker.ts
@@ -7,13 +7,17 @@
 // @ts-ignore .open-next/worker.js 在 `opennextjs-cloudflare build` 时生成
 import { default as handler } from "./.open-next/worker.js";
 import { captureRanks } from "./src/lib/ranks/capture";
+import { syncIndexNow } from "./src/lib/indexnow/sync";
 
 export default {
 	fetch: handler.fetch,
 
-	// 每天 UTC 08:00（wrangler.jsonc triggers.crons）抓 App Store 各地区榜单名次入 D1。
+	// 每天 UTC 08:00（wrangler.jsonc triggers.crons）：
+	//   ① 抓 App Store 各地区榜单名次入 D1；
+	//   ② 把有变更的页面推给 IndexNow（Bing 等），只推与台账版本不一致的 URL。
 	async scheduled(_controller, env, ctx) {
 		ctx.waitUntil(captureRanks(env.IAP_DB));
+		ctx.waitUntil(syncIndexNow(env.IAP_DB).catch((err) => console.error("[indexnow] sync failed:", err)));
 	},
 } satisfies ExportedHandler<CloudflareEnv>;
 

--- a/apps/web/migrations/0008_indexnow.sql
+++ b/apps/web/migrations/0008_indexnow.sql
@@ -1,0 +1,8 @@
+-- IndexNow 推送台账：记住每个 URL 上次是以哪个「内容版本」推给搜索引擎的。
+-- signature 取自 src/lib/site/urls.ts 的 updated（YYYY-MM-DD）：
+-- 清单里的版本与这里不一致（或压根没有这一行）才需要重新推，避免把没变的页面反复提交。
+CREATE TABLE IF NOT EXISTS indexnow_urls (
+	url          TEXT    NOT NULL PRIMARY KEY,  -- 绝对 URL，如 https://o-c.do/guides/…
+	signature    TEXT    NOT NULL,              -- 推送时的内容版本 'YYYY-MM-DD'
+	submitted_at INTEGER NOT NULL               -- 推送时刻, ms epoch
+);

--- a/apps/web/public/baidu_verify_codeva-nfNBzz3sqh.html
+++ b/apps/web/public/baidu_verify_codeva-nfNBzz3sqh.html
@@ -1,0 +1,1 @@
+ee3f48e76d91a9ea5af7718e27df6bf3

--- a/apps/web/src/app/api/indexnow/route.ts
+++ b/apps/web/src/app/api/indexnow/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { isApiAuthed } from "@/lib/admin/auth";
+import { previewPending, syncIndexNow } from "@/lib/indexnow/sync";
+
+// IndexNow 手动推送接口。鉴权同后台：会话 cookie 或 `Authorization: Bearer <管理口令>`。
+//   GET  /api/indexnow          → 预览「本次会推哪些 URL」，不发请求
+//   POST /api/indexnow          → 推送变更的 URL
+//   POST /api/indexnow?force=1  → 无视台账全量重推（换域名 / 台账丢了时用）
+// 平时不用管：cron 每天自动跑一趟（custom-worker.ts）。发完新指南想立刻通知才打这里。
+export const dynamic = "force-dynamic";
+
+const NO_STORE = { "cache-control": "no-store" };
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+	const { env } = getCloudflareContext();
+	if (!(await isApiAuthed(request, env.ADMIN_PASSWORD))) {
+		return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+	}
+	const force = request.nextUrl.searchParams.get("force") === "1";
+	const preview = await previewPending(env.IAP_DB, force);
+	return NextResponse.json(
+		{ total: preview.total, skipped: preview.skipped, pending: preview.pending.map((e) => e.url) },
+		{ headers: NO_STORE },
+	);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+	const { env } = getCloudflareContext();
+	if (!(await isApiAuthed(request, env.ADMIN_PASSWORD))) {
+		return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+	}
+	const force = request.nextUrl.searchParams.get("force") === "1";
+	const result = await syncIndexNow(env.IAP_DB, { force });
+	return NextResponse.json(result, { status: result.ok ? 200 : 502, headers: NO_STORE });
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,45 +1,11 @@
 import type { MetadataRoute } from "next";
-import { routing } from "@/i18n/routing";
-import { GUIDE_LOCALES, guidePath, guidesFor } from "@/lib/guides/guides";
+import { siteUrls } from "@/lib/site/urls";
 
-const SITE_URL = "https://o-c.do";
-
-function urlFor(locale: string, path: string) {
-	const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;
-	return `${SITE_URL}${prefix}${path}` || SITE_URL;
-}
-
+// URL 清单与 IndexNow 推送同源，见 src/lib/site/urls.ts。
 export default function sitemap(): MetadataRoute.Sitemap {
-	const pages = ["", "/privacy", "/terms", "/contact"];
-
-	const localized: MetadataRoute.Sitemap = pages.map((path) => ({
-		url: urlFor(routing.defaultLocale, path) || SITE_URL,
-		lastModified: new Date(),
-		alternates: {
-			languages: Object.fromEntries(routing.locales.map((locale) => [locale, urlFor(locale, path)])),
-		},
+	return siteUrls().map((entry) => ({
+		url: entry.url,
+		lastModified: new Date(entry.updated),
+		...(entry.languages ? { alternates: { languages: entry.languages } } : {}),
 	}));
-
-	// 指南板块只有英文与简体中文两套，且文章各写各的：
-	// 只有索引页互为 alternates，文章不列，避免指向不存在的语言版本
-	const guides: MetadataRoute.Sitemap = GUIDE_LOCALES.flatMap((locale) => {
-		const list = guidesFor(locale);
-		return [
-			{
-				url: `${SITE_URL}${guidePath(locale, "/guides")}`,
-				lastModified: new Date(list[0].updated),
-				alternates: {
-					languages: Object.fromEntries(
-						GUIDE_LOCALES.map((l) => [l, `${SITE_URL}${guidePath(l, "/guides")}`]),
-					),
-				},
-			},
-			...list.map((guide) => ({
-				url: `${SITE_URL}${guidePath(locale, `/guides/${guide.slug}`)}`,
-				lastModified: new Date(guide.updated),
-			})),
-		];
-	});
-
-	return [...localized, ...guides];
 }

--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -36,8 +36,6 @@ export default async function SiteFooter() {
 				<p className="mt-5 max-w-[64ch] text-[12px] leading-relaxed t-tertiary">{t("disclaimer")}</p>
 				<div className="mt-5 flex flex-wrap items-center gap-3">
 					<a href="https://trendshift.io/repositories/53962?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-53962" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/53962/daily?language=Swift" alt="chen2he%2Forange-cloud | Trendshift" width="250" height="55" /></a>
-					<a href="https://hicyou.com"><img src="https://hicyou.com/badge/featured-dark.svg" alt="Featured" /></a>
-					<a href="https://upperstory.io/?utm_source=badge" target="_blank" rel="noopener"><img src="https://upperstory.io/brand/upperstory/badge-dark.svg" alt="Featured on Upperstory" width="172" height="40" /></a>
 				</div>
 			</div>
 		</footer>

--- a/apps/web/src/lib/indexnow/client.ts
+++ b/apps/web/src/lib/indexnow/client.ts
@@ -1,0 +1,122 @@
+// IndexNow 客户端：把变更的 URL 推给搜索引擎（Bing / Yandex / Seznam / Naver / Yep 共用同一协议）。
+//
+// 鉴权就是一个公开的密钥文件：https://o-c.do/<key>.txt 里放着同一串 key，
+// 搜索引擎回抓这个文件确认「提交者确实控制这个域名」。文件在 public/，别删。
+
+import { SITE_HOST, SITE_URL } from "../site/urls";
+
+export const INDEXNOW_KEY = "ae4368227a78d73327c42c34949e9075";
+export const INDEXNOW_KEY_LOCATION = `${SITE_URL}/${INDEXNOW_KEY}.txt`;
+
+/**
+ * 端点按「从 Workers 打得通」排序，逐个试到第一个收下为止。
+ * 协议规定提交给任一参与方的 URL 会自动共享给其余所有参与的搜索引擎，
+ * 所以只要有一个收下就够了，不必逐个端点重复提交。
+ *
+ * 为什么中立端点 api.indexnow.org 反而排第二 —— 2026-08-21 实测：
+ * 从 Cloudflare Workers 的出口 IP 打它一律 429（单条 URL 也 429、且不带 Retry-After），
+ * 同一份请求体从本机出口打是 202。即 Workers 的共享出口 IP 被限流，
+ * 与本站配额、批量大小无关；同一趟从 Workers 打 bing 返回 203 OK、打 yandex 返回 202。
+ * 留着它做备选：换出口（本机 / CI）跑时它能覆盖最多的搜索引擎。
+ */
+const ENDPOINTS = [
+	"https://www.bing.com/indexnow",
+	"https://api.indexnow.org/indexnow",
+	"https://yandex.com/indexnow",
+] as const;
+
+/** 协议上限 10000 条／次，本站远远用不到，仍按批切分兜底。 */
+const BATCH_SIZE = 10_000;
+
+export type Attempt = {
+	endpoint: string;
+	/** HTTP 状态码；请求本身就没打出去（超时 / DNS 等）时为 null */
+	status: number | null;
+	note: string;
+};
+
+export type SubmitResult = {
+	ok: boolean;
+	urls: string[];
+	/** 每次尝试的结果，按顺序；后台接口直接回显它，出问题时一眼看出卡在哪个端点 */
+	attempts: Attempt[];
+	message?: string;
+};
+
+/** 状态码语义（照 IndexNow 规范；2xx 一律视为收下——bing 实际返回的是 203） */
+function describe(status: number): string {
+	if (status === 200) return "OK";
+	if (status === 202) return "Accepted：已收下，密钥文件待校验";
+	if (status >= 200 && status < 300) return `HTTP ${status}：已收下`;
+	switch (status) {
+		case 400:
+			return "Bad request：请求体格式不对";
+		case 403:
+			return "Forbidden：密钥校验失败（检查 /<key>.txt 是否可访问且内容一致）";
+		case 422:
+			return "Unprocessable：URL 不属于本站，或与密钥不匹配";
+		case 429:
+			return "Too many requests：该出口 IP 被限流";
+		default:
+			return `HTTP ${status}`;
+	}
+}
+
+const accepted = (status: number) => status >= 200 && status < 300;
+
+/** 我们自己的错（密钥 / 格式 / URL 归属）——换个端点也是一样的结果，不必再试。 */
+const ourFault = (status: number) => status >= 400 && status < 500 && status !== 429;
+
+async function postBatch(endpoint: string, batch: string[]): Promise<Attempt> {
+	try {
+		const res = await fetch(endpoint, {
+			method: "POST",
+			headers: { "content-type": "application/json; charset=utf-8" },
+			body: JSON.stringify({
+				host: SITE_HOST,
+				key: INDEXNOW_KEY,
+				keyLocation: INDEXNOW_KEY_LOCATION,
+				urlList: batch,
+			}),
+			signal: AbortSignal.timeout(15_000),
+		});
+		return { endpoint, status: res.status, note: describe(res.status) };
+	} catch (err) {
+		return { endpoint, status: null, note: `请求失败：${err instanceof Error ? err.message : String(err)}` };
+	}
+}
+
+/**
+ * 推一批 URL：端点逐个降级，任一端点 2xx 即算成功。
+ * 429 / 5xx / 网络错误换下一个端点；403、422 这类自己的错直接失败，别拿同样的错去烦别家。
+ */
+export async function submitUrls(urls: string[]): Promise<SubmitResult> {
+	if (urls.length === 0) return { ok: true, urls: [], attempts: [] };
+
+	const attempts: Attempt[] = [];
+
+	for (let i = 0; i < urls.length; i += BATCH_SIZE) {
+		const batch = urls.slice(i, i + BATCH_SIZE);
+		let done = false;
+
+		for (const endpoint of ENDPOINTS) {
+			const attempt = await postBatch(endpoint, batch);
+			attempts.push(attempt);
+			if (attempt.status !== null && accepted(attempt.status)) {
+				done = true;
+				break;
+			}
+			if (attempt.status !== null && ourFault(attempt.status)) {
+				return { ok: false, urls, attempts, message: `${endpoint} → ${attempt.note}` };
+			}
+		}
+
+		if (!done) {
+			const last = attempts[attempts.length - 1];
+			return { ok: false, urls, attempts, message: `所有端点都没收下，最后一次：${last.endpoint} → ${last.note}` };
+		}
+	}
+
+	const win = attempts[attempts.length - 1];
+	return { ok: true, urls, attempts, message: `${win.endpoint} → ${win.note}` };
+}

--- a/apps/web/src/lib/indexnow/indexnow.test.ts
+++ b/apps/web/src/lib/indexnow/indexnow.test.ts
@@ -1,0 +1,234 @@
+// IndexNow：清单构造 / 变更判定 / 提交载荷 / 台账记账（台账部分跑真实 SQL，node:sqlite）。
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { indexableUrls, siteUrls } from "../site/urls";
+import { INDEXNOW_KEY, submitUrls } from "./client";
+import { knownSignatures, recordSubmitted } from "./store";
+import { pendingEntries, syncIndexNow } from "./sync";
+
+// ---- 最小 D1 适配器（仅覆盖 store 用到的 prepare/bind/all/batch）----
+class FakeStmt {
+	private args: unknown[] = [];
+	constructor(
+		private readonly db: DatabaseSync,
+		private readonly sql: string,
+	) {}
+	bind(...args: unknown[]): this {
+		this.args = args;
+		return this;
+	}
+	run() {
+		this.db.prepare(this.sql).run(...(this.args as never[]));
+		return { success: true };
+	}
+	async all<T>() {
+		return { results: this.db.prepare(this.sql).all(...(this.args as never[])) as T[] };
+	}
+}
+class FakeD1 {
+	constructor(private readonly db: DatabaseSync) {}
+	prepare(sql: string): FakeStmt {
+		return new FakeStmt(this.db, sql);
+	}
+	async batch(statements: FakeStmt[]) {
+		return statements.map((s) => s.run());
+	}
+}
+
+let raw: DatabaseSync;
+let db: FakeD1;
+const schema = readFileSync(new URL("../../../migrations/0008_indexnow.sql", import.meta.url), "utf8");
+
+beforeEach(() => {
+	raw = new DatabaseSync(":memory:");
+	raw.exec(schema);
+	db = new FakeD1(raw);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+/** 桩一个 fetch：按端点给状态码（默认全部 200），记下每次请求 */
+function stubFetch(status: number | Record<string, number>) {
+	const calls: { url: string; body: Record<string, unknown> }[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (url: string, init: RequestInit) => {
+			const href = String(url);
+			calls.push({ url: href, body: JSON.parse(String(init.body)) });
+			const code =
+				typeof status === "number"
+					? status
+					: (Object.entries(status).find(([host]) => href.includes(host))?.[1] ?? 200);
+			return new Response("", { status: code });
+		}),
+	);
+	return calls;
+}
+
+describe("URL 清单", () => {
+	it("全是 o-c.do 的绝对 URL，且不重复", () => {
+		const urls = indexableUrls().map((e) => e.url);
+		expect(urls.length).toBeGreaterThan(0);
+		for (const url of urls) expect(url.startsWith("https://o-c.do")).toBe(true);
+		expect(new Set(urls).size).toBe(urls.length);
+	});
+
+	it("静态页摊平成各语言版本，默认语言无前缀", () => {
+		const urls = indexableUrls().map((e) => e.url);
+		expect(urls).toContain("https://o-c.do/privacy");
+		expect(urls).toContain("https://o-c.do/ja/privacy");
+		expect(urls).not.toContain("https://o-c.do/en/privacy");
+	});
+
+	it("指南两套语言各自成条，中文带 /zh-Hans 前缀", () => {
+		const urls = indexableUrls().map((e) => e.url);
+		expect(urls).toContain("https://o-c.do/guides");
+		expect(urls).toContain("https://o-c.do/zh-Hans/guides");
+		expect(urls.some((u) => u.startsWith("https://o-c.do/guides/"))).toBe(true);
+		expect(urls.some((u) => u.startsWith("https://o-c.do/zh-Hans/guides/"))).toBe(true);
+	});
+
+	it("指南索引页的 lastmod 取最新一篇，不是清单里的第一篇", () => {
+		const index = siteUrls().find((e) => e.url === "https://o-c.do/guides")!;
+		const articles = siteUrls()
+			.filter((e) => e.url.startsWith("https://o-c.do/guides/"))
+			.map((e) => e.updated);
+		expect(index.updated).toBe(articles.reduce((a, b) => (a > b ? a : b)));
+	});
+});
+
+describe("变更判定", () => {
+	const entries = [
+		{ url: "https://o-c.do/a", updated: "2026-08-01" },
+		{ url: "https://o-c.do/b", updated: "2026-08-02" },
+	];
+
+	it("台账里没有 → 需要推", () => {
+		expect(pendingEntries(entries, new Map())).toHaveLength(2);
+	});
+
+	it("版本一致 → 跳过；版本变了 → 重推", () => {
+		const known = new Map([
+			["https://o-c.do/a", "2026-08-01"],
+			["https://o-c.do/b", "2026-07-01"],
+		]);
+		expect(pendingEntries(entries, known).map((e) => e.url)).toEqual(["https://o-c.do/b"]);
+	});
+
+	it("force 无视台账全量重推", () => {
+		const known = new Map(entries.map((e) => [e.url, e.updated]));
+		expect(pendingEntries(entries, known, true)).toHaveLength(2);
+	});
+});
+
+describe("提交载荷", () => {
+	it("默认打 bing 端点，带 host/key/keyLocation/urlList", async () => {
+		const calls = stubFetch(200);
+		const result = await submitUrls(["https://o-c.do/guides"]);
+		expect(result.ok).toBe(true);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe("https://www.bing.com/indexnow");
+		expect(calls[0].body).toEqual({
+			host: "o-c.do",
+			key: INDEXNOW_KEY,
+			keyLocation: `https://o-c.do/${INDEXNOW_KEY}.txt`,
+			urlList: ["https://o-c.do/guides"],
+		});
+	});
+
+	it("空清单不发请求", async () => {
+		const calls = stubFetch(200);
+		expect((await submitUrls([])).ok).toBe(true);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("2xx 都算收下：202（密钥待校验）与 bing 的 203", async () => {
+		stubFetch(202);
+		expect((await submitUrls(["https://o-c.do/"])).ok).toBe(true);
+		stubFetch(203);
+		expect((await submitUrls(["https://o-c.do/"])).ok).toBe(true);
+	});
+
+	it("429 换下一个端点，直到有人收下", async () => {
+		const calls = stubFetch({ "bing.com": 429, "api.indexnow.org": 429, "yandex.com": 202 });
+		const result = await submitUrls(["https://o-c.do/"]);
+		expect(result.ok).toBe(true);
+		expect(calls.map((c) => new URL(c.url).host)).toEqual([
+			"www.bing.com",
+			"api.indexnow.org",
+			"yandex.com",
+		]);
+	});
+
+	it("全部端点 429 才算失败", async () => {
+		stubFetch(429);
+		const result = await submitUrls(["https://o-c.do/"]);
+		expect(result.ok).toBe(false);
+		expect(result.attempts).toHaveLength(3);
+		expect(result.message).toContain("限流");
+	});
+
+	it("403（密钥不对）立刻失败，不拿同样的错去烦别的端点", async () => {
+		const calls = stubFetch(403);
+		const result = await submitUrls(["https://o-c.do/"]);
+		expect(result.ok).toBe(false);
+		expect(calls).toHaveLength(1);
+		expect(result.message).toContain("密钥");
+	});
+
+	it("网络异常也换下一个端点", async () => {
+		let first = true;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				if (first) {
+					first = false;
+					throw new Error("timeout");
+				}
+				return new Response("", { status: 200 });
+			}),
+		);
+		const result = await submitUrls(["https://o-c.do/"]);
+		expect(result.ok).toBe(true);
+		expect(result.attempts[0].status).toBe(null);
+	});
+});
+
+describe("同步与台账（真实 SQL）", () => {
+	it("首轮全推并记账，第二轮无变更不再发请求", async () => {
+		const first = stubFetch(200);
+		const total = indexableUrls().length;
+		const run1 = await syncIndexNow(db as never, { now: 1 });
+		expect(run1.ok).toBe(true);
+		expect(run1.submitted).toHaveLength(total);
+		expect(first).toHaveLength(1);
+		expect((await knownSignatures(db as never)).size).toBe(total);
+
+		const second = stubFetch(200);
+		const run2 = await syncIndexNow(db as never, { now: 2 });
+		expect(run2.submitted).toHaveLength(0);
+		expect(run2.skipped).toBe(total);
+		expect(second).toHaveLength(0);
+	});
+
+	it("全端点失败不记账，下一轮重试", async () => {
+		stubFetch(429);
+		const failed = await syncIndexNow(db as never, { now: 1 });
+		expect(failed.ok).toBe(false);
+		expect((await knownSignatures(db as never)).size).toBe(0);
+
+		const retry = stubFetch(200);
+		expect((await syncIndexNow(db as never, { now: 2 })).ok).toBe(true);
+		expect(retry).toHaveLength(1);
+	});
+
+	it("同一 URL 版本变化后覆盖记账", async () => {
+		await recordSubmitted(db as never, [{ url: "https://o-c.do/x", updated: "2026-08-01" }], 1);
+		await recordSubmitted(db as never, [{ url: "https://o-c.do/x", updated: "2026-08-09" }], 2);
+		const rows = raw.prepare("SELECT url, signature, submitted_at FROM indexnow_urls").all();
+		expect(rows).toEqual([{ url: "https://o-c.do/x", signature: "2026-08-09", submitted_at: 2 }]);
+	});
+});

--- a/apps/web/src/lib/indexnow/store.ts
+++ b/apps/web/src/lib/indexnow/store.ts
@@ -1,0 +1,34 @@
+// IndexNow 的推送台账：记住「哪个 URL 以哪个内容版本推过」，下次只推变了的。
+// 表见 migrations/0008_indexnow.sql，与账本共用 IAP_DB。
+
+export type SubmittedRow = { url: string; signature: string; submitted_at: number };
+
+/** 读回已推送过的 URL → 内容版本。 */
+export async function knownSignatures(db: D1Database): Promise<Map<string, string>> {
+	const { results } = await db
+		.prepare("SELECT url, signature FROM indexnow_urls")
+		.all<{ url: string; signature: string }>();
+	return new Map((results ?? []).map((row) => [row.url, row.signature]));
+}
+
+/** 记账：推送成功后把这批 URL 的内容版本写回（同 URL 覆盖）。 */
+export async function recordSubmitted(
+	db: D1Database,
+	entries: { url: string; updated: string }[],
+	submittedAt: number,
+): Promise<void> {
+	if (entries.length === 0) return;
+	await db.batch(
+		entries.map((entry) =>
+			db
+				.prepare(
+					`INSERT INTO indexnow_urls (url, signature, submitted_at)
+					 VALUES (?, ?, ?)
+					 ON CONFLICT(url) DO UPDATE SET
+					   signature = excluded.signature,
+					   submitted_at = excluded.submitted_at`,
+				)
+				.bind(entry.url, entry.updated, submittedAt),
+		),
+	);
+}

--- a/apps/web/src/lib/indexnow/sync.ts
+++ b/apps/web/src/lib/indexnow/sync.ts
@@ -1,0 +1,74 @@
+// 变更推送的编排：清单（src/lib/site/urls.ts）↔ 台账（D1）比对出「变了的 URL」，推给 IndexNow，成功才记账。
+//
+// 触发点两处：
+//   1. custom-worker.ts 的 scheduled()：每天 UTC 08:00 与榜单抓取同一趟跑，新指南上线后一天内自动推；
+//   2. POST /api/indexnow（管理口令）：发完新内容想立刻推就打这个，别等 cron。
+
+import { indexableUrls } from "../site/urls";
+import { type Attempt, submitUrls } from "./client";
+import { knownSignatures, recordSubmitted } from "./store";
+
+export type SyncResult = {
+	/** 本次推送的 URL */
+	submitted: string[];
+	/** 内容版本没变、跳过的条数 */
+	skipped: number;
+	/** 各端点的尝试结果（按顺序），排障时看这个 */
+	attempts: Attempt[];
+	ok: boolean;
+	message?: string;
+};
+
+/** 纯函数：清单 ∖ 台账 = 需要推送的条目（新 URL，或内容版本变了的 URL）。 */
+export function pendingEntries(
+	entries: { url: string; updated: string }[],
+	known: Map<string, string>,
+	force = false,
+): { url: string; updated: string }[] {
+	if (force) return [...entries];
+	return entries.filter((entry) => known.get(entry.url) !== entry.updated);
+}
+
+/** 待推送预览（不发请求），给 GET /api/indexnow 用。 */
+export async function previewPending(db: D1Database, force = false) {
+	const entries = indexableUrls();
+	const known = await knownSignatures(db);
+	const pending = pendingEntries(entries, known, force);
+	return { total: entries.length, pending, skipped: entries.length - pending.length };
+}
+
+/**
+ * 比对 → 推送 → 记账。推送失败不记账，下一趟自然重试。
+ * 无变更时直接返回，不产生任何外发请求。
+ */
+export async function syncIndexNow(
+	db: D1Database,
+	options: { force?: boolean; now?: number } = {},
+): Promise<SyncResult> {
+	const { force = false, now = Date.now() } = options;
+	const entries = indexableUrls();
+	const known = await knownSignatures(db);
+	const pending = pendingEntries(entries, known, force);
+	const skipped = entries.length - pending.length;
+
+	if (pending.length === 0) {
+		console.log(`[indexnow] nothing changed (${entries.length} urls)`);
+		return { submitted: [], skipped, attempts: [], ok: true };
+	}
+
+	const result = await submitUrls(pending.map((entry) => entry.url));
+	if (!result.ok) {
+		console.error(`[indexnow] submit failed: ${result.message} (${pending.length} urls)`);
+		return { submitted: [], skipped, attempts: result.attempts, ok: false, message: result.message };
+	}
+
+	await recordSubmitted(db, pending, now);
+	console.log(`[indexnow] submitted ${pending.length} urls, skipped ${skipped} (${result.message})`);
+	return {
+		submitted: pending.map((entry) => entry.url),
+		skipped,
+		attempts: result.attempts,
+		ok: true,
+		message: result.message,
+	};
+}

--- a/apps/web/src/lib/site/urls.ts
+++ b/apps/web/src/lib/site/urls.ts
@@ -1,0 +1,86 @@
+// 站点可索引 URL 的唯一清单：sitemap.xml 与 IndexNow 推送都读这里，避免两处各写一份而漂移。
+//
+// 每个条目带 `updated`（内容版本，YYYY-MM-DD）：
+//   - sitemap 用它做 <lastmod>；
+//   - IndexNow 用它判断「这个 URL 自上次推送后有没有变」（见 src/lib/indexnow/）。
+// 所以改了页面内容就要把日期往前推，否则搜索引擎不会被通知。
+
+import { routing } from "../../i18n/routing";
+import { GUIDE_LOCALES, guidePath, guidesFor } from "../guides/guides";
+
+export const SITE_URL = "https://o-c.do";
+export const SITE_HOST = "o-c.do";
+
+export type SiteUrlEntry = {
+	url: string;
+	/** 内容版本 'YYYY-MM-DD'：sitemap 的 lastmod + IndexNow 的变更判定 */
+	updated: string;
+	/** 同一内容的各语言 URL（hreflang），键为 locale；无多语言版本时省略 */
+	languages?: Record<string, string>;
+};
+
+/**
+ * 落地页 / 法务页——**改动这些页面（含 src/messages 的文案）后，手动把日期改成当天**。
+ * 以前 sitemap 这几条的 lastmod 写的是 `new Date()`（每次抓取都是"刚刚更新"），
+ * 既不真实，也没法用来判断该不该推送 IndexNow。
+ */
+const STATIC_PAGES: { path: string; updated: string }[] = [
+	{ path: "", updated: "2026-08-08" },
+	{ path: "/privacy", updated: "2026-06-12" },
+	{ path: "/terms", updated: "2026-06-12" },
+	{ path: "/contact", updated: "2026-06-12" },
+];
+
+/** 站内绝对 URL：默认语言无前缀（与 next-intl 的 as-needed 一致） */
+export function localeUrl(locale: string, path: string): string {
+	const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;
+	return `${SITE_URL}${prefix}${path}`;
+}
+
+function newest(dates: string[]): string {
+	return dates.reduce((a, b) => (a > b ? a : b));
+}
+
+/** 全站可索引条目（静态页 + 指南索引 + 指南文章），带 hreflang 分组。 */
+export function siteUrls(): SiteUrlEntry[] {
+	const statics: SiteUrlEntry[] = STATIC_PAGES.map(({ path, updated }) => ({
+		url: localeUrl(routing.defaultLocale, path),
+		updated,
+		languages: Object.fromEntries(routing.locales.map((locale) => [locale, localeUrl(locale, path)])),
+	}));
+
+	// 指南板块只有英文与简体中文两套，且文章各写各的：
+	// 只有索引页互为 alternates，文章不列，避免指向不存在的语言版本
+	const guides: SiteUrlEntry[] = GUIDE_LOCALES.flatMap((locale) => {
+		const list = guidesFor(locale);
+		return [
+			{
+				url: `${SITE_URL}${guidePath(locale, "/guides")}`,
+				// 索引页跟着「最新的一篇」走（原来取 list[0]，而清单是按时间正序排的，取到的是最老的一篇）
+				updated: newest(list.map((guide) => guide.updated)),
+				languages: Object.fromEntries(
+					GUIDE_LOCALES.map((l) => [l, `${SITE_URL}${guidePath(l, "/guides")}`]),
+				),
+			},
+			...list.map((guide) => ({
+				url: `${SITE_URL}${guidePath(locale, `/guides/${guide.slug}`)}`,
+				updated: guide.updated,
+			})),
+		];
+	});
+
+	return [...statics, ...guides];
+}
+
+/**
+ * 摊平成「一个 URL 一行」：IndexNow 推的是真实页面地址，
+ * 所以静态页的 13 个语言版本各算一条（sitemap 里它们是 alternates，只出现一次）。
+ */
+export function indexableUrls(): { url: string; updated: string }[] {
+	const seen = new Map<string, string>();
+	for (const entry of siteUrls()) {
+		seen.set(entry.url, entry.updated);
+		for (const url of Object.values(entry.languages ?? {})) seen.set(url, entry.updated);
+	}
+	return [...seen].map(([url, updated]) => ({ url, updated }));
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -15,7 +15,11 @@
 	],
 	"assets": {
 		"binding": "ASSETS",
-		"directory": ".open-next/assets"
+		"directory": ".open-next/assets",
+		// 默认的 "auto-trailing-slash" 会把 /x.html 302/307 到 /x，
+		// 导致百度站长的验证文件（要求 .html 原样 200）拿不到内容。
+		// 本站静态资源里唯一的 .html 就是站长验证文件，关掉这层改写最省事。
+		"html_handling": "none"
 	},
 	"images": {
 		// Enable image optimization


### PR DESCRIPTION
Bing 站长后台一直提示用 IndexNow 推送更新，而站里此前只有一个密钥文件和 README 里一条没人跑的手抄 curl。这个 PR 把它做成自动推送，另捎带两个此前未提交的小改动。

## IndexNow 自动推送

- **`src/lib/site/urls.ts` 作为 URL 唯一清单**，`sitemap.ts` 与 IndexNow 同源，不再两处各写一份。每条带 `updated` 日期——既是 sitemap 的 `lastmod`，也是「这页变没变」的判据。指南文章直接取 `GUIDES[].updated`，写新指南照旧填日期即可；落地页 / 隐私 / 条款 / 联系四页在 `STATIC_PAGES` 里手动改日期。
- **台账 `indexnow_urls`（`migrations/0008`）** 记住每个 URL 上次以哪个版本推过，只推差集；**推成功才记账**，失败不记、下一趟自然重试；无变更时零外发请求（IndexNow 明确不建议重复提交未变更内容）。
- **触发两处**：每天 UTC 08:00 的 cron（与 App Store 榜单抓取同一趟，两个 `waitUntil` 互不拖累）；`POST /api/indexnow`（管理口令，发完新指南想立刻推）。`GET` 只预览会推哪些、不发请求，`?force=1` 无视台账全量重推。

### 端点顺序：为什么中立端点排第二

首轮上线打 `api.indexnow.org` 直接吃 429。逐项排查的结论是**出口 IP 被限流**，与本站配额、批量大小、密钥都无关：

| 出口 | 端点 | URL 数 | 结果 |
|---|---|---|---|
| 本机 | api.indexnow.org | 1 | **202** Accepted |
| Cloudflare Workers | api.indexnow.org | 1 | **429**（两次，且不带 `Retry-After`） |
| Cloudflare Workers | www.bing.com/indexnow | 1 | **203** OK |
| Cloudflare Workers | yandex.com/indexnow | 1 | **202** `{"success":true}` |

（Workers 侧用 `wrangler dev --remote` 起了个一次性探针 worker 打的，走真实边缘出口。）Workers 出口 IP 全网共享，微软那侧按 IP 计限流，我们这点量根本轮不到自己触发。

所以端点按「从 Workers 打得通」排序：**bing → api.indexnow.org → yandex**，逐个降级到第一个 2xx 为止。协议规定「提交给任一参与方的 URL 会自动共享给其余所有参与的搜索引擎」，打通一个即全覆盖。降级规则：2xx 一律算收下（bing 实际返回 203）；429 / 5xx / 网络异常换下一个端点；403（密钥不对）/ 422（URL 不属于本站）/ 400 立刻失败，不拿同样的错去烦别家。`api.indexnow.org` 留作备选：换出口（本机 / CI）跑时它覆盖面最广。

### 顺带修的 sitemap 两处

- 指南索引页的 `lastmod` 原取 `list[0]`，而清单按时间正序排，取到的是**最老**一篇 → 改为取最新。
- 静态页的 `lastmod` 原是 `new Date()`（每次抓取都是"刚刚更新"）→ 改为真实日期。

## 另外两个 commit

- `chore(web)` 百度站长验证文件 + `html_handling: "none"`（验证文件要 `.html` 原样 200，默认的 auto-trailing-slash 会 302 到 /x）。两者绑定，拆开任一个都说不通。
- `chore(web)` 页脚移除 hicyou / upperstory 两个徽章，保留 Trendshift。

## 验证

- `pnpm test`：新增 17 条（清单构造 / 变更判定 / 提交载荷 / 端点降级 / 403 不降级 / 网络异常降级 / 真实 SQL 记账与失败不记账），全仓 150 条通过。
- `next build` + `wrangler deploy --dry-run` 确认新端点已进 cron 的 bundle。
- 已部署（版本 `31d283b5`）并线上核验：`/`、`/guides`、密钥文件、百度验证文件均 200；`/api/indexnow` 无口令返回 401；`sitemap.xml` 13 条 `<url>`、hreflang 完整；cron `0 8 * * *` 已挂；D1 `indexnow_urls` 表在、0 行。
- 首轮全量推送（摊平后 61 条）待手动打一次带口令的 `POST /api/indexnow`。