### PR TITLE
fix(web): /guides 橙云篇改吃信息型意图，不再与首页抢品牌词

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-cname-flattening/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-cname-flattening/page.tsx
@@ -54,7 +54,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 const RELATED: RelatedLink[] = [
 	{
 		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
-		label: "What does the orange cloud mean in Cloudflare?",
+		label: "Orange cloud vs grey cloud: proxied vs DNS only",
 		note: "Every proxied record is flattened by definition — this is what the proxy returns instead of your origin.",
 	},
 	{

--- a/apps/web/src/app/[locale]/guides/cloudflare-orange-to-orange/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-orange-to-orange/page.tsx
@@ -32,7 +32,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 const RELATED: RelatedLink[] = [
 	{
 		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
-		label: "What does the orange cloud mean in Cloudflare?",
+		label: "What is the orange cloud in Cloudflare?",
 		note: "The prerequisite: proxied vs DNS only, which records qualify, and which ports the proxy covers.",
 	},
 	{

--- a/apps/web/src/app/[locale]/guides/cloudflare-purge-cache-not-working/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-purge-cache-not-working/page.tsx
@@ -62,7 +62,7 @@ const RELATED: RelatedLink[] = [
 	},
 	{
 		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
-		label: "What does the orange cloud mean in Cloudflare?",
+		label: "What does DNS only mean in Cloudflare?",
 		note: "Nothing is cached — and nothing can be purged — on a hostname that is set to DNS only.",
 	},
 	{

--- a/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
@@ -41,7 +41,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 const RELATED: RelatedLink[] = [
 	{
 		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
-		label: "What does the orange cloud mean in Cloudflare?",
+		label: "What is the orange cloud in Cloudflare?",
 		note: "The prerequisite: encryption modes only apply to records that are proxied in the first place.",
 	},
 	{
@@ -165,7 +165,7 @@ export default async function EncryptionModesGuide({ params }: { params: Promise
 					connects directly, so there is no second hop for the mode to govern. If that distinction is new,
 					start with{" "}
 					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
-						what the orange cloud means in Cloudflare
+						what the orange cloud is and what proxying changes
 					</Link>
 					.
 				</p>

--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { setRequestLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import ProxyStatusPaths from "@/components/guides/ProxyStatusPaths";
 import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
 
 const SITE_URL = "https://o-c.do";
@@ -16,16 +17,16 @@ const FAQ: Array<{ q: string; a: string }> = [
 		a: "It means that DNS record is proxied. Cloudflare answers queries for the hostname with its own anycast IP addresses, so HTTP and HTTPS requests reach Cloudflare first and your Cloudflare settings — caching, WAF, rules — apply before the request is passed to your origin server.",
 	},
 	{
-		q: "What’s the difference between the orange cloud and the grey cloud?",
-		a: "The orange cloud proxies traffic through Cloudflare; the gray cloud — spelled grey outside the US, and labelled DNS only in the dashboard — does not. A gray-clouded record returns your origin IP address, so visitors connect straight to your server, and no caching, WAF, or HTTP analytics apply to those requests.",
+		q: "What is the difference between the orange cloud and the grey cloud?",
+		a: "The orange cloud proxies traffic through Cloudflare; the grey cloud — written gray cloud in Cloudflare's own dashboard, where it is labelled DNS only — does not. A grey-clouded record returns your origin IP address, so visitors connect straight to your server, and no caching, WAF, or HTTP analytics apply to those requests.",
 	},
 	{
 		q: "Should the orange cloud be on or off?",
 		a: "On for any A, AAAA, or CNAME record that serves your website or API over HTTP/HTTPS. Off for mail hostnames, domain-verification records, SSH and other non-HTTP services, and endpoints a third party has to reach at your real IP address.",
 	},
 	{
-		q: "Why can’t I turn on the orange cloud for my MX record?",
-		a: "Only A, AAAA, and CNAME records can be proxied. MX, TXT, NS, SRV, and every other type stay DNS only, because Cloudflare’s proxy handles HTTP and HTTPS traffic and has no anycast address to substitute for those record types.",
+		q: "What does DNS only mean in Cloudflare?",
+		a: "DNS only — the grey cloud — means Cloudflare publishes the record but does not proxy it. The query returns your origin IP address, visitors connect straight to your server, and caching, the WAF, Rules and Workers routes never see the request. MX, TXT, NS, SRV and every record type other than A, AAAA and CNAME is permanently DNS only.",
 	},
 	{
 		q: "Does the orange cloud hide my origin IP?",
@@ -141,40 +142,41 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 			<GuideShell
 				title={guide.h1}
-				lede="One toggle in the Cloudflare dashboard decides whether your traffic goes through Cloudflare at all. Here is exactly what it changes."
+				lede="Orange cloud or grey cloud, proxied or DNS only — one toggle in the Cloudflare dashboard decides whether your traffic goes through Cloudflare at all. Here is exactly what it changes."
 				updated={guide.updated}
 				readingTime={guide.readingTime}
 				related={RELATED}
 			>
 				<div className="glass r-island note p-6 sm:p-7">
 					<p>
-						<strong>The orange cloud means a DNS record is proxied.</strong> Cloudflare answers queries for
-						that hostname with its own anycast IP addresses, and HTTP/HTTPS traffic passes through
-						Cloudflare on the way to your server. The gray cloud means DNS only: traffic goes straight to
-						your origin.
+						<strong>The orange cloud means a DNS record is proxied through Cloudflare.</strong> Cloudflare
+						answers queries for that hostname with its own anycast IP addresses, so HTTP/HTTPS traffic
+						passes through Cloudflare on the way to your server. The grey cloud means DNS only: traffic
+						goes straight to your origin.
 					</p>
 				</div>
 
 				<p>
-					In the Cloudflare dashboard, every A, AAAA, and CNAME record has a small cloud icon next to it.
-					Orange means <em>proxied</em>. Gray — spelled grey in much of the world, and often searched that
-					way — means <em>DNS only</em>. It looks like a cosmetic toggle and it
-					is not: it decides whether Cloudflare is a CDN and firewall in front of your site, or merely the
-					place where your DNS records happen to live.
+					In the Cloudflare dashboard, every A, AAAA, and CNAME record carries a cloud icon under{" "}
+					<strong>Proxy status</strong>. Orange means <em>proxied</em>; grey — spelled gray in Cloudflare’s
+					own documentation — means <em>DNS only</em>. It looks cosmetic and is not: it decides whether
+					Cloudflare is a CDN and firewall in front of your site, or merely the place your DNS records
+					happen to live.
 				</p>
 
-				<h2 id="orange-vs-gray">Orange cloud vs gray cloud</h2>
+				<h2 id="orange-vs-gray">Orange cloud vs grey cloud: proxied vs DNS only</h2>
 				<p>
-					The difference starts one step earlier than most people expect — at the DNS answer itself, before
-					any HTTP request exists.
+					The difference starts at the DNS answer itself, before any HTTP request exists.
 				</p>
+				<ProxyStatusPaths />
+				<p>Everything else follows from those two answers:</p>
 				<div className="table-wrap">
 					<table>
 						<thead>
 							<tr>
 								<th scope="col">&nbsp;</th>
 								<th scope="col">Orange cloud (proxied)</th>
-								<th scope="col">Gray cloud (DNS only)</th>
+								<th scope="col">Grey cloud (DNS only)</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -227,18 +229,16 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 					</table>
 				</div>
 				<p>
-					One consequence is worth spelling out: a gray-clouded record publishes your server’s real address,
-					which is what makes “I moved to Cloudflare and still got hit directly” possible. Cloudflare can
-					only protect requests it actually receives.
+					One consequence is worth spelling out: a grey-clouded record publishes your server’s real
+					address, which is what makes “I moved to Cloudflare and still got hit directly” possible.
 				</p>
 
 				<h2 id="which-records">Which records can be orange-clouded</h2>
 				<p>
-					Only <strong>A</strong>, <strong>AAAA</strong>, and <strong>CNAME</strong> records — the record
-					types that resolve a name to an address. MX, TXT, NS, SRV, CAA and the rest are always DNS only,
-					and the dashboard will not offer you a toggle for them. The reason is structural rather than
-					arbitrary: proxying works by handing out Cloudflare anycast addresses instead of yours, and there
-					is nothing to substitute in a TXT or MX record.
+					Only <strong>A</strong>, <strong>AAAA</strong>, and <strong>CNAME</strong> records — the ones
+					that resolve a name to an address. MX, TXT, NS, SRV, CAA and the rest are always DNS only, and
+					the dashboard offers no toggle for them: proxying works by handing out Cloudflare anycast
+					addresses instead of yours, and there is nothing to substitute in a TXT or MX record.
 				</p>
 				<p>Three behaviours that surprise people:</p>
 				<ul>
@@ -248,18 +248,21 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 					</li>
 					<li>
 						<strong>Proxying is inherited along a CNAME chain.</strong> If a name anywhere in the chain is
-						proxied, the request is proxied.
+						proxied, the request is proxied — and a proxied CNAME is always{" "}
+						<Link href="/guides/cloudflare-cname-flattening">flattened</Link>, because the answer it
+						returns is a Cloudflare address rather than the target name.
 					</li>
 					<li>
 						<strong>Some CNAME targets are blocked from proxying on purpose.</strong> DKIM and validation
-						targets such as <code>dkim.amazonses.com</code>, <code>acm-validations.aws</code>, or
-						subdomains of <code>onmicrosoft.com</code> cannot be orange-clouded, because a proxied answer
-						would break the very check they exist for.
+						targets — <code>dkim.amazonses.com</code> and its subdomains, subdomains of{" "}
+						<code>acm-validations.aws</code> and <code>onmicrosoft.com</code>, <code>zmverify.zoho.com</code>{" "}
+						— cannot be orange-clouded, because a proxied answer would break the very check they exist
+						for.
 					</li>
 				</ul>
 				<p>
-					Pointing a proxied record at a hostname in a <em>different</em> Cloudflare account is also
-					refused — that is{" "}
+					Pointing a proxied record at a hostname in a <em>different</em> Cloudflare account is refused —
+					that is{" "}
 					<a
 						href="https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/"
 						target="_blank"
@@ -274,8 +277,8 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 
 				<h2 id="ports">The proxy only covers certain HTTP and HTTPS ports</h2>
 				<p>
-					This is the single biggest trap for newcomers. The orange cloud is an HTTP/HTTPS reverse proxy,
-					not a general network tunnel. By default it handles these ports:
+					The orange cloud is an HTTP/HTTPS reverse proxy, not a general network tunnel. By default it
+					handles these ports:
 				</p>
 				<div className="table-wrap">
 					<table>
@@ -305,9 +308,9 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 				</div>
 				<p>
 					Everything outside that list — SSH on 22, RDP on 3389, SMTP on 25, a database port, a game
-					server, a dev server on 3000 — is not proxied. The hostname now resolves to Cloudflare, and
-					Cloudflare has no reason to forward a connection on those ports to your machine, so the
-					connection simply fails. Gray-cloud that hostname, or put it behind{" "}
+					server — is not proxied. The hostname now resolves to Cloudflare, which has no reason to
+					forward those ports to your machine, so the connection simply fails. Grey-cloud that hostname,
+					or put it behind{" "}
 					<a
 						href="https://developers.cloudflare.com/spectrum/"
 						target="_blank"
@@ -318,69 +321,67 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 					, which does handle arbitrary TCP and UDP.
 				</p>
 				<p>
-					Note also that the alternate ports (<code>2052</code>, <code>2053</code>, <code>2082</code>,{" "}
-					<code>2083</code>, <code>2086</code>, <code>2087</code>, <code>2095</code>, <code>2096</code>,{" "}
-					<code>8880</code>, <code>8443</code>) are proxied but <em>not cached</em> by default. If you serve
-					a site on 8443 and wonder why the cache hit rate is zero, that is why.
+					The alternate ports (everything above except <code>80</code> and <code>443</code>) are proxied
+					but <em>not cached</em> by default. If you serve a site on 8443 and wonder why the cache hit
+					rate is zero, that is why.
 				</p>
 
-				<h2 id="when-gray">When the gray cloud is the right answer</h2>
-				<p>Reach for DNS only whenever the service on the other end is not plain HTTP/HTTPS to your own origin:</p>
+				<h2 id="when-gray">When DNS only (the grey cloud) is the right answer</h2>
+				<p>Reach for DNS only whenever the far end is not plain HTTP/HTTPS to your own origin:</p>
 				<ul>
 					<li>
 						<strong>Mail.</strong> MX records cannot be proxied at all, and a hostname used for mail
-						delivery (<code>mail.example.com</code>) should stay gray. Cloudflare does not proxy SMTP on
-						port 25, so proxying the mail host points senders at Cloudflare and delivery stops.
+						delivery (<code>mail.example.com</code>) should stay grey. Cloudflare does not proxy SMTP on
+						port 25, so proxying it points senders at Cloudflare and delivery stops.
 					</li>
 					<li>
 						<strong>Domain verification.</strong> Verification CNAMEs and TXT records must return the
-						exact value the third party expects; a proxied answer returns Cloudflare addresses and
-						verification fails.
+						exact value the third party expects; a proxied answer returns Cloudflare addresses instead
+						and verification fails.
 					</li>
 					<li>
-						<strong>Non-HTTP services.</strong> SSH, RDP, FTP, game servers, anything on a port outside
+						<strong>Non-HTTP services.</strong> SSH, RDP, FTP, game servers — anything on a port outside
 						the list above.
 					</li>
 					<li>
 						<strong>Sites hosted on a SaaS platform</strong> that terminates its own TLS — Wix,
-						Squarespace, Webflow and similar — unless that platform is explicitly integrated with
-						Cloudflare. Two proxies both terminating TLS and both redirecting to HTTPS is how you get
-						certificate errors and redirect loops.
+						Squarespace, Webflow — unless the platform is explicitly integrated with Cloudflare. Two
+						proxies both terminating TLS and both redirecting to HTTPS is how you get certificate
+						errors and redirect loops.
 					</li>
 					<li>
-						<strong>Endpoints validated by IP.</strong> If a partner allowlists your server’s address for
-						webhooks or API calls, proxying replaces it with Cloudflare’s.
+						<strong>Endpoints validated by IP.</strong> If a partner allowlists your server’s address,
+						proxying replaces it with Cloudflare’s.
 					</li>
 				</ul>
 				<p>
 					A rule of thumb: <em>if the hostname serves web traffic on a standard port and you control the
-					origin, orange-cloud it. Everything else stays gray.</em>
+					origin, orange-cloud it. Everything else stays grey.</em>
 				</p>
 
 				<h2 id="troubleshooting">When the toggle causes an error</h2>
 				<p>Most orange-cloud incidents look like one of these.</p>
 				<h3>SSH or a custom port stopped working right after you switched</h3>
 				<p>
-					Expected. That port is not proxied. Move the service to its own hostname and gray-cloud that
+					Expected. That port is not proxied. Move the service to its own hostname and grey-cloud that
 					hostname, keeping the web hostname orange.
 				</p>
 				<h3>Mail stopped being delivered</h3>
 				<p>
-					Check whether the hostname your MX record points to is proxied. Give mail its own DNS-only
-					hostname rather than sharing the web hostname. (Cloudflare does try to save you here: if an MX
-					record points at a proxied name, it dynamically prepends <code>_dc-mx</code> to the answer so mail
-					bypasses the proxy — a safety net, not a design to rely on.)
+					Check whether the hostname your MX record points to is proxied, and give mail its own DNS-only
+					hostname. (Cloudflare does try to save you: if an MX record points at a proxied name, it
+					prepends <code>_dc-mx</code> to the answer so mail bypasses the proxy — a safety net, not a
+					design to rely on.)
 				</p>
 				<h3>522, 521, or 524 errors appeared</h3>
 				<p>
-					These only exist because traffic is now proxied: Cloudflare is reaching your origin and not
-					getting a usable answer. A 521 means the origin refused the connection, 522 means it timed out —
-					both usually a firewall that does not allow{" "}
+					These exist only because traffic is now proxied: Cloudflare is reaching your origin and not
+					getting a usable answer. 521 means the origin refused the connection and 522 means it timed
+					out — usually a firewall that does not allow{" "}
 					<a href="https://www.cloudflare.com/ips/" target="_blank" rel="noopener noreferrer">
 						Cloudflare’s IP ranges
 					</a>
-					, or an origin that is down. A 524 means the origin accepted the connection but took longer than
-					the proxy read timeout to respond.
+					. 524 means the origin accepted the connection but exceeded the proxy read timeout.
 				</p>
 				<h3>Redirect loop or certificate error appeared</h3>
 				<p>
@@ -410,10 +411,31 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 				</p>
 				<h3>Your origin IP leaked anyway</h3>
 				<p>
-					Look for the other records in the same zone — <code>mail</code>, <code>ftp</code>, <code>cpanel</code>,
-					a forgotten staging subdomain — that still point at the same server. Also remember that while a
-					newly added domain is still pending activation (up to 24 hours), records behave as DNS only even
-					when marked proxied; rotating the origin IP after activation closes that window.
+					Look for other records in the same zone — <code>mail</code>, <code>ftp</code>,{" "}
+					<code>cpanel</code>, a forgotten staging subdomain — still pointing at the same server. And
+					while a newly added domain is pending activation (up to 24 hours), records behave as DNS only
+					even when marked proxied; rotate the origin IP after activation to close that window.
+				</p>
+				<h3>Client certificates (mTLS) stopped validating</h3>
+				<p>
+					On a proxied record TLS terminates at Cloudflare, which opens a second connection to your
+					origin — so the origin never sees the visitor’s client certificate. Validate client
+					certificates{" "}
+					<a
+						href="https://developers.cloudflare.com/ssl/client-certificates/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						at Cloudflare
+					</a>{" "}
+					instead, or have Cloudflare forward the certificate details to your origin in a header.
+				</p>
+				<h3>Windows authentication prompts in a loop</h3>
+				<p>
+					Integrated Windows Authentication, NTLM and Kerberos are incompatible with proxied records:
+					NTLM authenticates the TCP connection rather than the request, and Cloudflare does not
+					guarantee that consecutive requests reuse the same connection. That hostname needs to be DNS
+					only.
 				</p>
 				<h3>Your app now sees Cloudflare addresses as the visitor IP</h3>
 				<p>
@@ -421,16 +443,15 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 					<code>CF-Connecting-IP</code> header (or <code>X-Forwarded-For</code>) instead of the socket.
 				</p>
 
-				<h2 id="how-to-switch">How to switch it</h2>
+				<h2 id="how-to-switch">How to turn the orange cloud on or off</h2>
 				<p>
-					<strong>In the dashboard:</strong> open your domain, go to <strong>DNS → Records</strong>, select{" "}
-					<strong>Edit</strong> on the record, and click the cloud under <strong>Proxy status</strong>. It
-					takes effect at Cloudflare immediately, though resolvers may hold the previous answer for up to
-					five minutes.
+					<strong>In the dashboard:</strong> open your domain, go to <strong>DNS → Records</strong>,{" "}
+					<strong>Edit</strong> the record, and click the cloud under <strong>Proxy status</strong>. It
+					takes effect immediately, though resolvers may hold the previous answer for up to five
+					minutes.
 				</p>
 				<p>
-					<strong>Over the API:</strong> proxy status is the <code>proxied</code> boolean on the DNS record.
-					A partial update is enough:
+					<strong>Over the API:</strong> proxy status is the <code>proxied</code> boolean on the record:
 				</p>
 				<pre>
 					<code>{API_EXAMPLE}</code>
@@ -443,10 +464,10 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 
 				<h2 id="both-orange">What if both ends are orange?</h2>
 				<p>
-					If your proxied record points at a hostname that is itself proxied by Cloudflare — typically a
-					SaaS platform using Cloudflare for SaaS, such as a Shopify store on your own domain — the request
-					crosses two Cloudflare zones, and both sets of settings apply in a defined order. Cloudflare calls
-					this Orange-to-Orange, or O2O, and it has its own rules about which zone wins:{" "}
+					If your proxied record points at a hostname that is itself proxied — typically a SaaS platform
+					using Cloudflare for SaaS, such as a Shopify store on your own domain — the request crosses two
+					Cloudflare zones and both sets of settings apply, in order. Cloudflare calls this
+					Orange-to-Orange, or O2O:{" "}
 					<Link href="/guides/cloudflare-orange-to-orange">
 						Cloudflare Orange-to-Orange (O2O), explained
 					</Link>

--- a/apps/web/src/app/[locale]/guides/why-is-cloudflare-not-caching-my-site/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-cloudflare-not-caching-my-site/page.tsx
@@ -179,7 +179,7 @@ export default async function NotCachingGuide({ params }: { params: Promise<{ lo
 					is missing, the response came from your origin, whatever else the page appears to be doing. If the
 					headers are absent entirely, the hostname is probably not proxied at all — see{" "}
 					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
-						what the orange cloud means in Cloudflare
+						proxied vs DNS only
 					</Link>{" "}
 					for that case, because a DNS-only record never reaches a cache in the first place.
 				</p>

--- a/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
@@ -54,7 +54,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 const RELATED: RelatedLink[] = [
 	{
 		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
-		label: "What does the orange cloud mean in Cloudflare?",
+		label: "Orange cloud vs grey cloud, explained",
 		note: "Why a proxied record never returns your origin IP — and why that changes what dig can tell you.",
 	},
 	{

--- a/apps/web/src/components/guides/ProxyStatusPaths.tsx
+++ b/apps/web/src/components/guides/ProxyStatusPaths.tsx
@@ -1,0 +1,115 @@
+/**
+ * 代理状态对照图：同一个名字在橙云 / 灰云下，DNS 答案与请求路径分别长什么样。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；单列竖排，窄屏不溢出。
+ * 说明文字一律放在方框外的整幅宽度上——框内只留一个词，避免窄屏挤到边。
+ */
+export default function ProxyStatusPaths() {
+	const node = (x: number, y: number) => ({ x, y, width: 100, height: 48, rx: 12 });
+	const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace";
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 360 352"
+				role="img"
+				aria-label="Two request paths compared. With the orange cloud the DNS answer is a Cloudflare anycast address and the request goes from the visitor to Cloudflare and then to your origin, so caching, WAF and Rules run at the Cloudflare hop. With the grey cloud the DNS answer is your own server address and the request goes straight from the visitor to your origin, skipping Cloudflare entirely."
+				className="mx-auto block h-auto w-full max-w-[440px]"
+			>
+				<title>Orange cloud (proxied) vs grey cloud (DNS only): the two request paths</title>
+
+				<defs>
+					<marker id="ps-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+					<marker id="ps-arrow-grey" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--t-tertiary)" />
+					</marker>
+				</defs>
+
+				{/* —— 橙云：请求先到 Cloudflare —— */}
+				<text x="180" y="16" textAnchor="middle" fontSize="11" letterSpacing="0.8" fill="var(--oc-orange)">
+					ORANGE CLOUD · PROXIED
+				</text>
+				<text x="180" y="39" textAnchor="middle" fontSize="11" fill="var(--t-secondary)" fontFamily={MONO}>
+					DNS answer: 104.21.0.1
+				</text>
+
+				<rect {...node(8, 54)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="58" y="83" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Visitor
+				</text>
+
+				<rect {...node(130, 54)} fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.6" />
+				<text x="180" y="83" textAnchor="middle" fontSize="13" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare
+				</text>
+
+				<rect {...node(252, 54)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="302" y="83" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Your origin
+				</text>
+
+				<g stroke="var(--oc-orange)" strokeWidth="1.6" markerEnd="url(#ps-arrow)" fill="none">
+					<path d="M108 78 L126 78" />
+					<path d="M230 78 L248 78" />
+				</g>
+
+				<text x="180" y="126" textAnchor="middle" fontSize="11.5" fill="var(--t-secondary)">
+					Cache, WAF and Rules run at this hop.
+				</text>
+				<text x="180" y="144" textAnchor="middle" fontSize="11.5" fill="var(--t-secondary)">
+					Your origin address is never published for this name.
+				</text>
+
+				<line x1="30" y1="168" x2="330" y2="168" stroke="var(--divider)" strokeWidth="1" />
+
+				{/* —— 灰云：Cloudflare 根本不在路径上 —— */}
+				<text x="180" y="199" textAnchor="middle" fontSize="11" letterSpacing="0.8" fill="var(--t-tertiary)">
+					GREY CLOUD · DNS ONLY
+				</text>
+				<text x="180" y="222" textAnchor="middle" fontSize="11" fill="var(--t-secondary)" fontFamily={MONO}>
+					DNS answer: 203.0.113.10
+				</text>
+
+				<rect {...node(8, 237)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="58" y="266" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Visitor
+				</text>
+
+				<rect
+					{...node(130, 237)}
+					fill="none"
+					stroke="var(--divider)"
+					strokeDasharray="4 5"
+					strokeOpacity="0.8"
+				/>
+				<text x="180" y="260" textAnchor="middle" fontSize="13" fill="var(--t-tertiary)">
+					Cloudflare
+				</text>
+				<text x="180" y="276" textAnchor="middle" fontSize="11" fill="var(--t-tertiary)">
+					skipped
+				</text>
+
+				<rect {...node(252, 237)} fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="302" y="266" textAnchor="middle" fontSize="13" fill="var(--t-primary)">
+					Your origin
+				</text>
+
+				<path
+					d="M108 268 C 142 322, 218 322, 246 272"
+					fill="none"
+					stroke="var(--t-tertiary)"
+					strokeWidth="1.6"
+					markerEnd="url(#ps-arrow-grey)"
+				/>
+
+				<text x="180" y="345" textAnchor="middle" fontSize="11.5" fill="var(--t-secondary)">
+					Nothing to cache, filter or log.
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				The toggle changes the DNS answer first; the path follows.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -37,14 +37,14 @@ export type GuideMeta = {
 export const GUIDES: GuideMeta[] = [
 	{
 		slug: "what-is-the-orange-cloud-in-cloudflare",
-		h1: "What Does the Orange Cloud Mean in Cloudflare?",
-		title: "Cloudflare Orange Cloud: Proxied vs DNS Only, Explained",
+		h1: "What Is the Orange Cloud in Cloudflare?",
+		title: "What Is the Orange Cloud? Proxied vs DNS Only in Cloudflare",
 		description:
-			"The orange cloud means a DNS record is proxied through Cloudflare. The gray cloud means DNS only. What changes, which records qualify, when to use each.",
+			"The orange cloud means a DNS record is proxied through Cloudflare; the grey cloud means DNS only. What changes, which records qualify, when to use each.",
 		blurb:
-			"Proxied vs DNS only: what the toggle actually changes, which record types and ports it covers, and how to read the errors it causes.",
-		updated: "2026-08-19",
-		readingTime: "8 min read",
+			"Orange cloud vs grey cloud, proxied vs DNS only: what the toggle actually changes, which record types and ports it covers, and the errors it causes.",
+		updated: "2026-08-23",
+		readingTime: "9 min read",
 	},
 	{
 		slug: "cloudflare-orange-to-orange",


### PR DESCRIPTION
## 为什么是「修」而不是「新写一篇」

本轮 GSC（28 天）触发了 SKILL 里「目标词被本站其它页面抢走 → 改成修这个」的条件：

| 查询词 | 展示 | 赢家 | 均位 |
|---|---|---|---|
| `orange cloud` | 481 | `/` | 7.6 |
| `cloudflare orange cloud` | 98 | `/` | 5.1 |
| `orange cloud cloudflare` | 55 | `/` | 4.9 |
| **`what is orange cloud in cloudflare`** | 2 | **`/`** | 10.0 |

最后一行是关键：连这句问句都由首页承接，而 slug 恰好就是 `what-is-the-orange-cloud-in-cloudflare` 的那篇文章一次都没赢过（全期 12 次展示、均位 18.3）。品牌名本身叫 Orange Cloud，Google 把裸品牌词判成导航意图——这批词不该抢。正确解是把这篇整体切到首页天然接不住的**问句 / 对比意图**上。

另外核对了另外两条修复触发条件，均未触发：英文文章全部「已提交，且已编入索引」；三篇零展示的（not-caching / purge / cname-flattening）分别只上线 3 / 1 / 0 天，未达 14 天门槛。

## 改了什么

- **title**：`Cloudflare Orange Cloud: Proxied vs DNS Only, Explained` → `What Is the Orange Cloud? Proxied vs DNS Only in Cloudflare`（59 字符）。不再以 `Cloudflare Orange Cloud` 这个直接映射到首页的二元组开头。
- **H1**：`What Does the Orange Cloud Mean in Cloudflare?` → `What Is the Orange Cloud in Cloudflare?`，与 slug、与实测查询逐字对齐；「what does it mean」这一变体下放到正文首段与 FAQ 首条，两种问法各有落点。
- **meta description**：仍是答案先行，`gray` 改 `grey`（正文两种拼法都保留）。
- **小节标题**切到对比措辞：`Orange cloud vs grey cloud: proxied vs DNS only`、`When DNS only (the grey cloud) is the right answer`、`How to turn the orange cloud on or off`。
- **FAQ**：用 `What does DNS only mean in Cloudflare?` 替换 MX 那条（MX 的事实正文已完整覆盖，不损失信息），仍为 5 条，问答与 JSON-LD 同源逐字一致。
- **新增内联 SVG** `ProxyStatusPaths`：同一个名字在橙云 / 灰云下的 DNS 答案与请求路径对照。走主题 token、竖排双栏、`role="img"` + `aria-label` + `<title>`。
- **入链锚文本**：六篇引用此文的指南此前用的是同一句锚文本，拆成四种问法（`What is the orange cloud in Cloudflare?` / `Orange cloud vs grey cloud: proxied vs DNS only` / `What does DNS only mean in Cloudflare?` / `Orange cloud vs grey cloud, explained`），另有两处正文内链锚文本改写。
- 顺带把新上线、零展示的 CNAME 展平那篇接进正文（proxied CNAME 默认被展平，官方文档明说）。

## 核对官方文档时修正 / 新增的论断

逐条对着当前版本文档核过（`index.md` 原文）：

| 项 | 结论 | 文档 |
|---|---|---|
| `acm-validations.aws` | **修正**：原文写成与 `dkim.amazonses.com` 并列的「精确匹配」目标，实际是「Subdomain of」；同批补上 `zmverify.zoho.com` | [proxy-status/limitations](https://developers.cloudflare.com/dns/proxy-status/limitations/) |
| 客户端证书 / mTLS | **新增**：代理下 TLS 终止在 Cloudflare，源站在握手中永远拿不到访客的客户端证书 | [proxy-status/use-cases](https://developers.cloudflare.com/dns/proxy-status/use-cases/) |
| NTLM / Kerberos | **新增**：与代理记录不兼容，NTLM 认的是 TCP 连接、而 Cloudflare 不保证连接复用 | [proxy-status/limitations](https://developers.cloudflare.com/dns/proxy-status/limitations/) |
| 端口清单、TTL 300s、混合记录、CNAME 链继承、1014、`_dc-mx`、pending 24h、524 | 原文照旧，逐条复核无误 | [network-ports](https://developers.cloudflare.com/fundamentals/reference/network-ports/) / [proxy-status](https://developers.cloudflare.com/dns/proxy-status/) |

没有放弃的论断——原文技术部分复核后全部成立，改动集中在意图与措辞。

## 硬门槛

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（一次 Google Fonts 取字体的网络抖动，重跑即过） |
| 2 | `npx vitest run` | ✅ 21 files / 166 tests 全绿 |
| 3 | `npx eslint`（9 个改动文件） | ✅ 无 error |
| 4 | dev 服务器新 URL 200 | ⚠️ **未能按原方式执行**：`preview_start` 的 dev-server 模式在无人值守运行中被禁用（「nobody is present to approve」）。替代验证：production build 已成功预渲染该路由（`.next/server/app/en/guides/…html`，105 KB），全部断言直接跑在这份产物上；合并部署后另行 curl 线上 URL 复核 |
| 5 | canonical 自引用 + hreflang | ✅ canonical = `https://o-c.do/guides/what-is-the-orange-cloud-in-cloudflare`；alternates 仅 `en` 与 `x-default`，均指向自身 |
| 6 | JSON-LD 可解析 + FAQ 逐字出现在可见正文 | ✅ 脚本断言：2 个 ld+json 块全部 `json.loads` 通过（`SoftwareApplication` / `TechArticle` / `FAQPage` / `BreadcrumbList`），5 条问 + 5 条答逐字命中渲染后可见文本 |
| 7 | 标题层级无跳级 | ✅ `[1,2,2,2,2,2,3×8,2,2,2,3×5,2,2]`，无跳级 |
| 8 | 375px 无横向滚动 | ✅ 在 375×812 的真实 CSS 环境下量得 `scrollWidth == clientWidth == 375`；新 SVG 渲染宽 327px（left 24 / right 351），框内最长标签 65/100 单位、全部文本落在 360 视框内；宽表继续靠 `.table-wrap` 内部横滚 |
| 9 | 外链 2xx/3xx | ✅ 6 条全部 200（`www.cloudflare.com/ips/` 需带 UA，直连也是 200） |
| 10 | 词数 1000–1800 | ✅ 1791 词（首轮改完 1963，逐段收紧至达标） |

第 4 项未按原方式跑通，其余 9 项全过。