### PR TITLE
feat(web): /guides 新增英文指南「Cloudflare 下怎么拿到访客真实 IP」

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
@@ -68,6 +68,11 @@ const RELATED: RelatedLink[] = [
 		note: "Why a proxied record puts Cloudflare on the path at all, and what changes the moment you grey-cloud it for a test.",
 	},
 	{
+		href: "/guides/cloudflare-real-visitor-ip-cf-connecting-ip",
+		label: "How do you get the real visitor IP behind Cloudflare?",
+		note: "The same published IP ranges, used at the origin for the other half of the job — deciding which requests may claim a visitor address.",
+	},
+	{
 		href: DOCS_522,
 		label: "Cloudflare docs: Error 522",
 		note: "The official cause and resolution list this guide reorganises. Check it before changing anything at the origin.",

--- a/apps/web/src/app/[locale]/guides/cloudflare-real-visitor-ip-cf-connecting-ip/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-real-visitor-ip-cf-connecting-ip/page.tsx
@@ -1,0 +1,401 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import VisitorIpTrust from "@/components/guides/VisitorIpTrust";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-real-visitor-ip-cf-connecting-ip");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_HEADERS = "https://developers.cloudflare.com/fundamentals/reference/http-headers/";
+const DOCS_CF_CONNECTING_IP = `${DOCS_HEADERS}#cf-connecting-ip`;
+const DOCS_TRUE_CLIENT_IP = `${DOCS_HEADERS}#true-client-ip-enterprise-plan-only`;
+const DOCS_XFF = `${DOCS_HEADERS}#x-forwarded-for`;
+const DOCS_RESTORE =
+	"https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/";
+const DOCS_IP_ADDRESSES = "https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/";
+const DOCS_MANAGED_TRANSFORMS = "https://developers.cloudflare.com/rules/transform/managed-transforms/reference/";
+const DOCS_PSEUDO_IPV4 = "https://developers.cloudflare.com/network/pseudo-ipv4/";
+const DOCS_PROXY_STATUS = "https://developers.cloudflare.com/dns/proxy-status/";
+const CF_IPS = "https://www.cloudflare.com/ips/";
+const NGINX_REALIP = "https://nginx.org/en/docs/http/ngx_http_realip_module.html";
+const APACHE_REMOTEIP = "https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "How do I get the real visitor IP behind Cloudflare?",
+		a: "Read the CF-Connecting-IP request header instead of the address of the connection itself. Every proxied request Cloudflare forwards to your origin carries it, and it always holds exactly one address.",
+	},
+	{
+		q: "What is the CF-Connecting-IP header?",
+		a: "It is the header Cloudflare adds to a proxied request to give the origin the client IP address that connected to Cloudflare. Cloudflare only sends it on traffic from its own edge to your origin, so it never appears on a request that reached your server some other way.",
+	},
+	{
+		q: "Should I use CF-Connecting-IP or X-Forwarded-For?",
+		a: "Cloudflare recommends CF-Connecting-IP or True-Client-IP over X-Forwarded-For, because both contain a single address in a consistent format. X-Forwarded-For is a list that grows by one entry for every proxy in front of Cloudflare, so parsing it correctly is harder than it looks.",
+	},
+	{
+		q: "Can the CF-Connecting-IP header be spoofed?",
+		a: "Not through Cloudflare, but a request that reaches your origin directly can carry any header its sender likes. That is why real-IP modules take a trusted proxy list, and why Cloudflare recommends blocking traffic at the origin that does not come from its published IP ranges.",
+	},
+	{
+		q: "Why is CF-Connecting-IP missing from my requests?",
+		a: "The three documented reasons are that the record is not proxied, that the Remove visitor IP headers Managed Transform is enabled on the zone, or that Pseudo IPv4 is set to Overwrite Headers, which replaces the value with a Class E address and moves the real one into CF-Connecting-IPv6.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "The proxy status on the record is what puts Cloudflare between the visitor and your server in the first place — and what makes this header appear.",
+	},
+	{
+		href: "/guides/cloudflare-error-1000-dns-points-to-prohibited-ip",
+		label: "Cloudflare error 1000: DNS points to prohibited IP",
+		note: "The other place origin addresses and request headers collide, this time by sending Cloudflare back to itself.",
+	},
+	{
+		href: "/guides/cloudflare-error-522-connection-timed-out",
+		label: "Cloudflare error 522: connection timed out",
+		note: "The same list of Cloudflare IP ranges, used for the opposite purpose: letting the proxy reach your origin at all.",
+	},
+	{
+		href: DOCS_RESTORE,
+		label: "Cloudflare docs: Restoring original visitor IPs",
+		note: "The per-server instructions this guide summarises, including Lighttpd, LiteSpeed, IIS and Tomcat.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+export default async function VisitorIpGuide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="Every entry in the access log is a Cloudflare address, the rate limiter is throttling continents at a time, and the ban list has stopped meaning anything. Here is where the visitor went, and how to get them back."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>
+							The visitor&rsquo;s address is in the <code>CF-Connecting-IP</code> request header.
+						</strong>{" "}
+						Configure your web server to read that instead of the connection&rsquo;s source address — and to
+						believe it only on connections from Cloudflare&rsquo;s published IP ranges.
+					</p>
+				</div>
+
+				<p>
+					Nothing is broken. Once a DNS record is{" "}
+					<a href={DOCS_PROXY_STATUS} target="_blank" rel="noopener noreferrer">
+						proxied
+					</a>
+					, Cloudflare is a reverse proxy in front of your server, so Cloudflare is the client as far as your
+					origin is concerned. The TCP connection genuinely originates at a Cloudflare data centre, and{" "}
+					<code>REMOTE_ADDR</code> — along with everything that derives from it — genuinely describes that
+					connection. The visitor has not disappeared; they have moved from the connection into a header.
+				</p>
+
+				<VisitorIpTrust />
+
+				<h2 id="headers">The headers that carry the address</h2>
+				<p>
+					Cloudflare adds several, and they are not interchangeable. The differences matter mostly when you get
+					to parsing:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Header</th>
+								<th scope="col">Contains</th>
+								<th scope="col">Availability</th>
+								<th scope="col">Watch out for</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_CF_CONNECTING_IP} target="_blank" rel="noopener noreferrer">
+										<code>CF-Connecting-IP</code>
+									</a>
+								</th>
+								<td>Exactly one address: the client that connected to Cloudflare</td>
+								<td>All plans, added automatically</td>
+								<td>Only ever sent from Cloudflare&rsquo;s edge to your origin</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<code>CF-Connecting-IPv6</code>
+								</th>
+								<td>The original IPv6 address</td>
+								<td>With Pseudo IPv4 in <em>Overwrite Headers</em> mode</td>
+								<td>Only relevant if you use Pseudo IPv4 at all</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_TRUE_CLIENT_IP} target="_blank" rel="noopener noreferrer">
+										<code>True-Client-IP</code>
+									</a>
+								</th>
+								<td>The same single address, under a different name</td>
+								<td>Enterprise, and only once the Managed Transform is enabled</td>
+								<td>Not added by default; a stacked CDN can forge it</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_XFF} target="_blank" rel="noopener noreferrer">
+										<code>X-Forwarded-For</code>
+									</a>
+								</th>
+								<td>A comma-separated chain, visitor first</td>
+								<td>All plans</td>
+								<td>Grows by one entry per proxy ahead of Cloudflare</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Cloudflare documents <code>True-Client-IP</code> as differing from <code>CF-Connecting-IP</code> in
+					name alone. It exists for Enterprise customers whose load balancers or firewalls already read that
+					header name and cannot be reconfigured.
+				</p>
+
+				<h2 id="xff">Why X-Forwarded-For is the tempting wrong answer</h2>
+				<p>
+					If nothing sits in front of Cloudflare, <code>X-Forwarded-For</code> has the same value as{" "}
+					<code>CF-Connecting-IP</code>, which is exactly why so many setups appear to work and then quietly
+					stop. The moment a request passes through another proxy first, Cloudflare appends rather than
+					replaces. Cloudflare&rsquo;s own worked example: a visitor at <code>203.0.113.1</code> going through
+					proxy A (<code>198.51.100.101</code>) and proxy B (<code>198.51.100.102</code>) arrives at your
+					origin as
+				</p>
+				<pre>
+					<code>x-forwarded-for: 203.0.113.1,198.51.100.101,198.51.100.102</code>
+				</pre>
+				<p>
+					Read the last entry and you ban proxy B. Read the first and you trust whatever the earliest hop
+					claimed. Cloudflare&rsquo;s recommendation is unambiguous — use <code>CF-Connecting-IP</code> or{" "}
+					<code>True-Client-IP</code> for logging and applications, because both hold a single address in a
+					consistent format. Treat XFF as a diagnostic, not as an identity.
+				</p>
+
+				<h2 id="configure">Configuring your web server</h2>
+				<p>
+					The pattern for restoring the real IP is the same everywhere: name the header, then name the
+					addresses you will accept it from. Both halves are required.
+				</p>
+
+				<h3 id="nginx">Nginx</h3>
+				<p>
+					Use the built-in{" "}
+					<a href={NGINX_REALIP} target="_blank" rel="noopener noreferrer">
+						<code>ngx_http_realip_module</code>
+					</a>
+					. One <code>set_real_ip_from</code> line per Cloudflare range, then the header:
+				</p>
+				<pre>
+					<code>{`set_real_ip_from 198.51.100.0/24;   # repeat for every published range
+real_ip_header CF-Connecting-IP;`}</code>
+				</pre>
+				<p>
+					To keep the address in the access log, Cloudflare notes that you add{" "}
+					<code>$http_cf_connecting_ip</code> — and, if you want it, <code>$http_x_forwarded_for</code> — to
+					your <code>log_format</code> directive. It is the same header throughout, spelled three ways
+					depending on where you are looking: <code>CF-Connecting-IP</code> in Cloudflare&rsquo;s reference,{" "}
+					<code>cf-connecting-ip</code> on the wire, and <code>$http_cf_connecting_ip</code> once Nginx has
+					turned it into a variable.
+				</p>
+
+				<h3 id="apache">Apache</h3>
+				<p>
+					Cloudflare stopped updating and supporting <code>mod_cloudflare</code> as of Debian 9 and Ubuntu
+					18.04 LTS, and now points to Apache&rsquo;s own{" "}
+					<a href={APACHE_REMOTEIP} target="_blank" rel="noopener noreferrer">
+						<code>mod_remoteip</code>
+					</a>
+					. Enable it with <code>a2enmod remoteip</code>, then:
+				</p>
+				<pre>
+					<code>{`RemoteIPHeader CF-Connecting-IP
+RemoteIPTrustedProxy 198.51.100.0/24   # repeat for every published range`}</code>
+				</pre>
+				<p>
+					The step people miss is the log format itself. <code>%h</code> logs the connection&rsquo;s address
+					and will keep printing Cloudflare&rsquo;s; swap it for <code>%a</code> in your{" "}
+					<code>combined</code> <code>LogFormat</code> line so the restored address is what lands in the file.
+				</p>
+				<p>
+					Cloudflare&rsquo;s{" "}
+					<a href={DOCS_RESTORE} target="_blank" rel="noopener noreferrer">
+						restoring original visitor IPs
+					</a>{" "}
+					page carries the equivalent recipes for Lighttpd, LiteSpeed, IIS and Tomcat, plus a one-line PHP
+					fallback that reassigns <code>REMOTE_ADDR</code> for scripts without touching the server logs.
+				</p>
+
+				<h2 id="trust">The trust boundary, which is the whole point</h2>
+				<p>
+					A header is a string that someone put in a request. Through Cloudflare it is reliable; sent straight
+					to your server it is whatever the sender typed. If your origin address is discoverable — and{" "}
+					<a href={DOCS_IP_ADDRESSES} target="_blank" rel="noopener noreferrer">
+						Cloudflare notes it often is
+					</a>
+					, through historical DNS records or mail configuration — then an application that reads{" "}
+					<code>CF-Connecting-IP</code> unconditionally has handed its rate limiter, its ban list and its
+					geolocation to anyone willing to set one header.
+				</p>
+				<p>Two measures, and the second is the one that actually holds:</p>
+				<ol>
+					<li>
+						<strong>Give the module a trusted proxy list.</strong> That is what{" "}
+						<code>set_real_ip_from</code> and <code>RemoteIPTrustedProxy</code> are for. Cloudflare publishes
+						the ranges at{" "}
+						<a href={CF_IPS} target="_blank" rel="noopener noreferrer">
+							cloudflare.com/ips
+						</a>{" "}
+						and says plainly that the list needs updating regularly — a config written three years ago is
+						probably incomplete now, so pull it from the published source on a schedule rather than pasting
+						it once.
+					</li>
+					<li>
+						<strong>Refuse the connections in the first place.</strong> Cloudflare recommends blocking all
+						traffic to ports 80 and 443 that does not come from its ranges or from partners you trust. Then a
+						forged header never reaches the parser, and the same allowlist doubles as the fix for the
+						firewall-shaped causes of{" "}
+						<Link href="/guides/cloudflare-error-522-connection-timed-out">error 522</Link>.
+					</li>
+				</ol>
+
+				<h2 id="missing">When the header is not there at all</h2>
+				<p>Four documented reasons, in the order worth checking:</p>
+				<ul>
+					<li>
+						<strong>The record is grey-clouded.</strong> Cloudflare only sends the header on traffic from its
+						edge to your origin. On a DNS-only record there is no edge on the path, and the connection
+						address is already the visitor. See{" "}
+						<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
+							what the orange cloud means in Cloudflare
+						</Link>{" "}
+						if you are not sure which records are proxied.
+					</li>
+					<li>
+						<strong>A Managed Transform is stripping it.</strong>{" "}
+						<a href={DOCS_MANAGED_TRANSFORMS} target="_blank" rel="noopener noreferrer">
+							Remove visitor IP headers
+						</a>{" "}
+						removes <code>cf-connecting-ip</code>, <code>true-client-ip</code> and the visitor entry from{" "}
+						<code>x-forwarded-for</code> together. It is a privacy feature, and it is mutually exclusive with
+						the Enterprise transform that adds <code>True-Client-IP</code>.
+					</li>
+					<li>
+						<strong>
+							<a href={DOCS_PSEUDO_IPV4} target="_blank" rel="noopener noreferrer">
+								Pseudo IPv4
+							</a>{" "}
+							is set to Overwrite Headers.
+						</strong>{" "}
+						The header is present but holds a Class E address such as <code>240.16.0.1</code>, hashed from the
+						visitor&rsquo;s IPv6 address. The real one is in <code>CF-Connecting-IPv6</code>.
+					</li>
+					<li>
+						<strong>A Worker is in the path.</strong> In same-zone subrequests the value reflects{" "}
+						<code>x-real-ip</code>, which a Worker script can alter; in cross-zone subrequests Cloudflare
+						deliberately sets it to <code>2a06:98c0:3600::103</code> instead of the client address. If your
+						traffic passes through a Worker, verify the value rather than assuming it.
+					</li>
+				</ul>
+				<p>
+					One last trap worth knowing about, because it produces a header that vanishes for no visible reason:
+					Cloudflare may drop request headers whose <em>names</em> it considers invalid by Nginx&rsquo;s rules
+					— a custom header with a dot in the name, for instance. If you are forwarding a visitor address under
+					a name of your own devising, that is a good place to look before you suspect the proxy.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -60,6 +60,11 @@ const RELATED: RelatedLink[] = [
 		note: "What happens when a proxied record hands the proxy an address that is Cloudflare’s own.",
 	},
 	{
+		href: "/guides/cloudflare-real-visitor-ip-cf-connecting-ip",
+		label: "How do you get the real visitor IP behind Cloudflare?",
+		note: "The first thing proxying changes at the origin: every connection now comes from Cloudflare, and the visitor moves into a header.",
+	},
+	{
 		href: "https://developers.cloudflare.com/dns/proxy-status/",
 		label: "Cloudflare docs: Proxy status",
 		note: "The official reference for proxied and DNS-only records, including limitations and use cases.",

--- a/apps/web/src/components/guides/VisitorIpTrust.tsx
+++ b/apps/web/src/components/guides/VisitorIpTrust.tsx
@@ -1,0 +1,101 @@
+/**
+ * 「访客真实 IP 在哪、什么时候可信」——英文版指南用图。
+ * 上半部分：一次代理请求到达源站时，TCP 对端是 Cloudflare 节点，访客地址在请求头里；
+ * 下半部分：这些头唯一的可信条件是连接本身来自 Cloudflare 已发布的 IP 段。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏靠整体缩放不溢出。
+ */
+export default function VisitorIpTrust() {
+	const mono = "ui-monospace, SFMono-Regular, Menlo, monospace";
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 380 400"
+				role="img"
+				aria-label="When a proxied request reaches your origin server, the TCP peer address belongs to Cloudflare, while the visitor's own address travels in the CF-Connecting-IP request header. Your web server then has to decide whether to believe that header: if the connection came from one of Cloudflare's published IP ranges, the header is the visitor and can be logged; if the connection came from anywhere else, the header was set by whoever opened the connection and must be discarded."
+				className="mx-auto block h-auto w-full max-w-[440px]"
+			>
+				<title>Where the visitor IP travels, and the one condition that makes it trustworthy</title>
+
+				<defs>
+					<marker id="vip-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+					<marker id="vip-arrow-quiet" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--t-tertiary)" />
+					</marker>
+				</defs>
+
+				{/* 1 · 源站实际收到的东西 */}
+				<rect x="24" y="12" width="332" height="98" rx="14" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="44" y="36" fontSize="11" letterSpacing="0.7" fill="var(--t-tertiary)">
+					ONE PROXIED REQUEST, AT YOUR ORIGIN
+				</text>
+				<text x="44" y="61" fontSize="13" fontFamily={mono} fill="var(--t-secondary)">
+					172.71.0.1
+				</text>
+				<text x="140" y="61" fontSize="12" fill="var(--t-tertiary)">
+					TCP peer — a Cloudflare address
+				</text>
+				<text x="44" y="88" fontSize="13" fontFamily={mono} fill="var(--t-primary)">
+					203.0.113.7
+				</text>
+				<text x="140" y="88" fontSize="12" fill="var(--t-secondary)">
+					cf-connecting-ip — the visitor
+				</text>
+
+				<path d="M190 110 L190 132" stroke="var(--oc-orange)" strokeWidth="1.6" fill="none" markerEnd="url(#vip-arrow)" />
+
+				{/* 2 · 唯一的判断 */}
+				<rect
+					x="24"
+					y="138"
+					width="332"
+					height="58"
+					rx="14"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.6"
+					strokeDasharray="5 4"
+				/>
+				<text x="190" y="163" textAnchor="middle" fontSize="13.5" fontWeight="600" fill="var(--t-primary)">
+					Did this connection arrive from
+				</text>
+				<text x="190" y="182" textAnchor="middle" fontSize="13.5" fontWeight="600" fill="var(--t-primary)">
+					a published Cloudflare IP range?
+				</text>
+
+				{/* 3 · 分叉：从判断框底部下探，转向左侧脊线 */}
+				<path d="M190 196 L190 210 L44 210 L44 336" stroke="var(--divider)" strokeWidth="1.4" fill="none" />
+
+				<path d="M44 246 L74 246" stroke="var(--oc-orange)" strokeWidth="1.6" fill="none" markerEnd="url(#vip-arrow)" />
+				<rect x="82" y="222" width="274" height="62" rx="12" fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.5" />
+				<text x="98" y="245" fontSize="12" fontWeight="600" fill="var(--oc-orange)">
+					Yes
+				</text>
+				<text x="98" y="265" fontSize="12.5" fill="var(--t-secondary)">
+					The header is the visitor. Log it,
+				</text>
+				<text x="98" y="280" fontSize="12.5" fill="var(--t-secondary)">
+					rate limit on it, geolocate it.
+				</text>
+
+				<path d="M44 336 L74 336" stroke="var(--divider)" strokeWidth="1.6" fill="none" markerEnd="url(#vip-arrow-quiet)" />
+				<rect x="82" y="312" width="274" height="62" rx="12" fill="none" stroke="var(--divider)" strokeDasharray="5 4" />
+				<text x="98" y="335" fontSize="12" fontWeight="600" fill="var(--t-tertiary)">
+					No
+				</text>
+				<text x="98" y="355" fontSize="12.5" fill="var(--t-tertiary)">
+					Whoever opened the connection
+				</text>
+				<text x="98" y="370" fontSize="12.5" fill="var(--t-tertiary)">
+					chose that value. Discard it.
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				A request header is only as trustworthy as the connection that carried it, which is why every real-IP
+				module asks you for a list of trusted proxies.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -134,6 +134,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-27",
 		readingTime: "8 min read",
 	},
+	{
+		slug: "cloudflare-real-visitor-ip-cf-connecting-ip",
+		h1: "How Do You Get the Real Visitor IP Behind Cloudflare?",
+		title: "Cloudflare Real Visitor IP: CF-Connecting-IP Explained",
+		description:
+			"The visitor's real address arrives in the CF-Connecting-IP header. Read that instead of the connection source, and trust it only from Cloudflare's IPs.",
+		blurb:
+			"Your logs fill up with Cloudflare addresses because Cloudflare is the client now. Which header carries the real one, why X-Forwarded-For is the wrong one to read, and the trust boundary every guide leaves out.",
+		updated: "2026-08-28",
+		readingTime: "8 min read",
+	},
 ];
 
 export const GUIDES_ZH: GuideMeta[] = [


### PR DESCRIPTION
## 选题依据（本轮 GSC 数据）

**先看数据，结论是本轮不需要修复、可以写新文章：**

- `gsc.py guides --days 28`：9 篇英文指南全部「已提交，且已编入索引」，唯二未收录的是 08-26 / 08-27 刚上线的 error-1000 与 error-522，状态是「Google 无法识别此网址」——按约定这一状态不算技术故障，且不足 7 天。
- `owners`：多页竞争全部落在裸品牌词（`orange cloud` 等由 `/` 承接，属预期），O2O 词簇的赢家就是 O2O 那篇本身。`/privacy`、`/contact` 在 30–60 位捡到的零星展示是噪声，不构成抢词。
- 已知待修的 `what-is-the-orange-cloud-in-cloudflare` 已于 08-24 完成意图切换（title/H1/meta 改打 `proxied vs dns only` / `orange vs grey cloud`），修复后仅积累两天数据，本轮不重复动。
- `why-is-cloudflare-not-caching-my-site` 零展示但上线仅 8 天（<14 天阈值），下轮起需要盯。

**`gaps` 本轮没有给出可用线索**——19 条里标 `[可做]` 的 5 条（`cloud orange` / `cloudflare orange` / `icloud orange` / `one cloud orange` / `ornycloud`）全是品牌名的错拼与倒装，导航意图、且已由首页承接，按规则不抢。因此回到备选题库取序号 3：**在源站拿到访客真实 IP（CF-Connecting-IP）**。

过六条门槛：真实问句（"why does my log show Cloudflare IPs"）；对应 App 覆盖的代理状态能力；官方文档可逐条核实；与已有 9 篇不重复；主词不含品牌词、不与首页抢；变体可枚举且已各自落点——`cf-connecting-ip`（连字符）、`$http_cf_connecting_ip`（下划线）、`XFF`（缩写）、`True-Client-IP`、`real visitor IP` / `visitor IP` / `real IP`（词序倒装）、`mod_remoteip` / `RemoteIPHeader`。

## 核对官方文档时修正 / 放弃了哪些论断

- **放弃「Cloudflare 会覆盖客户端伪造的 CF-Connecting-IP」**。这是流传最广的说法，但当前文档里找不到这句话——[HTTP headers](https://developers.cloudflare.com/fundamentals/reference/http-headers/) 只说 Cloudflare「添加」该头，明确提到覆写的只有 `Accept-Encoding`、`X-Forwarded-Proto`、`Connection` 以及 Pseudo IPv4 那条。故全文改为可被文档支撑的表述：**头的可信度等于承载它的那条连接**，依据是各真实 IP 模块都要求可信代理列表，以及 [Cloudflare IP addresses](https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/) 里「阻断非 Cloudflare 来源流量」的建议。
- **修正 Apache 的推荐模块**。`mod_cloudflare` 自 Debian 9 / Ubuntu 18.04 LTS 起已停止更新与支持，文档现在指向 [`mod_remoteip`](https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html)。文中只写 `mod_remoteip`，并补上最常被漏掉的 `LogFormat` 里 `%h` → `%a` 这一步。
- **修正文档路径**。`/support/troubleshooting/restoring-original-visitor-ips/` 已 404，现址为 [`/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/`](https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/)。所有外链（含三个锚点 `#cf-connecting-ip`、`#true-client-ip-enterprise-plan-only`、`#x-forwarded-for`）均已实测。
- **True-Client-IP 补上两个限定**：Enterprise 专属，且**默认不添加**，要启用托管转换；文档同时警告 stacked CDN 场景下它可被伪造。
- **Remove visitor IP headers 的处理范围**按 [Managed Transforms reference](https://developers.cloudflare.com/rules/transform/managed-transforms/reference/) 逐条列出（`cf-connecting-ip` / `x-forwarded-for` / `true-client-ip`），并写明与 Enterprise 那条互斥。
- **Worker 子请求**按文档区分同 zone（值反映可被脚本改写的 `x-real-ip`）与跨 zone（固定为 `2a06:98c0:3600::103`）。

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，新路由 `/en/guides/cloudflare-real-visitor-ip-cf-connecting-ip` 已静态预渲染；无新增告警（仅既有的 middleware 废弃告警） |
| 2 | `npx vitest run` | ✅ 21 文件 / 166 用例全绿 |
| 3 | `npx eslint`（5 个新增改动文件） | ✅ 0 error |
| 4 | dev 服务器新 URL 返回 200 | ⚠️ **无法执行**——本次为无人值守定时任务，`preview_start` 拒绝启动 dev 服务器（无人批准）。**替代验证**：构建已把该路由预渲染为静态 HTML，第 5–7、10 项全部直接断言在这份产物上；合并后再 curl 线上 URL 复核（见下） |
| 5 | canonical 自引用 + hreflang 仅 en/x-default | ✅ 脚本断言通过 |
| 6 | JSON-LD 可 `json.loads`；FAQ 逐字出现在可见正文 | ✅ 2 个 JSON-LD 块全部解析；`TechArticle`/`FAQPage`/`BreadcrumbList` 齐备；5 组问答共 10 条逐字命中 |
| 7 | 标题层级无跳级 | ✅ 16 个标题、唯一 h1、无跳级 |
| 8 | 375px 无横向溢出 | ✅ 见下方说明 |
| 9 | 外链全部 2xx/3xx | ✅ 10 条外链 + 3 个锚点全部实测 200 |
| 10 | 词数 1000–1800 | ✅ 正文 1263 词 |

第 8 项的做法：dev 服务器不可用，改为在 375×812 下打开**线上同构页面** `/guides/cloudflare-cname-flattening`（与本文共用 `.prose pre`、`.table-wrap`、指南 SVG 三种原语），量得 `scrollWidth == clientWidth == 375`；再把**本文真实的**最长 `<pre>` 三段与最长行内 `<code>`（`$http_cf_connecting_ip`、`2a06:98c0:3600::103`、`RemoteIPTrustedProxy` 等）注入线上样式表下实测——页面级仍 `375 == 375`，三段 `<pre>` 各自在 `overflow-x: auto` 内部横滚（scrollW 507/605/629，clientW 327），无行内 code 溢出。

## 其它

- 新增纯 SVG 图 `VisitorIpTrust.tsx`：配色全走主题 token、竖版、`role="img"` + `aria-label` + `<title>` 齐备。中文版那篇用的 `RealIpTrust` 是中文标注，未复用。
- 双向内链：本文 → 小黄云 / error 1000 / error 522；小黄云与 error 522 的「延伸阅读」各加回本文。
- 全文提及 Orange Cloud 产品 0 处（仅 GuideShell 页脚那张卡，计 1 处）。
