### PR TITLE
feat(web): /guides 新增英文指南「Cloudflare Error 522: Connection Timed Out」

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-error-1000-dns-points-to-prohibited-ip/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-1000-dns-points-to-prohibited-ip/page.tsx
@@ -65,6 +65,11 @@ const RELATED: RelatedLink[] = [
 		note: "What your root record actually resolves to, which is where a prohibited address most often hides.",
 	},
 	{
+		href: "/guides/cloudflare-error-522-connection-timed-out",
+		label: "Cloudflare error 522: connection timed out",
+		note: "The neighbouring failure: the origin address is fine, but nothing answers on it before Cloudflare gives up.",
+	},
+	{
 		href: DOCS_1000,
 		label: "Cloudflare docs: Error 1000",
 		note: "The official cause and resolution list this guide reorganises. Check it before changing anything.",

--- a/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
@@ -1,0 +1,441 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import Error522Path from "@/components/guides/Error522Path";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-error-522-connection-timed-out");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_5XX = "https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/";
+const DOCS_520 = `${DOCS_5XX}error-520/`;
+const DOCS_521 = `${DOCS_5XX}error-521/`;
+const DOCS_522 = `${DOCS_5XX}error-522/`;
+const DOCS_523 = `${DOCS_5XX}error-523/`;
+const DOCS_524 = `${DOCS_5XX}error-524/`;
+const DOCS_LIMITS = "https://developers.cloudflare.com/fundamentals/reference/connection-limits/";
+const DOCS_RAY = "https://developers.cloudflare.com/fundamentals/reference/cloudflare-ray-id/";
+const DOCS_ORIGIN_ANALYTICS = "https://developers.cloudflare.com/speed/origin-analytics/";
+const DOCS_DNS_ONLY = "https://developers.cloudflare.com/dns/proxy-status/";
+const DOCS_WORKERS_DOMAIN = "https://developers.cloudflare.com/workers/configuration/routing/custom-domains/";
+const DOCS_FLAG =
+	"https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public";
+const DOCS_ORIGIN_RULES = "https://developers.cloudflare.com/rules/origin-rules/";
+const DOCS_PAGES_DOMAIN = "https://developers.cloudflare.com/pages/configuration/custom-domains/";
+const CF_IPS = "https://www.cloudflare.com/ips/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What does Cloudflare error 522 mean?",
+		a: "It means Cloudflare tried to reach your origin server over TCP and got no usable answer in time. Either the connection did not complete within 19 seconds, or an established connection produced no acknowledgement of the request within 90 seconds.",
+	},
+	{
+		q: "How do I fix a 522 connection timed out error?",
+		a: "Start at the origin firewall. Confirm that every address in Cloudflare's published IP ranges is allowed through, then confirm the origin is running and that the address in your DNS record is still the one your hosting provider has assigned to the server.",
+	},
+	{
+		q: "What is the difference between Cloudflare error 521 and error 522?",
+		a: "521 is a refusal and 522 is a silence. Cloudflare documents 521 as the origin refusing its connections, and 522 as Cloudflare timing out while contacting the origin, so a firewall that rejects packets tends to produce 521 while one that drops them produces 522.",
+	},
+	{
+		q: "Is error 522 the same as a 502 bad gateway?",
+		a: "No. A 502 is a standard HTTP status that any server or proxy can return, while error code 522 is specific to Cloudflare and always describes the Cloudflare-to-origin hop. A 502 on a proxied site usually came from your own stack rather than from Cloudflare.",
+	},
+	{
+		q: "Can I get a 522 error on Cloudflare Workers or Pages?",
+		a: "Yes. A Worker on a Custom Domain that fetches its own hostname returns 522, and a Pages project reached through a CNAME that does not point at a configured custom Pages domain can produce one too. In both cases the origin firewall is irrelevant.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/cloudflare-error-1000-dns-points-to-prohibited-ip",
+		label: "Cloudflare error 1000: DNS points to prohibited IP",
+		note: "The other error that comes from the origin address in your DNS record — this one because the address is Cloudflare's own.",
+	},
+	{
+		href: "/guides/cloudflare-ssl-tls-encryption-modes",
+		label: "Which Cloudflare SSL/TLS encryption mode should you use?",
+		note: "Your encryption mode decides whether the origin needs to be listening on port 80 or port 443 — which decides what the firewall has to allow.",
+	},
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "Why a proxied record puts Cloudflare on the path at all, and what changes the moment you grey-cloud it for a test.",
+	},
+	{
+		href: DOCS_522,
+		label: "Cloudflare docs: Error 522",
+		note: "The official cause and resolution list this guide reorganises. Check it before changing anything at the origin.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function Error522Guide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="The page says connection timed out and nothing else. Here is which connection, which deadline it missed, and the order in which the possible causes are worth checking."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>Cloudflare error 522 means Cloudflare could not complete a connection to your origin
+						server in time.</strong> Either no TCP handshake finished within 19 seconds, or an open
+						connection produced no acknowledgement within 90. The usual cause is an origin firewall
+						dropping Cloudflare&rsquo;s addresses.
+					</p>
+				</div>
+
+				<p>
+					The 522 page is generated at Cloudflare&rsquo;s edge, not by your application, which is why it
+					appears with a{" "}
+					<a href={DOCS_RAY} target="_blank" rel="noopener noreferrer">
+						Ray ID
+					</a>{" "}
+					and none of your own error handling. That also narrows the problem usefully: the visitor reached
+					Cloudflare without trouble, so whatever is broken sits on the second hop — between Cloudflare and
+					your server. Nothing in your DNS provider, your CDN settings, or the visitor&rsquo;s network is
+					implicated by an HTTP error 522.
+				</p>
+
+				<h2 id="where">Where a 522 error happens</h2>
+				<Error522Path />
+				<p>
+					Cloudflare defines error 522 as timing out while contacting the origin web server, and error 521
+					as the origin <em>refusing</em> its connections. That difference is the most useful thing on this
+					page. A firewall rule that rejects a packet sends something back, and Cloudflare reports 521; a
+					rule that drops it sends nothing, so Cloudflare keeps retrying until the clock runs out and
+					reports 522. Both are usually the same misconfiguration seen through different firewall policies.
+				</p>
+
+				<h2 id="deadlines">Two deadlines, one error code</h2>
+				<p>
+					The 522 errors Cloudflare returns come from two separate timers on the origin connection, and it
+					is worth knowing which one you hit before you start changing things.
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Stage</th>
+								<th scope="col">What Cloudflare is waiting for</th>
+								<th scope="col">Limit</th>
+								<th scope="col">Error</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Opening the connection</th>
+								<td>A SYN+ACK in reply to its SYN, retried at 1, 1, 1, 1, 1, 2, 4 and 8 seconds</td>
+								<td>19 s</td>
+								<td>522</td>
+							</tr>
+							<tr>
+								<th scope="row">Connection established</th>
+								<td>An acknowledgement of the resource request it sent</td>
+								<td>90 s</td>
+								<td>522</td>
+							</tr>
+							<tr>
+								<th scope="row">Request acknowledged</th>
+								<td>The HTTP response itself — the Proxy Read Timeout</td>
+								<td>125 s</td>
+								<td>524</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Neither of the 522 limits can be changed; only the 125-second read timeout is configurable, and
+					only on Enterprise zones. The{" "}
+					<a href={DOCS_LIMITS} target="_blank" rel="noopener noreferrer">
+						connection limits reference
+					</a>{" "}
+					lists all of them together. In practice you can tell the two apart with a stopwatch: a page that
+					fails after roughly twenty seconds never connected at all, while one that hangs for a minute and a
+					half connected and then went quiet — a very different problem, usually load rather than filtering.
+				</p>
+
+				<h2 id="causes">The causes, in the order worth checking</h2>
+				<p>Cloudflare&rsquo;s own list, ordered by how often it turns out to be the answer:</p>
+				<ol>
+					<li>
+						<strong>Cloudflare IP addresses are blocked or rate limited at the origin</strong> — in{" "}
+						<code>.htaccess</code>, <code>iptables</code>, or a firewall. Cloudflare calls this the most
+						common cause. Rate limiting deserves its own mention: a rule that permits Cloudflare but
+						throttles it will produce 522s that come and go with traffic, which is far harder to spot than
+						a flat block.
+					</li>
+					<li>
+						<strong>The origin is overloaded or offline</strong> and drops incoming requests rather than
+						answering them.
+					</li>
+					<li>
+						<strong>Keepalives are disabled at the origin.</strong> Cloudflare reuses open TCP connections
+						to your server; when the origin refuses to hold them open, connections get reset under load.
+					</li>
+					<li>
+						<strong>The address in your DNS record is stale</strong> — it no longer matches the IP your
+						hosting provider has provisioned for the server. Worth checking after any migration.
+					</li>
+					<li>
+						<strong>Packets are being dropped</strong> somewhere between Cloudflare and the origin. This is
+						the residual case, and the one where a traceroute from the origin back to a Cloudflare address
+						is the evidence your host will want.
+					</li>
+				</ol>
+				<p>
+					One nuance on the first item: which port has to be open depends on your encryption mode, because
+					that is what decides whether Cloudflare connects to the origin over HTTP or HTTPS. If you are not
+					sure which one your zone uses, see{" "}
+					<Link href="/guides/cloudflare-ssl-tls-encryption-modes">
+						which Cloudflare SSL/TLS encryption mode you should use
+					</Link>
+					.
+				</p>
+
+				<h2 id="platform">The 522s that have nothing to do with your firewall</h2>
+				<p>
+					Three documented cases produce a Cloudflare 522 with a perfectly healthy origin, and every generic
+					checklist misses them:
+				</p>
+				<ul>
+					<li>
+						<strong>A Worker on a Custom Domain fetching its own hostname.</strong> Per the docs, a{" "}
+						<code>fetch</code> from a Worker on a{" "}
+						<a href={DOCS_WORKERS_DOMAIN} target="_blank" rel="noopener noreferrer">
+							Custom Domain
+						</a>{" "}
+						back to that same hostname returns 522. Use a Route, target a different hostname, or enable
+						the{" "}
+						<a href={DOCS_FLAG} target="_blank" rel="noopener noreferrer">
+							<code>global_fetch_strictly_public</code>
+						</a>{" "}
+						compatibility flag.
+					</li>
+					<li>
+						<strong>A Pages project without a custom domain.</strong> If a CNAME points at a Pages project
+						that has no{" "}
+						<a href={DOCS_PAGES_DOMAIN} target="_blank" rel="noopener noreferrer">
+							custom domain
+						</a>{" "}
+						configured for it, the request has nowhere valid to land.
+					</li>
+					<li>
+						<strong>An Origin Rule pointing at a hostname that will not resolve.</strong>{" "}
+						<a href={DOCS_ORIGIN_RULES} target="_blank" rel="noopener noreferrer">
+							Origin Rules
+						</a>{" "}
+						override where a request is sent, so a rule aimed at a Worker route whose hostname is an A
+						record on a reserved address such as <code>192.0.2.0</code> produces 522 no matter what your
+						real origin is doing.
+					</li>
+				</ul>
+
+				<h2 id="diagnose">Narrowing it down</h2>
+				<ol>
+					<li>
+						<strong>Capture the details first.</strong> The error code, the exact URL, and the time with
+						timezone are the three things Cloudflare tells you to hand your hosting provider; the Ray ID
+						from the page makes the request findable in logs.
+					</li>
+					<li>
+						<strong>Check whether it is everything or some paths.</strong> In the dashboard, open{" "}
+						<strong>HTTP Traffic</strong> and add a filter on <em>Edge status code</em> for 522. Error
+						analytics run on a 1% traffic sample, so treat the shape as the signal, not the counts.
+					</li>
+					<li>
+						<strong>Allow the ranges rather than checking them.</strong> Cloudflare connects from{" "}
+						<a href={CF_IPS} target="_blank" rel="noopener noreferrer">
+							its published IP ranges
+						</a>
+						, and those change over time. An allowlist that was complete two years ago may not be now.
+					</li>
+					<li>
+						<strong>Request the origin directly.</strong> From a shell, connect to the origin address with
+						the correct <code>Host</code> header. If it answers for you but not for Cloudflare, you are
+						looking at a filter, not an outage — and the fact that it answers <em>you</em> is why an
+						overloaded origin is so often misdiagnosed.
+					</li>
+					<li>
+						<strong>Grey-cloud the record briefly.</strong> Setting it to{" "}
+						<a href={DOCS_DNS_ONLY} target="_blank" rel="noopener noreferrer">
+							DNS only
+						</a>{" "}
+						takes Cloudflare off the path: if the site is still unreachable, the origin is the problem.
+						The record exposes your server&rsquo;s real address while it is grey, so change it back.
+					</li>
+					<li>
+						<strong>Look at TCP failures per endpoint.</strong>{" "}
+						<a href={DOCS_ORIGIN_ANALYTICS} target="_blank" rel="noopener noreferrer">
+							Origin Analytics
+						</a>{" "}
+						reports connection failure rates by path, which separates a struggling endpoint from an origin
+						that is unreachable outright.
+					</li>
+				</ol>
+
+				<h2 id="neighbours">522 next to its neighbours</h2>
+				<p>
+					The 5xx family Cloudflare generates all describes the same hop, and the codes are easy to mix up:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Error</th>
+								<th scope="col">What the origin did</th>
+								<th scope="col">First move</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_520} target="_blank" rel="noopener noreferrer">
+										520
+									</a>
+								</th>
+								<td>Answered, but with an empty, malformed or unexpected response</td>
+								<td>Read the origin error log for crashes; check HTTP/2 support at the origin</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_521} target="_blank" rel="noopener noreferrer">
+										521
+									</a>
+								</th>
+								<td>Refused the connection outright</td>
+								<td>Confirm the service is running and listening on the port your SSL mode requires</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_522} target="_blank" rel="noopener noreferrer">
+										522
+									</a>
+								</th>
+								<td>Said nothing at all, until the clock ran out</td>
+								<td>Allow Cloudflare&rsquo;s IP ranges; check origin load</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_523} target="_blank" rel="noopener noreferrer">
+										523
+									</a>
+								</th>
+								<td>Could not be reached — no route to the address at all</td>
+								<td>Verify the A record, and route tables between the network and Cloudflare</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_524} target="_blank" rel="noopener noreferrer">
+										524
+									</a>
+								</th>
+								<td>Accepted the request, then took too long to answer it</td>
+								<td>Profile the slow request; move long jobs off the proxied hostname</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					A rough rule: 520 is a bad answer, 521 is a refusal, 522 is silence, 523 is no route, and 524 is
+					slowness. If you administer more than one zone, the{" "}
+					<a href={DOCS_5XX} target="_blank" rel="noopener noreferrer">
+						5xx index
+					</a>{" "}
+					is worth a bookmark. And if the error you are actually seeing is a four-digit one, the cause is
+					elsewhere entirely — see{" "}
+					<Link href="/guides/cloudflare-error-1000-dns-points-to-prohibited-ip">
+						error 1000, DNS points to prohibited IP
+					</Link>
+					.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/components/guides/Error522Path.tsx
+++ b/apps/web/src/components/guides/Error522Path.tsx
@@ -1,0 +1,98 @@
+/**
+ * Error 522 的位置图：请求到了 Cloudflare 边缘，边缘向源站发起 TCP 连接，
+ * 但源站那一侧静默（丢包 / 防火墙 drop），19 秒内等不到 SYN+ACK —— 于是返回 522。
+ * 与 521 的分界画在同一张图上：被拒绝（RST）是 521，被丢弃（静默）才是 522。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function Error522Path() {
+	const col = { x: 30, width: 260, rx: 14 };
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 400 404"
+				role="img"
+				aria-label="Where Cloudflare error 522 happens: a visitor reaches the Cloudflare edge, the edge opens a TCP connection to the origin server, but nothing comes back because the packets are silently dropped. After 19 seconds of retried SYN packets with no SYN and ACK reply, Cloudflare gives up and returns error 522, connection timed out. If the origin had actively refused the connection instead of dropping it, the result would be error 521 rather than 522."
+				className="mx-auto block h-auto w-full max-w-[440px]"
+			>
+				<title>Where a Cloudflare 522 error happens on the path to your origin</title>
+
+				{/* 1 · 访客 → 边缘：这一段是通的 */}
+				<rect {...col} y="12" height="52" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="160" y="36" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Visitor
+				</text>
+				<text x="160" y="53" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					reaches Cloudflare normally
+				</text>
+
+				<defs>
+					<marker id="e522-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+				</defs>
+
+				<path
+					d="M160 68 L160 96"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e522-arrow)"
+				/>
+
+				{/* 2 · Cloudflare 边缘：向源站发 SYN */}
+				<rect {...col} y="102" height="56" fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="160" y="127" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare edge
+				</text>
+				<text x="160" y="144" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					opens a TCP connection to the origin
+				</text>
+
+				{/* 3 · 静默的一段：SYN 重试，没有任何回应 */}
+				<path
+					d="M160 162 L160 232"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					strokeDasharray="4 6"
+					fill="none"
+					markerEnd="url(#e522-arrow)"
+				/>
+				<text x="172" y="187" fontSize="11" fill="var(--t-tertiary)">
+					SYN, retried for 19 s
+				</text>
+				<text x="172" y="204" fontSize="11" fill="var(--t-tertiary)">
+					nothing comes back
+				</text>
+
+				{/* 4 · 源站侧：包被静默丢弃 */}
+				<rect {...col} y="238" height="56" fill="none" stroke="var(--divider)" strokeDasharray="5 4" />
+				<text x="160" y="263" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-secondary)">
+					Origin server
+				</text>
+				<text x="160" y="280" textAnchor="middle" fontSize="12" fill="var(--t-tertiary)">
+					silent: packets dropped, not refused
+				</text>
+
+				{/* 5 · 结果 */}
+				<path
+					d="M160 300 L160 326"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e522-arrow)"
+				/>
+				<rect {...col} y="332" height="56" fill="none" stroke="var(--oc-orange)" strokeOpacity="0.7" strokeDasharray="5 4" />
+				<text x="160" y="357" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Error 522
+				</text>
+				<text x="160" y="374" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					connection timed out
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				A 522 is silence, not rejection. Had the origin answered with a refusal, the visitor would see 521 instead.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -123,6 +123,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-26",
 		readingTime: "8 min read",
 	},
