### PR TITLE
chore(deps): 补钉 brace-expansion 2.x / 4-5.x 线的剩余告警

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,9 @@ overrides:
   nanoid@<3.3.16: 3.3.16
   nanoid@>=4.0.0 <5.1.6: 5.1.6
   brace-expansion@<1.1.18: 1.1.18
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
+  brace-expansion@>=3.0.0 <3.0.6: 3.0.6
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
 
 importers:
 
@@ -2188,11 +2189,11 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -6326,11 +6327,11 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7527,7 +7528,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -7535,7 +7536,7 @@ snapshots:
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,11 +13,12 @@ overrides:
   'sharp@<0.35.0': '0.35.0'
   'nanoid@<3.3.16': '3.3.16'
   'nanoid@>=4.0.0 <5.1.6': '5.1.6'
-  # brace-expansion 的两个公告按大版本各有独立漏洞范围，三条线都得钉：
-  # GHSA-3jxr-9vmj-r5cp（1.x / 2.x）+ GHSA-mh99-v99m-4gvg（<=5.0.7）+ 1.x 线 <1.1.18
+  # brace-expansion：每个公告对 1.x / 2.x / 3.x / 4-5.x 各有独立修复版，四条线都得钉；
+  # GHSA-mh99-v99m-4gvg + GHSA-rgw5-rvv9-x895 取各线较高者
   'brace-expansion@<1.1.18': '1.1.18'
-  'brace-expansion@>=2.0.0 <2.1.2': '2.1.2'
-  'brace-expansion@>=3.0.0 <5.0.8': '5.0.8'
+  'brace-expansion@>=2.0.0 <2.1.4': '2.1.4'
+  'brace-expansion@>=3.0.0 <3.0.6': '3.0.6'
+  'brace-expansion@>=4.0.0 <5.0.9': '5.0.9'
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true


### PR DESCRIPTION
## 中文

#105 之后仍有 3 条告警开放（#39 #45 #52），全部是 brace-expansion。原因是上一轮只看了公告的第一条漏洞范围，而同一个公告对每条大版本线各有独立修复版：

| 公告 | 命中的线 | 需要版本 | 上一轮钉的 |
|---|---|---|---|
| GHSA-rgw5-rvv9-x895 (#52) | 2.x | 2.1.4 | 2.1.2 ❌ |
| GHSA-rgw5-rvv9-x895 (#45) | 4–5.x | 5.0.9 | 5.0.8 ❌ |
| GHSA-mh99-v99m-4gvg (#39) | 2.x | 2.1.3 | 2.1.2 ❌ |

现按 1.x / 2.x / 3.x / 4–5.x 四条线分别取两个公告中较高的修复版：`1.1.18 / 2.1.4 / 3.0.6 / 5.0.9`。锁文件实际解析到 1.1.18、2.1.4、5.0.9（3.x 线本仓库无依赖，钉版仅作预防）。

验证：`pnpm test` 20 文件 150 项全过；`pnpm build`（Next 16 + OpenNext）连续两次成功。

## English

Three alerts stayed open after #105, all brace-expansion: the previous pass read only the first vulnerable range per advisory, while each advisory ships a separate fixed version per major line — 2.x needs 2.1.4 (GHSA-rgw5-rvv9-x895) / 2.1.3 (GHSA-mh99-v99m-4gvg), and the 4–5.x line needs 5.0.9.

All four lines are now pinned to the highest fix across both advisories: `1.1.18 / 2.1.4 / 3.0.6 / 5.0.9`. Lockfile resolves to 1.1.18, 2.1.4, 5.0.9 (the 3.x pin is preventive; nothing depends on it here).

`pnpm test` (150 tests) and `pnpm build` both pass.