### PR TITLE
fix(android): 域名设置页恢复滚动，发 2.1.1 (vc25)

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         // 实况通知促升(API36) 均 if-guard 渐进增强，Android 8–11 落固定品牌调色板与常驻通知回退。
         minSdk = 26
         targetSdk = 36
-        versionCode = 24
-        versionName = "2.1.0"
+        versionCode = 25
+        versionName = "2.1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // OAuth 回调（Web 后端 302 跳回的自定义 scheme）

--- a/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zonesettings/ZoneSettingsScreen.kt
+++ b/apps/android/app/src/main/kotlin/jiamin/chen/orangecloud/ui/zonesettings/ZoneSettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
@@ -19,6 +20,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
@@ -93,7 +95,7 @@ fun ZoneSettingsScreen(
                     refreshDescription = stringResource(R.string.common_refresh),
                 )
                 Column(
-                    modifier = Modifier.fillMaxSize().padding(16.dp),
+                    modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     // 暂停只依赖 zone.write，缺 zone-settings.read 时本页也保留它
@@ -149,7 +151,7 @@ fun ZoneSettingsScreen(
                         )
                     }
                     if (state.missingScope) {
-                        Box(Modifier.weight(1f)) {
+                        Box(Modifier.fillMaxWidth().padding(vertical = 48.dp)) {
                             SkyEmptyState(
                                 Icons.Outlined.Settings,
                                 stringResource(R.string.scope_missing), onSky, stringResource(R.string.common_refresh),


### PR DESCRIPTION
Closes #122

## 现象

Android 2.1.0 的域名设置页内容超过一屏后完全滑不动，底部的开发模式、「我正受到攻击」模式、清空全部缓存被裁在屏幕外够不着（见 issue 截图，最后一张卡已被切掉一半）。

## 根因

`ZoneSettingsScreen` 的内容 `Column` 从来没挂滚动容器：

```kotlin
Column(modifier = Modifier.fillMaxSize().padding(16.dp), ...)
```

兄弟页 `ZonePerformanceScreen` 一直带 `.verticalScroll(rememberScrollState())`，这页漏了。1.x 时代卡片少看不出来；2.1.0 补进机器人管控四张卡（链接迷宫 / 拦截内容机器人 / 托管 robots.txt / 许可声明）后内容必然超出一屏，问题才显形。横屏只是更早触发，竖屏同样中招。

## 改动

- 内容 Column 加 `.verticalScroll(rememberScrollState())`，写法对齐 `ZonePerformanceScreen`。
- 缺权限空状态的 `Box(Modifier.weight(1f))` 换成 `fillMaxWidth()` + 上下留白：滚动容器内高度无上界，`weight` 会被算成 0 高度，整块空状态会直接消失。
- `versionCode` 25 / `versionName` 2.1.1。

## 验证

- `:app:compileOssDebugKotlin` 与 `:app:compilePlayDebugKotlin` 均通过。
- **未做真机 / 模拟器验证**：Android 侧没有 mock 登录通道，进这页需要真实 OAuth 账号。
- 顺带扫了全部 Android 页面，无第二处漏滚动：`TunnelListScreen` 走 `StorageListBody`（内含 LazyColumn），`StorageHubScreen` 只有三行固定入口。iOS 这组开关在 `ZoneDetailView` 里，结构不同，不受影响。

## 相关

- 发布说明条目在 #123（infra 分支，先合）。本版 `inApp:false`，故 App 内 What's New 生成物零改动。
- 真要发 Play 时还差 `fastlane/metadata/android/<locale>/changelogs/25.txt`（13 语、每条 ≤500 字符、聚合自上个真正上架过的 versionCode），本 PR 未写。