+	{
+		slug: "cloudflare-error-522-connection-timed-out",
+		h1: "Why Am I Getting Cloudflare Error 522: Connection Timed Out?",
+		title: "Cloudflare Error 522: Connection Timed Out, Explained",
+		description:
+			"Error 522 means Cloudflare could not open a TCP connection to your origin within 19 seconds. The usual cause is a firewall dropping Cloudflare's IPs.",
+		blurb:
+			"Two deadlines produce the same error code, and a 522 is silence rather than refusal \u2014 which is what separates it from 521, 523 and 524.",
+		updated: "2026-08-27",
+		readingTime: "8 min read",
+	},
 ];
 
 export const GUIDES_ZH: GuideMeta[] = [


### PR DESCRIPTION
## 选题依据（GSC 数据）

`gsc.py gaps --days 28` 这一轮没给出可用的新选题线索——所有 `[可做]` 词（`cloud orange`、`cloudflare orange`、`icloud orange`…）都只是品牌词的拼写变体，全部由 `/` 承接，属于导航意图，按规则不抢。因此回退到备选题库首位。

`gsc.py guides --days 28` 显示的判断依据：

- `/zh-Hans/guides/cloudflare-522-error` 是**站内表现最好的中文文章**（2 次点击 / 19 次展示 / 均位 11.5），而英文侧 522 位一直空着；
- 522 是搜索量最大的 Cloudflare 错误码之一，且与站内表现最好的英文文章 `/guides/cloudflare-orange-to-orange`（281 次展示 / 均位 6.6）同属"窄而具体的技术概念"这一已验证成功模式；
- 主查询词不含品牌词，不与首页竞争。

`gsc.py owners --days 28` 未发现需要优先修复的情况：无 7 天以上的非收录页（两个"Google 无法识别此网址"都是 8-26 上线、不足 24 小时），无目标词被本站他页抢走，无上线超 14 天且零展示的文章。故本轮按新增执行。

## 核对官方文档时修正 / 放弃了哪些论断

逐条对着 `index.md` 原文核过，以下几处与常见写法不同：

| 论断 | 核对结果 | 依据 |
|---|---|---|
| "522 = 19 秒超时" | **不完整，已改写**。522 有**两个**触发时机：建连阶段 19 秒收不到 SYN+ACK，以及连接建立后 90 秒收不到请求的 ACK。文中做成三行对照表并说明如何用秒表区分。 | [error-522](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/) |
| SYN 重试间隔 | 补上官方给出的精确退避序列 1, 1, 1, 1, 1, 2, 4, 8 秒 | 同上 |
| "125 秒超时也是 522" | **错误，已排除**。125 秒 Proxy Read Timeout 返回的是 524，且仅企业版可调；19 / 90 秒两道均不可调 | [connection-limits](https://developers.cloudflare.com/fundamentals/reference/connection-limits/) |
| "521 和 522 是一回事" | **已改成可判定的判据**：官方定义 521 为源站*拒绝*连接、522 为 Cloudflare *超时*，故 REJECT 出 521、DROP 出 522。这是推导而非文档原文，正文把推导过程写出来了，没有当成官方表述。 | [error-521](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521/) + error-522 |
| 522 错误页的"Host Error"三栏布局 | **已放弃**。当前官方文档不描述错误页版式，且 Custom Errors 可以改版式，无法核实，故只写"边缘生成、带 Ray ID"。 | [5xx 索引](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/) |
| Error Analytics 计数 | 补上官方明说的**1% 采样**，避免读者按绝对数量做判断 | 同上 |
| 平台侧 522 | 新增一节，三条都来自官方文档而非经验：Custom Domain 上的 Worker `fetch` 自身域名、Pages 未配自定义域、Origin Rules 指向无法解析的主机名（例：Worker route 的主机名是指向 `192.0.2.0` 这类保留地址的 A 记录） | error-522 |

外链共 15 条，全部 curl 实测 200。

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（仅既有的 proxy env 告警） |
| 2 | `npx vitest run` | ✅ 21 文件 / 166 测试全绿 |
| 3 | `npx eslint`（4 个新增/改动文件） | ✅ 0 error |
| 4 | 新 URL 返回 200 | ⚠️ **本环境无法直接跑**：`preview_start` 在无人值守会话被禁用，任务又禁止用 Bash 起 server。替代证据：该路由为 SSG，`next build` 已成功预渲染出 `/en/guides/cloudflare-error-522-connection-timed-out.html`（渲染失败会中断构建）。**合并后已 curl 线上 URL 实测**，见下方"上线后复验" |
| 5 | canonical 自引用 + hreflang 仅 en/x-default | ✅ 脚本断言通过 |
| 6 | JSON-LD 可 `json.loads`，FAQPage 每条问答逐字出现在可见正文 | ✅ 脚本断言通过（TechArticle + FAQPage + BreadcrumbList 齐备，5 条问答逐字命中） |
| 7 | 标题层级无跳级 | ✅ `[1,2,2,2,2,2,2,2,3,3,3,3,3,2,2]`，无跳级，h1 唯一 |
| 8 | 375px 无横向溢出 | ⚠️ **同 #4 无法在合并前直接跑**。对照证据：线上同结构文章 `/guides/cloudflare-error-1000-…` 实测 `scrollWidth == clientWidth == 375`，两个 `.table-wrap` 内部横滚（327 / 480）；本文用完全相同的原语（表格全在 `.table-wrap`，SVG 为 `w-full max-w-[440px]`），未引入新的布局元素。**合并后已在线上实测**，见下方 |
| 9 | 外链全部 2xx/3xx | ✅ 15/15 返回 200 |
| 10 | 词数 1000–1800 | ✅ 1475 词（正文，不含 SVG 文字） |

`<title>` 53 字符，meta description 149 字符且首句即答案。

## 变体覆盖

`cloudflare error 522` / `522 error` / `error 522` / `error code 522` / `522 connection timed out` / `connection timed out` / `cloudflare 522` / `http error 522` / `522 errors Cloudflare`（词序倒装）——脚本逐条断言均在渲染后正文中自然出现。

## 内链

与 `/guides/cloudflare-error-1000-dns-points-to-prohibited-ip` 双向内链；另单向指向 SSL/TLS 加密模式（决定源站该开 80 还是 443）与 orange cloud 那篇（灰云测试）。
