### PR TITLE
chore(changelog): 发布说明数据源接入鸿蒙 track

### DIFF
--- a/packages/changelog/harmonyos.json
+++ b/packages/changelog/harmonyos.json
@@ -1,0 +1,64 @@
+[
+  {
+    "version": "1.0.0",
+    "date": "2026.08.30",
+    "channel": "AppGallery",
+    "items": [
+      {
+        "icon": "person.badge.key",
+        "title": {
+          "zh-Hans": "OAuth 一键登录",
+          "en": "One-tap OAuth sign-in"
+        },
+        "detail": {
+          "zh-Hans": "用 Cloudflare 官方授权登录，无需手动粘贴 API Token；一个 App 可同时登录多个身份与账号，随时切换。",
+          "en": "Sign in with Cloudflare's official authorization — no API tokens to paste. Keep several identities and accounts signed in and switch anytime."
+        }
+      },
+      {
+        "icon": "globe",
+        "title": {
+          "zh-Hans": "域名、DNS 与规则中心",
+          "en": "Domains, DNS and the rules hub"
+        },
+        "detail": {
+          "zh-Hans": "域名列表与详情、DNS 记录增删改查、WAF 与速率限制、缓存与 Transform、单条重定向与 Page Rules，都在手机上完成。",
+          "en": "Browse domains, manage DNS records, WAF and rate limiting, cache and transform rules, single redirects and Page Rules — all from your phone."
+        }
+      },
+      {
+        "icon": "bolt.fill",
+        "title": {
+          "zh-Hans": "开发者平台与实时日志",
+          "en": "Developer platform with live logs"
+        },
+        "detail": {
+          "zh-Hans": "Workers、Pages、Queues、Durable Objects、Hyperdrive、Workers AI 与 AI Gateway 收在一个 Tab；Worker 实时日志支持搜索、级别筛选与暂停。",
+          "en": "Workers, Pages, Queues, Durable Objects, Hyperdrive, Workers AI and AI Gateway share one tab, and Worker live logs support search, level filters and pause."
+        }
+      },
+      {
+        "icon": "externaldrive",
+        "title": {
+          "zh-Hans": "R2、D1 与 KV 随身管理",
+          "en": "R2, D1 and KV in your pocket"
+        },
+        "detail": {
+          "zh-Hans": "浏览 R2 存储桶与对象、跑 D1 SQL 查询并直接改行、读写 KV 键值；大表有截断与分页防线，不怕手机内存吃紧。",
+          "en": "Browse R2 buckets and objects, run D1 SQL and edit rows in place, read and write KV pairs — with truncation and paging guards so large tables stay safe on a phone."
+        }
+      },
+      {
+        "icon": "sun.horizon",
+        "title": {
+          "zh-Hans": "随时间走的晨昏界面与桌面卡片",
+          "en": "A daybreak interface and home-screen cards"
+        },
+        "detail": {
+          "zh-Hans": "整个 App 的天色随你所在时刻从清晨走到深夜；桌面服务卡片提供「天窗」与「山脊」两张，账号总览一眼可见。",
+          "en": "The whole app's sky follows your local time from dawn to night, and two home-screen cards — skylight and ridge — keep your account overview one glance away."
+        }
+      }
+    ]
+  }
+]

--- a/packages/changelog/index.ts
+++ b/packages/changelog/index.ts
@@ -1,8 +1,13 @@
 // 发布说明单一数据源（每平台一份）。App 端由 scripts/gen-*.mjs 生成 What's New，
-// 官网由本模块直接 import。新增一版只改 ios.json / android.json，再跑 `pnpm changelog:gen`。
+// 官网由本模块直接 import。新增一版只改 ios.json / android.json / harmonyos.json，
+// 再跑 `pnpm changelog:gen`。
+//
+// 注：鸿蒙 App 当前无 i18n（全 zh-Hans 硬编码），harmonyos.json 只维护 zh-Hans + en——
+// codegen 取 zh-Hans，en 供官网 / AppGallery 英文素材复用。
 
 import iosData from "./ios.json";
 import androidData from "./android.json";
