### PR TITLE
chore(android): 升 AGP 9 启用优化型资源缩减（Play 应用优化提示）

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -1,9 +1,7 @@
 import java.util.Properties
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
@@ -138,11 +136,8 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
-    }
-}
+// AGP 9 内置 Kotlin 编译（不再 apply org.jetbrains.kotlin.android）：
+// jvmTarget 默认取 android.compileOptions.targetCompatibility（此处 17），无需再显式声明。
 
 ksp {
     arg("room.schemaLocation", "$projectDir/schemas")

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -1,7 +1,15 @@
 // 顶层构建文件：仅声明插件，不在此 apply。
+// AGP 9 的内置 Kotlin 编译自带 KGP 2.2.10；这里显式抬到与 libs.versions.toml 的
+// kotlin 版本一致（compose / serialization 编译器插件与 KSP 都按该版本编译，
+// 版本错配会在 IR 常量折叠阶段抛 internal compiler error）。改 kotlin 版本时同步改这里。
+buildscript {
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.21")
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false

--- a/apps/android/gradle.properties
+++ b/apps/android/gradle.properties
@@ -4,7 +4,9 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 
 android.useAndroidX=true
-android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+# R8：优化型资源缩减（资源并入 R8 引用图，与代码一起裁剪，而非靠 aapt2 keep 规则保命）。
+# AGP 9 起在 isShrinkResources=true 时默认生效，无需显式开关；此处仅留说明。
+# 见 Play Console「应用优化」提示与 developer.android.com/build/shrink-code
 
 kotlin.code.style=official

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
-# 版本目录。版本号为 2026-06 最佳估计；本机未装工具链，首次 `gradle sync`
-# 可能需要按报错微调（尤其 AGP/Kotlin/Compose BOM 三者的兼容矩阵）。
+# 版本目录。AGP 9.x 起对工具链有硬约束：Gradle ≥ 9.5.0、JDK 17、build-tools 36，
+# 且 AGP 自带 KGP 运行时依赖（≥ 2.2.10）——升 AGP 时 Kotlin/KSP/Hilt 必须成套动。
 [versions]
-agp = "8.13.2"
-kotlin = "2.1.20"
-ksp = "2.1.20-2.0.0"
-hilt = "2.56.2"
+agp = "9.3.2"
+kotlin = "2.3.21"
+# KSP 自 2.3 起与 Kotlin 版本号解耦；≥ 2.3.6 才兼容 AGP 内置 Kotlin
+ksp = "2.3.11"
+hilt = "2.60.1"
 hiltNavigation = "1.2.0"
 
 coreKtx = "1.16.0"
@@ -90,7 +91,6 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/apps/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
[中文]
Play Console 的「应用优化」报了两条：未启用优化型资源缩减、AGP 需升到 9.0+。
两条其实是同一件事——android.r8.optimizedResourceShrinking 在 AGP 8.12/8.13 要
手动开，AGP 9 起在 isShrinkResources = true 时默认生效，故直接升 AGP 而不是加开关。

工具链成套动：AGP 8.13.2 → 9.3.2、Gradle 8.13 → 9.5.0、Kotlin 2.1.20 → 2.3.21、
KSP 2.1.20-2.0.0 → 2.3.11、Hilt 2.56.2 → 2.60.1。

路上三个坑，均已在 apps/android/CLAUDE.md 的工程基线记下：

- AGP 9 的新 DSL 与 org.jetbrains.kotlin.android 不兼容（ApplicationExtensionImpl
  cannot be cast to BaseExtension）。走内置 Kotlin 编译而不是用 android.newDsl=false
  打补丁——那两个 opt-out 到 AGP 10 会被移除。kotlin {} 块随之删除，jvmTarget 默认
  取 android.compileOptions.targetCompatibility
- KSP 2.2.x 明确拒绝内置 Kotlin，必须 ≥ 2.3.6（KSP 自 2.3 起与 Kotlin 版本号解耦）
- AGP 自带 KGP 2.2.10，而 compose / serialization 编译器插件按版本目录里的 kotlin
  版本走，版本错配会在 IR 常量折叠阶段抛 internal compiler error（触发点是
  Blake3.kt 的 toUInt()）。根 build.gradle.kts 的 buildscript classpath 把 KGP 钉
  到同版，改 kotlin 版本时两处要同步改

gradle.properties 去掉 nonTransitiveRClass 与 defaults.buildfeatures.buildconfig：
前者 AGP 9 恒为非传递 R，后者本模块已在 buildFeatures 显式开启。

验证：play / oss / direct 三风味 release、playDebug、bundlePlayRelease、单元测试
（AGP 9 起单测只对被测 build type 生成变体，是 testPlayDebugUnitTest）全部通过，
release APK 签名正常。体积 5,782,569 → 5,681,643 字节（-98.6 KB / -1.75%，AGP 8
下单独开优化缩减的净效果），AGP 9 下同量级 5,682,298；AAB 10,151,308 → 10,087,231。
模拟器装 release 包（R8 full mode + strictFullModeForKeepRules）冒烟：启动 2.1s 无
崩溃，导航正常，DNS 查询打通并正确解码，即 OkHttp + kotlinx.serialization + Compose
资源都没有被裁坏；工程内也没有 getIdentifier 之类反射取资源的写法。

登录、Room、Glance 小组件、Billing、FCM、direct 激活码这些依赖反射 / 序列化的路径
仍需真机走一遍再发版。

[English]
Play Console's app optimization report flagged two things: optimized resource
shrinking not enabled, and AGP needing 9.0+. They are the same issue —
android.r8.optimizedResourceShrinking must be set by hand on AGP 8.12/8.13 but
applies automatically from AGP 9 whenever isShrinkResources = true, so this
upgrades AGP instead of adding the flag.

The toolchain moves as a set: AGP 8.13.2 → 9.3.2, Gradle 8.13 → 9.5.0,
Kotlin 2.1.20 → 2.3.21, KSP 2.1.20-2.0.0 → 2.3.11, Hilt 2.56.2 → 2.60.1.

Three traps along the way, all recorded in apps/android/CLAUDE.md:

- AGP 9's new DSL is incompatible with org.jetbrains.kotlin.android
  (ApplicationExtensionImpl cannot be cast to BaseExtension). This moves to
  built-in Kotlin compilation rather than patching over it with
  android.newDsl=false, since both opt-outs disappear in AGP 10. The kotlin {}
  block goes away with it; jvmTarget defaults to
  android.compileOptions.targetCompatibility
- KSP 2.2.x explicitly refuses built-in Kotlin and must be >= 2.3.6 (KSP
  versioning decoupled from Kotlin as of 2.3)
- AGP ships KGP 2.2.10 while the compose/serialization compiler plugins follow
  the catalog's kotlin version; a mismatch throws an internal compiler error
  during IR constant folding (triggered by toUInt() in Blake3.kt). The root
  build.gradle.kts buildscript classpath pins KGP to the same version, so both
  places must change together

gradle.properties drops nonTransitiveRClass and
defaults.buildfeatures.buildconfig: AGP 9 is always non-transitive, and this
module already enables buildConfig explicitly in buildFeatures.

Verification: release builds for all three flavors (play/oss/direct), playDebug,
bundlePlayRelease and unit tests all pass (AGP 9 only creates unit test variants
for the tested build type, so it is testPlayDebugUnitTest), and the release APK
is signed correctly. Size went 5,782,569 → 5,681,643 bytes (-98.6 KB / -1.75%,
measured as the isolated effect of optimized shrinking on AGP 8), with AGP 9
landing at a comparable 5,682,298; the AAB went 10,151,308 → 10,087,231.
Smoke-tested the release APK on an emulator (R8 full mode plus
strictFullModeForKeepRules): launches in 2.1s without crashing, navigation
works, and a DNS lookup completes and decodes, so OkHttp, kotlinx.serialization
and Compose resources all survive shrinking. The project also has no reflective
resource lookups such as getIdentifier.

Sign-in, Room, the Glance widget, Billing, FCM and the direct-channel activation
codes all lean on reflection or serialization and should still be exercised on a
real device before shipping.
