### PR TITLE
feat(web): /guides 新增英文指南「Cloudflare CNAME 展平」

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-cname-flattening/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-cname-flattening/page.tsx
@@ -1,0 +1,389 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import CnameFlattening from "@/components/guides/CnameFlattening";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-cname-flattening");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_FLATTENING = "https://developers.cloudflare.com/dns/cname-flattening/";
+const DOCS_SETUP = "https://developers.cloudflare.com/dns/cname-flattening/set-up-cname-flattening/";
+const DOCS_DIAGRAM = "https://developers.cloudflare.com/dns/cname-flattening/cname-flattening-diagram/";
+const DOCS_APEX = "https://developers.cloudflare.com/dns/concepts/#zone-apex";
+const DOCS_CREATE_APEX = "https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-zone-apex/";
+const DOCS_CNAME = "https://developers.cloudflare.com/dns/manage-dns-records/reference/dns-record-types/#cname";
+const DOCS_TTL = "https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/";
+const DOCS_EMAIL = "https://developers.cloudflare.com/dns/troubleshooting/email-issues/";
+const DOCS_1014 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/";
+const DOCS_PROXY = "https://developers.cloudflare.com/dns/proxy-status/";
+const DOCS_PAGES = "https://developers.cloudflare.com/pages/configuration/custom-domains/";
+const DOCS_SETTINGS_API =
+	"https://developers.cloudflare.com/api/resources/dns/subresources/settings/subresources/zone/methods/edit/";
+const DOCS_ATTRIBUTES = "https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/";
+const RFC_1034 = "https://www.rfc-editor.org/rfc/rfc1034#section-3.6.2";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "Can I use a CNAME record at my root domain in Cloudflare?",
+		a: "Yes. Cloudflare flattens a CNAME at the zone apex automatically, on every plan, and there is no setting to turn that off. You add the record with the name @ and Cloudflare answers queries with the target's IP address instead of the CNAME.",
+	},
+	{
+		q: "Why does dig return an A record when I configured a CNAME?",
+		a: "Because the record was flattened. Flattening is not a redirect or a rewrite of your configuration — the CNAME stays in your zone, but Cloudflare resolves it and puts an address record on the wire. A dig for the CNAME type at an apex that is flattened returns nothing.",
+	},
+	{
+		q: "Does CNAME flattening break DKIM or domain verification?",
+		a: "It can. Some providers need to read the CNAME record itself, for DKIM keys, autodiscover, or proof that you control the domain. Once the record is flattened they see an address record instead and the check fails, which is why flattening every CNAME in a zone is riskier than flattening one.",
+	},
+	{
+		q: "What is the difference between ALIAS, ANAME and CNAME flattening?",
+		a: "They solve the same problem in different places. ALIAS and ANAME are provider-specific record types that resolve a hostname at the apex. Cloudflare has no such type: you recreate those records as ordinary CNAME records and flattening does the resolving.",
+	},
+	{
+		q: "Why does my flattened CNAME return an empty answer?",
+		a: "The target has no A or AAAA record to flatten to. Cloudflare documents this as a dangling CNAME, and the response is NODATA — an empty answer rather than an error, which reads like a record that never propagated.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "Every proxied record is flattened by definition — this is what the proxy returns instead of your origin.",
+	},
+	{
+		href: "/guides/why-is-my-cloudflare-dns-change-not-working",
+		label: "Why isn't my Cloudflare DNS change working yet?",
+		note: "The other reason a record looks broken when it is not: something downstream is still holding the old answer.",
+	},
+	{
+		href: DOCS_FLATTENING,
+		label: "Cloudflare docs: CNAME flattening",
+		note: "The official reference, including the caveats about third-party verification and dangling targets.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function CnameFlatteningGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="It is the reason your root domain can point at a hostname at all — and the reason a record you can see in the dashboard sometimes refuses to show up in dig."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						CNAME flattening means Cloudflare resolves the CNAME itself and answers with the target&rsquo;s IP
+						address instead of the CNAME record. It is what lets a root domain such as{" "}
+						<code>example.com</code> point at a hostname.
+					</p>
+				</div>
+
+				<p>
+					Every other DNS provider makes you choose between a root domain and a hostname target. Cloudflare
+					does not, and the mechanism behind that is worth understanding — because the same mechanism quietly
+					removes records that some services need to read.
+				</p>
+
+				<h2 id="why">Why a root domain cannot hold a CNAME</h2>
+				<p>
+					The restriction is older than any CDN. RFC 1034 states that{" "}
+					<a href={RFC_1034} target="_blank" rel="noopener noreferrer">
+						if a CNAME record is present at a node, no other data should be present
+					</a>
+					, so that an alias and its canonical name can never disagree. Your{" "}
+					<a href={DOCS_APEX} target="_blank" rel="noopener noreferrer">
+						zone apex
+					</a>{" "}
+					— the domain itself, the record you write as <code>@</code> — always carries other data, because
+					that is where the SOA record and the nameserver records live. A literal CNAME there would be a
+					standards violation, and resolvers are entitled to behave badly when they meet one.
+				</p>
+				<p>
+					That is a problem, because plenty of things you might want your bare domain to point at do not have
+					a stable IP address: a load balancer, an object storage endpoint, a platform that reassigns
+					addresses whenever it likes. Other providers invented non-standard record types for this — ALIAS
+					and ANAME. Cloudflare has neither. Its documentation tells you to{" "}
+					<a href={DOCS_CREATE_APEX} target="_blank" rel="noopener noreferrer">
+						recreate ALIAS or ANAME records as ordinary CNAME records
+					</a>
+					, and lets flattening do the work.
+				</p>
+
+				<h2 id="how">What Cloudflare puts on the wire</h2>
+				<CnameFlattening />
+				<p>
+					When a query arrives for a name whose CNAME is flattened, Cloudflare follows the target itself —{" "}
+					<a href={DOCS_FLATTENING} target="_blank" rel="noopener noreferrer">
+						one lookup, or several if the target is another CNAME
+					</a>{" "}
+					— and returns the final IP address under your own name. The CNAME never leaves the network. Two
+					details of that answer are documented in Cloudflare&rsquo;s{" "}
+					<a href={DOCS_DIAGRAM} target="_blank" rel="noopener noreferrer">
+						flattening example
+					</a>{" "}
+					and catch people out:
+				</p>
+				<ul>
+					<li>
+						<strong>If the record is proxied</strong>, the answer is made of Cloudflare anycast IPs with a
+						TTL of <code>300</code> — the target&rsquo;s address is never disclosed, and{" "}
+						<a href={DOCS_TTL} target="_blank" rel="noopener noreferrer">
+							the TTL of a proxied record cannot be edited
+						</a>
+						.
+					</li>
+					<li>
+						<strong>If the record is DNS only</strong>, the answer is the target&rsquo;s own IP address, and
+						its TTL is the <em>lower</em> of the target&rsquo;s TTL and your CNAME&rsquo;s TTL. Setting a
+						long TTL on your record does not raise it; the target&rsquo;s cache lifetime caps yours.
+					</li>
+				</ul>
+				<p>
+					Because what leaves Cloudflare is an address record rather than an alias, the apex can still carry
+					the MX and TXT records your mail and verification depend on. The conflict RFC 1034 forbids never
+					appears on the wire, which is exactly the point. The same trick is what allows a bare domain to be
+					used as a{" "}
+					<a href={DOCS_PAGES} target="_blank" rel="noopener noreferrer">
+						root custom domain on Cloudflare Pages
+					</a>
+					.
+				</p>
+
+				<h2 id="when">When flattening happens, and when you choose</h2>
+				<p>
+					Three of the five cases below are not settings at all — they happen whether you want them or not.
+					Only the last two are yours to configure, and both are{" "}
+					<a href={DOCS_SETUP} target="_blank" rel="noopener noreferrer">
+						limited to paid zones
+					</a>
+					.
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Case</th>
+								<th scope="col">What is flattened</th>
+								<th scope="col">Plans</th>
+								<th scope="col">Can you turn it off?</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">
+									CNAME at the apex (<code>@</code>)
+								</th>
+								<td>That record, always</td>
+								<td>All, by default</td>
+								<td>No</td>
+							</tr>
+							<tr>
+								<th scope="row">Target in the same zone</th>
+								<td>That record, always</td>
+								<td>All</td>
+								<td>No — the zone setting is ignored</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_PROXY} target="_blank" rel="noopener noreferrer">
+										Proxied
+									</a>{" "}
+									CNAME
+								</th>
+								<td>Every proxied record</td>
+								<td>All</td>
+								<td>No — proxying returns anycast IPs</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									All CNAME records (<code>flatten_all_cnames</code>)
+								</th>
+								<td>Every CNAME in the zone</td>
+								<td>Paid</td>
+								<td>Yes — off by default</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									Per record (<code>flatten_cname</code>)
+								</th>
+								<td>One record you pick</td>
+								<td>Paid</td>
+								<td>Yes — off by default</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					The zone-wide switch lives on the DNS Settings page and maps to{" "}
+					<a href={DOCS_SETTINGS_API} target="_blank" rel="noopener noreferrer">
+						<code>flatten_all_cnames</code> on the zone DNS settings endpoint
+					</a>
+					. The per-record option appears as a <strong>Flatten</strong> toggle when you edit a record, and it
+					is hidden in the cases where it would mean nothing: at the apex, on a proxied record, or when the
+					zone-wide switch is already on. Records flattened individually are marked with a{" "}
+					<a href={DOCS_ATTRIBUTES} target="_blank" rel="noopener noreferrer">
+						<code>cf-flatten-cname</code> tag
+					</a>{" "}
+					so the setting survives a zone-file export and import.
+				</p>
+
+				<h2 id="breaks">Three ways flattening bites</h2>
+				<p>
+					Turning it on for every CNAME in a zone sounds tidy — faster resolution, one less thing to think
+					about. It is the setting most likely to cause an outage you cannot see in the dashboard, because
+					your records still look exactly right there.
+				</p>
+				<ol>
+					<li>
+						<strong>Services that need to read the CNAME itself.</strong> DKIM keys, autodiscover endpoints
+						and domain-verification records are frequently published as CNAMEs pointing into a
+						provider&rsquo;s zone. Flatten them and the provider gets an address record instead, so{" "}
+						<a href={DOCS_EMAIL} target="_blank" rel="noopener noreferrer">
+							the check fails
+						</a>{" "}
+						even though the underlying value is correct. Cloudflare&rsquo;s own guidance is to turn
+						flattening off when a provider requires the CNAME.
+					</li>
+					<li>
+						<strong>Targets with nothing to flatten to.</strong> If the final target has no A or AAAA
+						record, there is no address to return, and Cloudflare answers with NODATA — an empty answer, not
+						an error. It looks precisely like{" "}
+						<Link href="/guides/why-is-my-cloudflare-dns-change-not-working">
+							a record that never propagated
+						</Link>
+						, which sends people hunting in the wrong place for hours.
+					</li>
+					<li>
+						<strong>Targets in someone else&rsquo;s Cloudflare account.</strong> Flattening does not get you
+						around this: a CNAME pointing at a hostname in a different Cloudflare account returns{" "}
+						<a href={DOCS_1014} target="_blank" rel="noopener noreferrer">
+							Error 1014: CNAME Cross-User Banned
+						</a>
+						. Within one account, or across zones you own, it is fine; otherwise the target&rsquo;s owner has
+						to onboard you through Cloudflare for SaaS.
+					</li>
+				</ol>
+
+				<h2 id="check">Checking what your zone actually returns</h2>
+				<p>Ask the nameservers rather than the dashboard. At an apex that is working normally:</p>
+				<pre>
+					<code>{"dig +noall +answer example.com A\ndig +noall +answer example.com CNAME"}</code>
+				</pre>
+				<p>
+					The first command returns an address record even though you configured a CNAME — that is flattening
+					working. The second returns nothing at all, which is not a bug and not a missing record: at a
+					flattened name there is no CNAME to hand out. A TTL of <code>300</code> in the first answer tells
+					you the record is proxied; anything else means it is DNS only and you are looking at the
+					target&rsquo;s address.
+				</p>
+				<p>
+					If you are auditing a whole zone, read the records back from the API instead of clicking through
+					them. Each{" "}
+					<a href={DOCS_CNAME} target="_blank" rel="noopener noreferrer">
+						CNAME record
+					</a>{" "}
+					carries its own <code>settings.flatten_cname</code> value, and the zone-level{" "}
+					<code>flatten_all_cnames</code> flag sits on the DNS settings endpoint — worth checking before you
+					blame a provider for a verification failure.
+				</p>
+
+				<h2 id="choose">A reasonable default</h2>
+				<p>
+					At the apex you have no decision to make. For everything else, the ordering that causes the fewest
+					surprises is: leave the zone-wide switch off, flatten individual DNS-only records when you have a
+					specific reason to — a slow multi-hop chain, a target that resolves through two or three
+					intermediaries — and never flatten a record a third party is going to read. If a provider ever tells
+					you your DNS record is missing while the dashboard shows it plainly, flattening is the first thing
+					to check.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
@@ -58,6 +58,11 @@ const RELATED: RelatedLink[] = [
 		note: "Why a proxied record never returns your origin IP — and why that changes what dig can tell you.",
 	},
 	{
+		href: "/guides/cloudflare-cname-flattening",
+		label: "What is CNAME flattening in Cloudflare?",
+		note: "A flattened CNAME whose target has no address returns an empty answer — which reads exactly like a change that never propagated.",
+	},
+	{
 		href: "/guides/why-is-cloudflare-not-caching-my-site",
 		label: "Why is Cloudflare not caching my site?",
 		note: "The other kind of stale answer: the one Cloudflare itself is serving from cache.",

--- a/apps/web/src/components/guides/CnameFlattening.tsx
+++ b/apps/web/src/components/guides/CnameFlattening.tsx
@@ -1,0 +1,123 @@
+/**
+ * CNAME flattening 流程图：解析器问 apex → Cloudflare 自己把 CNAME 解到底 →
+ * 用 apex 名字回一条 A 记录；代理与仅 DNS 两种答案分叉在底部。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function CnameFlattening() {
+	const box = (y: number) => ({ x: 26, y, width: 308, height: 54, rx: 14 });
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 470"
+				role="img"
+				aria-label="How CNAME flattening answers a query. A resolver asks for the A record of example.com. Inside Cloudflare DNS, the CNAME record at the zone apex is kept as configuration and never returned; Cloudflare resolves the target hostname itself down to an IP address, then rewrites the answer so it carries the apex name with record type A. The answer then splits two ways: a proxied record returns Cloudflare anycast IPs with a TTL of 300 seconds, while a DNS-only record returns the target's own IP address with a TTL equal to the lower of the two record TTLs."
+				className="mx-auto block h-auto w-full max-w-[420px]"
+			>
+				<title>How Cloudflare answers a flattened CNAME</title>
+
+				{/* 1 · 解析器提问 */}
+				<rect {...box(16)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="180" y="40" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					A resolver asks
+				</text>
+				<text
+					x="180"
+					y="58"
+					textAnchor="middle"
+					fontSize="12"
+					fill="var(--t-secondary)"
+					fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+				>
+					example.com IN A
+				</text>
+
+				{/* Cloudflare DNS：flattening 发生的地方 */}
+				<rect
+					x="12"
+					y="100"
+					width="336"
+					height="272"
+					rx="20"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.35"
+					strokeDasharray="4 5"
+				/>
+				<text x="180" y="120" textAnchor="middle" fontSize="11" fill="var(--t-tertiary)" letterSpacing="0.6">
+					INSIDE CLOUDFLARE DNS
+				</text>
+
+				{/* 2 · apex 上的 CNAME */}
+				<rect {...box(132)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="156" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					CNAME at the apex
+				</text>
+				<text x="180" y="174" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					kept as configuration, never returned
+				</text>
+
+				{/* 3 · Cloudflare 自己把目标解到底 */}
+				<rect {...box(216)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="240" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare resolves the target
+				</text>
+				<text x="180" y="258" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					one lookup, or several if it chains
+				</text>
+
+				{/* 4 · 换成 apex 的名字 */}
+				<rect {...box(300)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="180" y="324" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Answer rewritten to the apex
+				</text>
+				<text x="180" y="342" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					type A, name example.com
+				</text>
+
+				{/* 5 · 两种答案 */}
+				<rect x="22" y="396" width="148" height="58" rx="14" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="96" y="418" textAnchor="middle" fontSize="14" fontWeight="600" fill="var(--t-primary)">
+					Proxied
+				</text>
+				<text x="96" y="434" textAnchor="middle" fontSize="11" fill="var(--t-secondary)">
+					Cloudflare anycast IPs
+				</text>
+				<text x="96" y="448" textAnchor="middle" fontSize="11" fill="var(--t-secondary)">
+					TTL 300
+				</text>
+
+				<rect x="190" y="396" width="148" height="58" rx="14" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="264" y="418" textAnchor="middle" fontSize="14" fontWeight="600" fill="var(--t-primary)">
+					DNS only
+				</text>
+				<text x="264" y="434" textAnchor="middle" fontSize="11" fill="var(--t-secondary)">
+					the target&rsquo;s own IP
+				</text>
+				<text x="264" y="448" textAnchor="middle" fontSize="11" fill="var(--t-secondary)">
+					lower of the two TTLs
+				</text>
+
+				<defs>
+					<marker id="flat-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#flat-arrow)" fill="none">
+					<path d="M180 76 L180 126" />
+					<path d="M180 190 L180 210" />
+					<path d="M180 274 L180 294" />
+					<path d="M96 376 L96 390" />
+					<path d="M264 376 L264 390" />
+				</g>
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" fill="none">
+					<path d="M180 354 L180 376 M96 376 L264 376" />
+				</g>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				The apex CNAME never reaches the wire. What leaves Cloudflare is an address record carrying your own
+				domain name.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -101,6 +101,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-22",
 		readingTime: "7 min read",
 	},
+	{
+		slug: "cloudflare-cname-flattening",
+		h1: "What Is CNAME Flattening in Cloudflare?",
+		title: "Cloudflare CNAME Flattening: Root Domain CNAMEs Explained",
+		description:
+			"CNAME flattening means Cloudflare resolves the CNAME itself and returns the target's IP address. It is what lets a root domain point at a hostname.",
+		blurb:
+			"Why a root domain cannot hold a real CNAME, what Cloudflare returns instead, and the three setups flattening quietly breaks.",
+		updated: "2026-08-23",
+		readingTime: "8 min read",
+	},
 ];
 
 export const GUIDES_ZH: GuideMeta[] = [


### PR DESCRIPTION
## 选题依据

- **真实搜索问句**：`cloudflare cname flattening`、`cname at root domain`、`why does dig return A instead of CNAME`——都是「这是什么 / 为什么坏了」型，不是产品软文。
- **落在 App 覆盖范围内**：DNS + 代理状态。
- **可逐条核实**：全部论断对着 developers.cloudflare.com 当前文档核过（见下）。
- **不重复且能内链**：现有英文六篇没有 DNS 记录类型这一路；与「DNS 改动没生效」做了双向内链（展平后的悬空 CNAME 回 NODATA，看上去就像没生效），并单向链到「橙云是什么」。

## 核对官方文档时修正 / 放弃了什么

| 动笔前的想法 | 核对后 | 依据 |
|---|---|---|
| 「展平所有 CNAME」是免费版也能开的开关 | **修正**：整区开关与逐条 Flatten **都只对付费区可用**；apex 展平才是全计划自动生效且无法关闭 | [Setup](https://developers.cloudflare.com/dns/cname-flattening/set-up-cname-flattening/) |
| 仅 DNS 的展平答案沿用你自己记录的 TTL | **修正**：TTL 是目标记录与你 CNAME 记录**两者中较小的那个**；代理记录固定 300 且不可编辑 | [示例图](https://developers.cloudflare.com/dns/cname-flattening/cname-flattening-diagram/)、[TTL](https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/) |
| 目标没有 A 记录时会报错 | **修正**：返回 NODATA 空答案，不是错误——这正是它被误当成「没生效」的原因 | [CNAME flattening](https://developers.cloudflare.com/dns/cname-flattening/) |
| 打算引用 Cloudflare 2014 年那篇 flattening 博客 | **放弃**：`blog.cloudflare.com/introducing-cname-flattening-…` 本机 curl 返回 000（连不上），不放进正文外链 | — |
| 打算写「展平让 apex 能同时挂 MX/TXT」当作官方结论 | **降级**：文档没有这句原话，改成从「线上回的是 A 记录」+ RFC 1034 推出的表述 | [RFC 1034 §3.6.2](https://www.rfc-editor.org/rfc/rfc1034#section-3.6.2) |

其余核实来源：[Error 1014](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/)（跨账号 CNAME）、[邮件问题排查](https://developers.cloudflare.com/dns/troubleshooting/email-issues/)（DKIM / autodiscover 被展平后读不到）、[record attributes](https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/)（`cf-flatten-cname` 标签）、[create zone apex](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-zone-apex/)（ANAME/ALIAS 改写成 CNAME）、[Pages 根域](https://developers.cloudflare.com/pages/configuration/custom-domains/)。

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（仅既有的 proxy env 提示） |
| 2 | `npx vitest run` | ✅ 20 文件 / 150 用例全绿 |
| 3 | `npx eslint`（新增+改动文件） | ✅ 无 error |
| 4 | 新 URL 返回 200 | ⚠️ 定时任务为无人值守会话，`preview_start` 拒绝起 dev server。改以构建产物核验：`/en` 预渲染 `.meta` 无 status（=200）、非 en 语言均为 404；上线后再 curl 线上确认 |
| 5 | canonical 自引用 + hreflang | ✅ canonical `https://o-c.do/guides/cloudflare-cname-flattening`；hreflang 仅 `en` + `x-default`，均自引用 |
| 6 | JSON-LD 可解析 + FAQ 逐字出现在正文 | ✅ 脚本断言：2 个 ld+json 块全部 `json.loads` 通过，类型含 TechArticle / FAQPage / BreadcrumbList，5 组问答逐字命中渲染后可见文本 |
| 7 | 标题层级无跳级 | ✅ h1 → h2×7 → h3×5(FAQ) → h2×2(外壳)，无跳级，h1 唯一 |
| 8 | 375px 无横向溢出 | ⚠️ 同 #4 无法起本地 server；已在 375px 下核验线上同构页面（purge 一篇）`scrollWidth == clientWidth == 375`，本篇表格套 `.table-wrap`（`overflow-x:auto`）、`pre` 为 `overflow-x:auto`、SVG 为 `w-full max-w-[420px]`，与现网页面同构；上线后复核 |
| 9 | 外链全部 2xx/3xx | ✅ 正文 15 条外链全部 200（含 RFC 1034） |
| 10 | 词数 1000–1800 | ✅ 1442 词 |

`<title>`（57 字符）：`Cloudflare CNAME Flattening: Root Domain CNAMEs Explained`
meta description（147 字符）：`CNAME flattening means Cloudflare resolves the CNAME itself and returns the target's IP address. It is what lets a root domain point at a hostname.`