+import harmonyosData from "./harmonyos.json";
 
 /** 9 语 canonical 码（BCP-47）。Android 资源目录码映射在 scripts/gen-android.mjs。 */
 export const LOCALES = [
@@ -41,11 +46,12 @@ export interface Release {
   items: ChangelogItem[];
 }
 
-export type Track = "ios" | "android";
+export type Track = "ios" | "android" | "harmonyos";
 
 export const ios: Release[] = iosData as Release[];
 export const android: Release[] = androidData as Release[];
-export const tracks: Record<Track, Release[]> = { ios, android };
+export const harmonyos: Release[] = harmonyosData as Release[];
+export const tracks: Record<Track, Release[]> = { ios, android, harmonyos };
 
 /** 数值分段比较：a 是否比 b 新（"1.3.0" > "1.2.1"，"1.0 (5)" > "1.0 (4)"）。 */
 export function isNewer(a: string, b: string): boolean {

--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -3,16 +3,18 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "发布说明单一数据源：每平台一份 9 语 release，供 App codegen 与官网直读。",
+  "description": "发布说明单一数据源：每平台一份 release（iOS/Android 多语，鸿蒙 zh-Hans+en），供 App codegen 与官网直读。",
   "exports": {
     ".": "./index.ts",
     "./ios.json": "./ios.json",
-    "./android.json": "./android.json"
+    "./android.json": "./android.json",
+    "./harmonyos.json": "./harmonyos.json"
   },
   "scripts": {
     "gen:ios": "node scripts/gen-ios.mjs",
     "gen:android": "node scripts/gen-android.mjs",
-    "gen": "node scripts/gen-ios.mjs && node scripts/gen-android.mjs",
+    "gen:harmony": "node scripts/gen-harmony.mjs",
+    "gen": "node scripts/gen-ios.mjs && node scripts/gen-android.mjs && node scripts/gen-harmony.mjs",
     "check": "node scripts/check.mjs"
   }
 }

--- a/packages/changelog/scripts/check.mjs
+++ b/packages/changelog/scripts/check.mjs
@@ -1,5 +1,5 @@
-// 漂移守卫：以 check 模式跑两个 codegen（只比对不写盘）。
-// 任一生成文件与 ios.json/android.json 不同步即非零退出 —— 适合 CI / pre-commit。
+// 漂移守卫：以 check 模式跑三个 codegen（只比对不写盘）。
+// 任一生成文件与 ios.json/android.json/harmonyos.json 不同步即非零退出 —— 适合 CI / pre-commit。
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -8,7 +8,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const env = { ...process.env, CHANGELOG_CHECK: "1" };
 
 let code = 0;
-for (const script of ["gen-ios.mjs", "gen-android.mjs"]) {
+for (const script of ["gen-ios.mjs", "gen-android.mjs", "gen-harmony.mjs"]) {
   const r = spawnSync(process.execPath, [join(here, script)], { stdio: "inherit", env });
   if (r.status !== 0) code = 1;
 }

--- a/packages/changelog/scripts/gen-harmony.mjs
+++ b/packages/changelog/scripts/gen-harmony.mjs
@@ -1,0 +1,107 @@
+// CODEGEN —— 由 harmonyos.json 生成鸿蒙的「新功能」内容。运行：`pnpm changelog:gen`（或 gen:harmony）。
+// 产出 codegen 独占文件：
+//   entry/src/main/ets/core/whatsnew/WhatsNewReleases.generated.ets
+//
+// 与 iOS / Android 的两点不同：
+//  ① 鸿蒙 App 当前无 i18n（全 zh-Hans 硬编码），文案直接内联 zh-Hans，不出资源文件；
+//     harmonyos.json 里的 en 供官网 / AppGallery 英文素材复用。
+//  ② 图标：changelog 里写的是 SF Symbol 名（与 iOS 同源），这里按 ICONS 映射到
+//     HarmonyOS 的 sys.symbol。**映射表里的名字都已对着 SDK 的 id_defined.json 核过**；
+//     未收录的名字回退 checkmark_circle，并在控制台提示，避免生成编译不过的 $r()。
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { emit, finalize } from "./_emit.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repo = join(here, "..", "..", "..");
+const OUT = join(repo, "apps/harmonyos/entry/src/main/ets/core/whatsnew/WhatsNewReleases.generated.ets");
+
+// apps/harmonyos 不入库（见根 .gitignore）：干净 clone / CI 上该目录并不存在。
+// 此时写盘会 ENOENT，check 模式又会把「文件不存在」判成漂移而非零退出——
+// 两种都是误报，直接跳过，让 `pnpm changelog:gen` / `:check` 在没有鸿蒙工程的环境里照常通过。
+if (!existsSync(dirname(OUT))) {
+  console.log("⏭️  gen-harmony: 未找到 apps/harmonyos（该目录不入库），跳过生成");
+  process.exit(0);
+}
+
+/** SF Symbol → sys.symbol（右侧名字均已在 SDK id_defined.json 中验证存在） */
+const ICONS = {
+  "person.badge.key": "person_badge_checkmark",
+  "person.crop.circle.badge.checkmark": "person_badge_checkmark",
+  globe: "discover",
+  "bolt.fill": "bolt",
+  bolt: "bolt",
+  externaldrive: "externaldrive",
+  archivebox: "archivebox",
+  "sun.horizon": "sun_max",
+  brain: "wand_and_stars",
+  magnifyingglass: "magnifyingglass",
+  "bell.badge.fill": "bell",
+  "checkmark.shield": "checkmark_shield",
+  "lock.shield": "lock_shield",
+  "arrow.triangle.branch": "square_stack_3d",
+  "square.grid.2x2": "square_grid_2x2",
+  "doc.text": "doc_text",
+  "doc.richtext": "doc_text",
+  terminal: "code_slash",
+  "clock.arrow.circlepath": "clock",
+  "arrow.up.arrow.down": "sort",
+  "pause.circle": "timer",
+  envelope: "envelope",
+  "wrench.and.screwdriver.fill": "gearshape",
+};
+const FALLBACK = "checkmark_circle";
+
+const releases = JSON.parse(readFileSync(join(here, "..", "harmonyos.json"), "utf8"));
+const isNewer = (a, b) => a.localeCompare(b, undefined, { numeric: true }) > 0;
+const inApp = releases
+  .filter((r) => r.inApp !== false)
+  .sort((a, b) => (isNewer(a.version, b.version) ? -1 : 1));
+
+const missing = new Set();
+const symbolOf = (icon) => {
+  if (!icon) return FALLBACK;
+  const mapped = ICONS[icon];
+  if (!mapped) missing.add(icon);
+  return mapped ?? FALLBACK;
+};
+
+/** ArkTS 单引号字符串字面量转义 */
+const esc = (s) => (s ?? "").replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\n/g, "\\n");
+const zh = (map) => map?.["zh-Hans"] ?? map?.en ?? "";
+
+const body = inApp
+  .map((r) => {
+    const items = r.items
+      .map(
+        (it) =>
+          `      {\n` +
+          `        symbol: $r('sys.symbol.${symbolOf(it.icon)}'),\n` +
+          `        title: '${esc(zh(it.title))}',\n` +
+          `        detail: '${esc(zh(it.detail))}',\n` +
+          `      },`,
+      )
+      .join("\n");
+    return `  {\n    version: '${r.version}',\n    items: [\n${items}\n    ],\n  },`;
+  })
+  .join("\n");
+
+const ets = `// ⚠️ 自动生成 —— 请勿手改。改 packages/changelog/harmonyos.json 后运行 \`pnpm changelog:gen\`。
+// 文案取 zh-Hans（鸿蒙 App 当前无 i18n），图标由 SF Symbol 名映射到 sys.symbol。
+import { WhatsNewRelease } from './WhatsNew';
+
+/// 用函数而非顶层常量：\$r() 在函数体内求值，避免模块初始化期取资源。
+export function whatsNewReleases(): WhatsNewRelease[] {
+  return [
+${body}
+  ];
+}
+`;
+emit(OUT, ets);
+
+if (missing.size) {
+  console.warn(`⚠️  gen-harmony: 以下 SF Symbol 未在 ICONS 映射表里，已回退 ${FALLBACK}：${[...missing].join(", ")}`);
+}
+console.log(`✅ gen-harmony: ${inApp.length} releases → WhatsNewReleases.generated.ets`);
+finalize("gen-harmony");


### PR DESCRIPTION
[中文]
单一数据源从两条 track 扩到三条：Track 联合加 harmonyos，新增 harmonyos.json
与 gen-harmony.mjs，check.mjs 的漂移守卫从两个 codegen 扩到三个。

与 iOS / Android 的两点不同：

- 鸿蒙 App 当前无 i18n（全 zh-Hans 硬编码），harmonyos.json 只维护 zh-Hans + en，
  codegen 取 zh-Hans 内联进 WhatsNewReleases.generated.ets、不出资源文件，
  en 留给官网与 AppGallery 英文素材；
- changelog 里的图标是 SF Symbol 名（与 iOS 同源），生成时按 ICONS 表映射到
  HarmonyOS 的 sys.symbol（名字均已对着本地 SDK 的 id_defined.json 核过），
  未收录的回退 checkmark_circle 并在控制台提示，避免生成编译不过的 $r()。

apps/harmonyos 不入库，干净 clone / CI 上目录不存在：写盘会 ENOENT、check 模式
又会把「文件不存在」误判成漂移，两种都是误报。故 gen-harmony 在输出目录缺失时
跳过并 exit 0（守卫只加这一条 track，iOS / Android 的输出目录都入库，缺了就该炸）。
已在无 apps/harmonyos 的模拟仓库上验过 gen 与 check 两种模式均 exit 0。

官网侧本次不动：apps/web 有自己的 Track 联合且 renderTrack 硬编码 ios / android，
要上线鸿蒙需另外改 page.tsx、livestate/store.ts 与 D1 release_state。

本机 changelog:check 三条 track 全同步，changelog:gen 幂等、生成物零改动。

[English]
Extends the single-source changelog from two tracks to three: adds harmonyos
to the Track union, plus harmonyos.json and gen-harmony.mjs, and widens the
check.mjs drift guard from two codegens to three.

Two things differ from iOS/Android:

- the HarmonyOS app has no i18n yet (everything is hardcoded zh-Hans), so
  harmonyos.json only carries zh-Hans + en; the codegen inlines zh-Hans into
  WhatsNewReleases.generated.ets and emits no resource files, while en is kept
  for the website and AppGallery English assets;
- icons in the changelog are SF Symbol names (shared with iOS), so the codegen
  maps them to HarmonyOS sys.symbol via the ICONS table (every mapped name was
  checked against the local SDK's id_defined.json); unmapped names fall back to
  checkmark_circle with a console warning, so we never emit a $r() that fails
  to compile.

apps/harmonyos is not in version control, so on a clean clone or CI the output
directory does not exist: writing would throw ENOENT and check mode would
report the missing file as drift. Both are false alarms, so gen-harmony now
skips and exits 0 when the output directory is absent. The guard covers only
this track — the iOS/Android output directories are in the repo and should
still fail loudly. Verified on a simulated repo without apps/harmonyos: both
gen and check exit 0.

The website is untouched here: apps/web has its own Track union and hardcodes
renderTrack for ios/android, so shipping HarmonyOS there additionally needs
page.tsx, livestate/store.ts and the D1 release_state row.

Locally changelog:check reports all three tracks in sync and changelog:gen is
idempotent, leaving generated files unchanged.
