### PR TITLE
fix(web): 小黄云指南改打信息型意图，不再与首页抢裸品牌词

### DIFF
--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -17,7 +17,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 	},
 	{
 		q: "What’s the difference between the orange cloud and the grey cloud?",
-		a: "The orange cloud proxies traffic through Cloudflare; the gray cloud — spelled grey outside the US, and labelled DNS only in the dashboard — does not. A gray-clouded record returns your origin IP address, so visitors connect straight to your server, and no caching, WAF, or HTTP analytics apply to those requests.",
+		a: "It is the proxied vs DNS only choice. The orange cloud proxies traffic through Cloudflare; the grey cloud — spelled gray in Cloudflare’s own documentation, and labelled DNS only in the dashboard — does not. DNS only means the record returns your origin IP address, so visitors connect straight to your server, and no caching, WAF, or HTTP analytics apply to those requests.",
 	},
 	{
 		q: "Should the orange cloud be on or off?",
@@ -148,25 +148,25 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 			>
 				<div className="glass r-island note p-6 sm:p-7">
 					<p>
-						<strong>The orange cloud means a DNS record is proxied.</strong> Cloudflare answers queries for
-						that hostname with its own anycast IP addresses, and HTTP/HTTPS traffic passes through
-						Cloudflare on the way to your server. The gray cloud means DNS only: traffic goes straight to
-						your origin.
+						<strong>The orange cloud means a DNS record is proxied:</strong> Cloudflare answers with its
+						own anycast IP addresses, and HTTP traffic passes through Cloudflare. The grey cloud means
+						DNS only — queries return your origin IP, and visitors connect straight to your server.
 					</p>
 				</div>
 
 				<p>
 					In the Cloudflare dashboard, every A, AAAA, and CNAME record has a small cloud icon next to it.
 					Orange means <em>proxied</em>. Gray — spelled grey in much of the world, and often searched that
-					way — means <em>DNS only</em>. It looks like a cosmetic toggle and it
+					way — means <em>DNS only</em>. So the meaning of the orange cloud comes down to one question about
+					that record: <strong>proxied vs DNS only</strong>. It looks like a cosmetic toggle and it
 					is not: it decides whether Cloudflare is a CDN and firewall in front of your site, or merely the
 					place where your DNS records happen to live.
 				</p>
 
-				<h2 id="orange-vs-gray">Orange cloud vs gray cloud</h2>
+				<h2 id="orange-vs-gray">Orange cloud vs grey cloud: proxied vs DNS only</h2>
 				<p>
-					The difference starts one step earlier than most people expect — at the DNS answer itself, before
-					any HTTP request exists.
+					The difference between the orange cloud and the grey cloud starts one step earlier than most
+					people expect — at the DNS answer itself, before any HTTP request exists.
 				</p>
 				<div className="table-wrap">
 					<table>
@@ -315,7 +315,7 @@ export default async function OrangeCloudGuide({ params }: { params: Promise<{ l
 					>
 						Cloudflare Spectrum
 					</a>
-					, which does handle arbitrary TCP and UDP.
+					, which proxies non-HTTP ports — all TCP and UDP ports on the Enterprise plan.
 				</p>
 				<p>
 					Note also that the alternate ports (<code>2052</code>, <code>2053</code>, <code>2082</code>,{" "}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -38,12 +38,12 @@ export const GUIDES: GuideMeta[] = [
 	{
 		slug: "what-is-the-orange-cloud-in-cloudflare",
 		h1: "What Does the Orange Cloud Mean in Cloudflare?",
-		title: "Cloudflare Orange Cloud: Proxied vs DNS Only, Explained",
+		title: "Proxied vs DNS Only: Cloudflare Orange vs Grey Cloud",
 		description:
-			"The orange cloud means a DNS record is proxied through Cloudflare. The gray cloud means DNS only. What changes, which records qualify, when to use each.",
+			"Proxied (orange cloud) routes HTTP traffic through Cloudflare; DNS only (grey cloud) sends visitors straight to your origin. What each changes, and when.",
 		blurb:
-			"Proxied vs DNS only: what the toggle actually changes, which record types and ports it covers, and how to read the errors it causes.",
-		updated: "2026-08-19",
+			"Proxied vs DNS only, in plain terms: what the orange and grey cloud each change, which record types and ports qualify, and how to read the errors the toggle causes.",
+		updated: "2026-08-24",
 		readingTime: "8 min read",
 	},
 	{


### PR DESCRIPTION
## 本轮为什么是「修」不是「新增」

`gsc.py guides --days 28` + `owners` 的数据直接触发了修复优先规则第 2 条
（目标词被本站其它页面抢走）：

| 页面 | 点击 | 展示 | 均位 |
|---|---|---|---|
| `/guides/cloudflare-orange-to-orange` | 1 | 117 | 6.1 |
| `/guides/what-is-the-orange-cloud-in-cloudflare` | 0 | **12** | **18.3** |

`owners` 里这篇一个词都没承接住，整个词簇归首页 `/`：

- `orange cloud` 展示 479 → `/` 均位 7.5
- `cloudflare orange cloud` 展示 96 → `/` 均位 5.1
- `cloudflare orange` 展示 26 → `/` 均位 5.7（这篇只分到 1 次、均位 17）

同一天上线的 O2O 那篇拿到 117 次展示、均位 6.1，独占 `cloudflare o2o` / `o2o cloudflare`。
差别不在写法，在意图：O2O 是纯信息型词簇，首页天然接不住；而裸品牌词 Google 判成导航意图，
首页永远赢。所以这篇不再抢品牌词，整体切到问句 / 对比意图。

其余两条修复触发条件均不成立：英文指南全部已编入索引；三篇 0 展示的文章（not-caching、
purge-cache、cname-flattening）上线均不足 4 天，未到 14 天观察线；三篇中文新稿是
「Google 无法识别此网址」，按规则不计入。

## 改了什么

- **title**：`Cloudflare Orange Cloud: Proxied vs DNS Only, Explained` →
  `Proxied vs DNS Only: Cloudflare Orange vs Grey Cloud`（52 字符）。
  不再以品牌词开头，改由信息型短语领起，一并覆盖 `proxied vs dns only`、
  `orange vs grey cloud`、`grey cloud`、`dns only` 四个目标写法。
- **H1 未动**——`What Does the Orange Cloud Mean in Cloudflare?` 本身就是问句，
  承接 `what is` / `meaning` 一侧。
- **description**：改为答案先行的对比句（153 字符）；blurb 同步。
- **答案玻璃岛**：46 词 → 40 词，且改为对比先行，更适合被单独摘成精选摘要。
- **对比小节标题**：`Orange cloud vs gray cloud` →
  `Orange cloud vs grey cloud: proxied vs DNS only`（`id` 保持 `orange-vs-gray` 不变，
  不破坏既有锚点）。
- **变体覆盖**：`grey cloud` 由 1 处增至 5 处，`proxied vs DNS only` 由 0 处增至 3 处，
  `meaning` 补 1 处自然落点。未新增元素、未堆关键词、未增加产品提及
  （仍为正文 1 处 + GuideShell 页脚卡 1 处）。

## 核对官方文档后修正的论断

逐条比对了 [Proxy status](https://developers.cloudflare.com/dns/proxy-status/)、
[Proxying limitations](https://developers.cloudflare.com/dns/proxy-status/limitations/)、
[Network ports](https://developers.cloudflare.com/fundamentals/reference/network-ports/)
的当前版本（均 2026-04 更新）。

- **修正一处**：原文写 Cloudflare Spectrum
  "does handle arbitrary TCP and UDP"。Network ports 文档明确
  "Spectrum for all TCP and UDP ports is only available on the Enterprise plan"，
  已改为「proxies non-HTTP ports — all TCP and UDP ports on the Enterprise plan」。
- **复核无误、未改动**：仅 A/AAAA/CNAME 可代理；同名混合记录一律按代理处理；
  CNAME 链上任一跳被代理即整体被代理；代理记录 TTL 固定 Auto=300s；
  HTTP/HTTPS 默认代理端口两张表逐个核对一致；备用端口默认不缓存；
  待激活域名（最长 24h）即使标记为代理也按 DNS only 行为、官方同样建议激活后轮换源站 IP；
  Error 1014 CNAME Cross-User Banned。
- **术语核对**：官方用的是 "gray cloud" / "gray-clouded" / "DNS-only"，
  `grey` 是非美式拼写。表格与正文保留 `Gray`（与 dashboard 一致），
  标题与 FAQ 用 `grey` 承接搜索写法，并在正文说明两种拼法，不是堆词。

## 硬门槛逐项结果

| # | 项目 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警 |
| 2 | `npx vitest run` | ✅ 21 文件 / 166 测试全绿 |
| 3 | `npx eslint`（改动文件） | ✅ 0 error |
| 4 | 新 URL 返回 200 | ⚠️ 见下「未能在浏览器中实测的两项」 |
| 5 | canonical 自引用 + hreflang | ✅ canonical 自引用正确；hreflang 恰好 2 条 = `en` + `x-default` |
| 6 | JSON-LD 可解析 + FAQ 逐字 | ✅ 脚本断言：2 个 JSON-LD 块全部 `JSON.parse` 通过，含 TechArticle / FAQPage / BreadcrumbList；FAQ 10/10 条问答逐字出现在渲染后可见正文中 |
| 7 | 标题层级无跳级 | ✅ `[1,2,2,2,2,2,3,3,3,3,3,3,2,2,2,3,3,3,3,3,2,2]`，无跳级 |
| 8 | 375px 无横向溢出 | ⚠️ 见下 |
| 9 | 外链 2xx/3xx | ✅ 6 条外链全部 200（含 5 条 Cloudflare 文档 + cloudflare.com/ips） |
| 10 | 词数 1000–1800 | ✅ 渲染后正文 1663 词 |

第 5/6/7/10 项均由脚本对 `next build` 产出的预渲染 HTML
（`.next/server/app/en/guides/…html`，93 KB）断言，非肉眼核对。

### 未能在浏览器中实测的两项

本次为**非交互的定时任务运行**，`preview_start` 拒绝启动 dev server
（"Dev servers can't be started from unattended sessions"），故第 4、8 项无法按原方式实测。
两项均以等价证据替代，请人工复核：

- **第 4 项（URL 200）**：`next build` 已把该页**静态预渲染**成 93 KB 的
  `en/guides/what-is-the-orange-cloud-in-cloudflare.html`，渲染期报错会直接构建失败；
  同时非 en 语种产出的是 24 KB 的 notFound 页，说明 `GUIDE_LOCALE` 门控仍生效。
  合并部署后会 curl 线上 URL 复核。
- **第 8 项（375px 溢出）**：本次是**纯文本改动**，未新增任何元素。
  已用浏览器在 375px 下实测**当前线上同结构页面**：`scrollWidth === clientWidth === 375`，无溢出；
  并静态断言正文内 2 个表格全部包在 `.table-wrap`、唯一 `<pre>` 亦有
  `overflow-x: auto`（globals.css:472/492），`<pre>` 之外无任何超过 45 字符的不可断词。
  部署后会在 375px 下对线上新页面再测一次。
