### PR TITLE
chore(changelog): Android 2.1.1 条目（修复域名设置页无法滚动）

### DIFF
--- a/packages/changelog/android.json
+++ b/packages/changelog/android.json
@@ -1,5 +1,46 @@
 [
   {
+    "version": "2.1.1",
+    "date": "2026.08.30",
+    "channel": "Google Play",
+    "inApp": false,
+    "items": [
+      {
+        "icon": "wrench.and.screwdriver",
+        "title": {
+          "zh-Hans": "域名设置页可以滚动了",
+          "en": "Domain settings scrolls again",
+          "zh-Hant": "網域設定頁可以捲動了",
+          "zh-HK": "域名設定頁可以滾動了",
+          "ja": "ドメイン設定がスクロールできるように",
+          "es-MX": "La configuración del dominio vuelve a desplazarse",
+          "ko": "도메인 설정 화면이 다시 스크롤됩니다",
+          "pt-BR": "As configurações do domínio voltam a rolar",
+          "pt-PT": "As definições do domínio voltam a deslocar-se",
+          "de": "Domain-Einstellungen lassen sich wieder scrollen",
+          "fr": "Les paramètres du domaine défilent à nouveau",
+          "ar": "صفحة إعدادات النطاق تعود للتمرير",
+          "tr": "Alan adı ayarları yeniden kaydırılabiliyor"
+        },
+        "detail": {
+          "zh-Hans": "域名设置页内容超过一屏时滑不动，底部的开发模式、「我正受到攻击」模式和清空全部缓存够不着。现在整页可以正常上下滚动。",
+          "en": "The domain settings page would not scroll once its content ran past one screen, leaving Development mode, “I'm Under Attack” mode and Purge everything out of reach. The whole page scrolls normally again.",
+          "zh-Hant": "網域設定頁內容超過一個螢幕時捲不動，底部的開發模式、「我正受到攻擊」模式和清除全部快取碰不到。現在整頁可以正常上下捲動。",
+          "zh-HK": "域名設定頁內容超過一屏時滑不動，底部的開發模式、「我正受到攻擊」模式和清除全部緩存夠不着。現在整頁可以正常上下滾動。",
+          "ja": "ドメイン設定の内容が 1 画面に収まらないとスクロールできず、下部の開発モード・「I'm Under Attack」モード・すべてのキャッシュを削除に手が届きませんでした。ページ全体が元どおりスクロールします。",
+          "es-MX": "La página de configuración del dominio dejaba de desplazarse cuando el contenido superaba una pantalla y el modo de desarrollo, el modo “Estoy bajo ataque” y purgar todo quedaban fuera de alcance. Ahora la página se desplaza con normalidad.",
+          "ko": "도메인 설정 내용이 한 화면을 넘으면 스크롤되지 않아 아래쪽의 개발 모드, 「I'm Under Attack」 모드, 전체 캐시 비우기에 손이 닿지 않았습니다. 이제 페이지 전체가 정상적으로 스크롤됩니다.",
+          "pt-BR": "A página de configurações do domínio não rolava quando o conteúdo passava de uma tela, deixando o modo de desenvolvimento, o modo “Estou sob ataque” e limpar tudo fora de alcance. Agora a página inteira rola normalmente.",
+          "pt-PT": "A página de definições do domínio não se deslocava quando o conteúdo passava de um ecrã, deixando o modo de desenvolvimento, o modo “Estou sob ataque” e limpar tudo fora de alcance. Agora a página desloca-se normalmente.",
+          "de": "Die Domain-Einstellungen ließen sich nicht mehr scrollen, sobald der Inhalt über einen Bildschirm hinausging – Entwicklungsmodus, „Ich werde angegriffen“-Modus und Alles leeren blieben unerreichbar. Jetzt scrollt die ganze Seite wieder normal.",
+          "fr": "La page des paramètres du domaine ne défilait plus dès que son contenu dépassait un écran, rendant inaccessibles le mode développement, le mode « Je suis attaqué » et Tout purger. Toute la page défile de nouveau normalement.",
+          "ar": "لم تكن صفحة إعدادات النطاق تُمرَّر عندما يتجاوز محتواها الشاشة، فيتعذّر الوصول إلى وضع التطوير ووضع ”أنا تحت الهجوم“ ومسح الكل. الآن تُمرَّر الصفحة بالكامل كما ينبغي.",
+          "tr": "Alan adı ayarları sayfası içerik bir ekranı aştığında kaydırılamıyor, alttaki geliştirme modu, “Saldırı altındayım” modu ve tümünü temizle erişilemez kalıyordu. Artık sayfanın tamamı normal şekilde kaydırılıyor."
+        }
+      }
+    ]
+  },
+  {
     "version": "2.1.0",
     "date": "2026.08.19",
     "channel": "Google Play",


### PR DESCRIPTION
按发布流程的分支策略，infra（changelog 源）先合，App 分支随后。

## 内容

`packages/changelog/android.json` 顶部加 2.1.1 条目，13 语齐（zh-Hans / en / zh-Hant / zh-HK / ja / es-MX / ko / pt-BR / pt-PT / de / fr / ar / tr）。文案里的功能名对齐各语言 `strings.xml` 的实际译法（开发模式 / 「我正受到攻击」模式 / 清空全部缓存）。

- `inApp: false`：纯修复版，官网更新历史仍列出，App 内不弹 What's New。
- 省略 `live`，等上架后由状态机翻牌。
- codegen 对 `whatsnew.xml` 与 `WhatsNewReleases.generated.kt` 零改动（`inApp:false` 不进生成物），`changelog:check` 通过。

修的是 https://github.com/chen2he/orange-cloud/issues/122 。App 侧修复与版本号在 `release/android-2.1.1`，路径互斥、不挟带。