### PR TITLE
chore(deps): 抬升 Dependabot 告警依赖的补丁版本

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,17 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici@>=7.0.0 <7.28.0: 7.28.0
+  undici@>=7.0.0 <7.29.0: 7.29.0
   form-data@>=4.0.0 <4.0.6: 4.0.6
   ws@>=8.0.0 <8.21.0: 8.21.0
-  postcss@<8.5.18: 8.5.18
+  postcss@<8.5.23: 8.5.23
   esbuild@>=0.27.3 <0.28.1: 0.28.1
   body-parser@>=2.0.0 <2.3.0: 2.3.0
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   sharp@<0.35.0: 0.35.0
-  brace-expansion@<1.1.16: 1.1.16
+  nanoid@<3.3.16: 3.3.16
+  nanoid@>=4.0.0 <5.1.6: 5.1.6
+  brace-expansion@<1.1.18: 1.1.18
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.8: 5.0.8
 
@@ -2183,8 +2185,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
@@ -2563,6 +2565,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3013,8 +3016,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3241,8 +3244,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3452,8 +3455,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3853,8 +3856,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -5035,7 +5038,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5891,7 +5894,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       tailwindcss: 4.3.0
 
   '@tsconfig/node18@1.0.3': {}
@@ -6318,7 +6321,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -7368,7 +7371,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7514,7 +7517,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.0
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260603.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -7528,7 +7531,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@8.0.7:
     dependencies:
@@ -7548,7 +7551,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -7581,7 +7584,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.34
       caniuse-lite: 1.0.30001797
-      postcss: 8.5.18
+      postcss: 8.5.23
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -7745,9 +7748,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8257,7 +8260,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -8318,7 +8321,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,17 +3,19 @@ packages:
   - 'packages/*'
 # 安全补丁：把存在 Dependabot 漏洞的间接依赖强制抬到补丁版（按漏洞范围精准命中，不跨大版本）
 overrides:
-  'undici@>=7.0.0 <7.28.0': '7.28.0'
+  'undici@>=7.0.0 <7.29.0': '7.29.0'
   'form-data@>=4.0.0 <4.0.6': '4.0.6'
   'ws@>=8.0.0 <8.21.0': '8.21.0'
-  'postcss@<8.5.18': '8.5.18'
+  'postcss@<8.5.23': '8.5.23'
   'esbuild@>=0.27.3 <0.28.1': '0.28.1'
   'body-parser@>=2.0.0 <2.3.0': '2.3.0'
-  'js-yaml@>=4.0.0 <4.3.0': '4.3.0'
+  'js-yaml@>=4.0.0 <4.3.1': '4.3.1'
   'sharp@<0.35.0': '0.35.0'
+  'nanoid@<3.3.16': '3.3.16'
+  'nanoid@>=4.0.0 <5.1.6': '5.1.6'
   # brace-expansion 的两个公告按大版本各有独立漏洞范围，三条线都得钉：
-  # GHSA-3jxr-9vmj-r5cp（1.x / 2.x）+ GHSA-mh99-v99m-4gvg（<=5.0.7，故需 5.0.8）
-  'brace-expansion@<1.1.16': '1.1.16'
+  # GHSA-3jxr-9vmj-r5cp（1.x / 2.x）+ GHSA-mh99-v99m-4gvg（<=5.0.7）+ 1.x 线 <1.1.18
+  'brace-expansion@<1.1.18': '1.1.18'
   'brace-expansion@>=2.0.0 <2.1.2': '2.1.2'
   'brace-expansion@>=3.0.0 <5.0.8': '5.0.8'
 allowBuilds:


### PR DESCRIPTION
## 中文

按 Dependabot 开放告警更新 `pnpm-workspace.yaml` 的 overrides 精准钉版（不跨大版本）。

实际需要修的 5 项（锁文件里确实存在漏洞版本）：

| 包 | 原锁定 | 现锁定 | 告警 |
|---|---|---|---|
| undici | 7.28.0 | 7.29.0 | #41 #42 缓存指令跨用户信息泄露 / 解析崩溃等 |
| postcss | 8.5.18 | 8.5.23 | #50 sourceMappingURL 任意 `.map` 读取（不完整修复） |
| js-yaml | 4.3.0 | 4.3.1 | #47 `!!omap` 解析二次方 CPU 消耗 |
| brace-expansion (1.x) | 1.1.16 | 1.1.18 | #45 无界展开 DoS |
| nanoid | 3.3.12 | 3.3.18 | #49 负 size 死循环（新增钉版） |

其余 5 条为过期告警：`undici <6.28.0`（#40 #43 #44）、`nanoid >=4 <5.1.6`（#51）、`brace-expansion >=4 <5.0.8`（#39 #46）在本仓库锁文件中已无对应版本，合入后重扫会自动关闭；对应钉版规则仍保留/补上，防止将来被间接拉入。

验证：`pnpm install` 干净、`pnpm test` 20 文件 150 项全过、`pnpm build`（Next 16 + OpenNext）成功。

## English

Bump pinned override versions in `pnpm-workspace.yaml` per open Dependabot alerts, matching advisory ranges exactly (no major bumps).

- undici 7.28.0 → 7.29.0 (cross-user cache-directive disclosure / parse crash, 4 advisories)
- postcss 8.5.18 → 8.5.23 (incomplete fix for arbitrary `.map` read via sourceMappingURL)
- js-yaml 4.3.0 → 4.3.1 (quadratic CPU in `!!omap` resolution)
- brace-expansion 1.x 1.1.16 → 1.1.18 (unbounded expansion DoS)
- new nanoid pins (`<3.3.16` → 3.3.16, 4.x/5.x → 5.1.6); resolves to 3.3.18

The remaining alerts (undici <6, nanoid 4.x/5.x, brace-expansion 4.x) match no version in this lockfile and are stale; they should close on rescan.

`pnpm test` (150 tests) and `pnpm build` both pass.