### PR TITLE
fix(ios): 缓存容器就地自愈 + 授权页失效提示 + 部分 authz 不再整块降级

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/AuthManager.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Auth/AuthManager.swift
@@ -17,6 +17,9 @@ nonisolated enum AuthError: LocalizedError {
     case invalidCallback
     case stateMismatch
     case oauthError(String)
+    /// 授权页被回退 / 刷新后再回到回调，Hydra 判定 consent verifier 已被消费。
+    /// 一次性状态，重来即可，不是配置问题（Sentry APPLE-IOS-5）。
+    case consentExpired
     case tokenExchangeFailed(String)
     /// token 端点返回非 2xx。status 用于区分「刷新令牌确已失效」（400）与瞬时错误（5xx/429）。
     case tokenEndpointError(status: Int, body: String)
@@ -27,10 +30,19 @@ nonisolated enum AuthError: LocalizedError {
         case .invalidCallback:              return String(localized: "授权回调格式错误")
         case .stateMismatch:                return String(localized: "state 校验失败，请重试")
         case .oauthError(let message):      return message
+        case .consentExpired:               return String(localized: "授权页面已失效，请重新发起登录。")
         case .tokenExchangeFailed(let msg): return String(localized: "换取 Token 失败：\(msg)")
         case .tokenEndpointError(let status, let body):
             return String(localized: "换取 Token 失败：\(body.isEmpty ? "HTTP \(status)" : body)")
         case .notLoggedIn:                  return String(localized: "登录已过期，请重新登录")
+        }
+    }
+
+    /// 授权流里「重来一次就好」的一次性状态：计入本地日志，但不该占遥测的故障额度。
+    var isRetriableFlowState: Bool {
+        switch self {
+        case .consentExpired, .stateMismatch: return true
+        default:                              return false
         }
     }
 }
@@ -212,6 +224,10 @@ final class AuthManager {
         } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
             // 用户主动取消，不算错误
             AppLog.auth.notice("login canceled by user")
+        } catch let error as AuthError where error.isRetriableFlowState {
+            // 用户重来一次就好，不是故障：记 notice 不进遥测
+            AppLog.auth.notice("login aborted (retriable): \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
         } catch {
             AppLog.auth.error("login failed: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
@@ -253,6 +269,9 @@ final class AuthManager {
             persist()
         } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
             AppLog.auth.notice("reauthorize canceled by user")
+        } catch let error as AuthError where error.isRetriableFlowState {
+            AppLog.auth.notice("reauthorize aborted (retriable): \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
         } catch {
             AppLog.auth.error("reauthorize failed: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
@@ -345,6 +364,11 @@ final class AuthManager {
                 var message = String(localized: "授权请求包含 Cloudflare 尚未对本 App 开放的权限，无法完成登录。请更新到最新版本后重试。")
                 if !description.isEmpty { message += "\n\(description)" }
                 throw AuthError.oauthError(message)
+            }
+            // Hydra 的一次性 consent verifier 被重复消费（授权途中后退 / 刷新过），
+            // 重新走一遍即可——别把英文原文甩给用户（Sentry APPLE-IOS-5 占登录失败大头）。
+            if description.contains("consent verifier has already been used") {
+                throw AuthError.consentExpired
             }
             throw AuthError.oauthError(description.isEmpty ? error : "\(error): \(description)")
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheContainer.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CacheContainer.swift
@@ -10,27 +10,40 @@ import SwiftData
 
 nonisolated enum CacheContainer {
 
-    static let shared: ModelContainer = {
-        let schema = Schema([
+    /// 容器可在启动自检后被就地替换（见 warmUp），故为 var。
+    /// 只在主线程、且在 SwiftUI 取用 `shared` 之前替换，替换后全程只读。
+    @MainActor private static var container: ModelContainer = makeContainer()
+
+    @MainActor static var shared: ModelContainer { container }
+
+    private static var schema: Schema {
+        Schema([
             CachedZone.self,
             CachedDNSRecord.self,
             CachedWorkerScript.self,
         ])
-        // cloudKitDatabase 必须显式 .none：App 带 iCloud entitlement 时 .automatic 会
-        // 强制开启 CloudKit 同步，而 CloudKit 不允许非可选属性和 @Attribute(.unique)。
-        // 缓存数据本就按账号实时拉取，无需跨设备同步。
-        let configuration = ModelConfiguration(
-            schema: schema,
-            isStoredInMemoryOnly: false,
-            cloudKitDatabase: .none
-        )
-        // 上一轮运行中 fetch 连续抛 ObjC 异常（见 CachePolicy.safeFetch）说明本机缓存库
-        // 大概率已损坏——容器活着时不能动店文件，标记留到此刻（容器创建前）清库重建。
-        if UserDefaults.standard.bool(forKey: rebuildFlagKey) {
-            AppLog.app.error("缓存库带损坏标记，启动前清库重建")
+    }
+
+    // cloudKitDatabase 必须显式 .none：App 带 iCloud entitlement 时 .automatic 会
+    // 强制开启 CloudKit 同步，而 CloudKit 不允许非可选属性和 @Attribute(.unique)。
+    // 缓存数据本就按账号实时拉取，无需跨设备同步。
+    private static var diskConfiguration: ModelConfiguration {
+        ModelConfiguration(schema: schema, isStoredInMemoryOnly: false, cloudKitDatabase: .none)
+    }
+
+    private static var memoryConfiguration: ModelConfiguration {
+        ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+    }
+
+    @MainActor
+    private static func makeContainer() -> ModelContainer {
+        let configuration = diskConfiguration
+        // 旧版本（≤2.1.0）会给下次启动留清库标记，此处照旧消费一次，避免老装机被搁浅。
+        if UserDefaults.standard.bool(forKey: legacyRebuildFlagKey) {
+            AppLog.app.notice("消费旧版清库标记，启动前清库重建")
             destroyStoreFiles(at: configuration.url)
-            UserDefaults.standard.removeObject(forKey: rebuildFlagKey)
-            UserDefaults.standard.removeObject(forKey: fetchExceptionCountKey)
+            UserDefaults.standard.removeObject(forKey: legacyRebuildFlagKey)
+            UserDefaults.standard.removeObject(forKey: legacyExceptionCountKey)
         }
         do {
             return try ModelContainer(for: schema, configurations: [configuration])
@@ -39,49 +52,82 @@ nonisolated enum CacheContainer {
             // 启动瞬间崩掉（旧写法在此 fatalError）。先清掉磁盘存储重建；仍失败则退到内存
             // 容器（本次不落盘），保证一定能启动。
             AppLog.app.error("ModelContainer 创建失败，尝试清库重建：\(error.localizedDescription)")
-            Self.destroyStoreFiles(at: configuration.url)
+            destroyStoreFiles(at: configuration.url)
             if let rebuilt = try? ModelContainer(for: schema, configurations: [configuration]) {
                 return rebuilt
             }
             AppLog.app.error("清库后仍失败，回退内存容器（缓存本次不落盘）")
-            let memory = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
-            return try! ModelContainer(for: schema, configurations: [memory])
+            return try! ModelContainer(for: schema, configurations: [memoryConfiguration])
         }
-    }()
+    }
 
-    /// 启动早期在主线程串行预热一次实体解析。Sentry APPLE-IOS-Y（1.8.2+27~1.8.3+30）：
-    /// iOS 17.x 冷启动后数秒内的首次 fetch 抛「could not locate an NSEntityDescription for
-    /// entity name 'CachedZone'」，疑为首次实体解析的并发竞态（@Query / Intents 查询 /
-    /// ViewModel fetch 同窗口首触）。在任何并发访问前做一次守卫下的空谓词 fetch 灌热实体
-    /// 描述；即便竞态假说不成立，异常也会被 SafeCache 兜住并计入店健康。
+    // MARK: - 启动自检与就地修复
+
+    /// 启动早期做一次实体解析自检，坏了就当场把容器换掉。
+    ///
+    /// Sentry APPLE-IOS-1（1.9.2~2.1.0，iOS 17.0 为主）：某些设备上 ModelContainer 创建
+    /// 「成功」了，但它的实体描述整个不可用——同一会话里 warmUp 的空谓词 fetch、syncZones、
+    /// syncWorkers、dnsRecordCount 回写全部抛
+    /// `could not locate an NSEntityDescription for entity name '…'`，次数一比一对应。
+    /// 坏的是模型注册而非 store 文件，所以旧的「标记 → 下次启动删库」既治不好，又让这批
+    /// 用户每次启动都丢一次缓存。改为当场重建，且**先不动磁盘数据**：
+    ///   ① 换一个新容器（多为本次进程的注册问题，磁盘数据是好的，用户缓存不丢）
+    ///   ② 仍坏才清库重建（这时才是 store 真损坏）
+    ///   ③ 再坏退内存容器（本次不落盘，但 App 全程可用）
+    /// 必须在 SwiftUI 取用 `shared` 之前调用（App.init 里），换容器才能同时惠及 @Query。
     @MainActor
     static func warmUp() {
-        _ = SafeCache.fetch(FetchDescriptor<CachedZone>(), context: shared.mainContext)
+        guard !SafeCache.probe(container) else { return }
+        AppLog.app.error("缓存库启动自检失败（实体描述不可用），就地重建容器")
+        repairContainer()
     }
 
-    // MARK: - 店健康记录（TF 崩溃点 D8tiH4pqdctLgx_nCLGnZ：单机纯谓词 fetch 也抛 NSException）
+    /// 运行中连续异常时的兜底修复（每进程至多一次）。启动自检已覆盖绝大多数情况，
+    /// 这里只处理「启动时是好的、跑着跑着坏掉」的残余场景；已被 SwiftUI 持有的 @Query
+    /// 仍绑在旧容器上，故只求让命令式读写恢复，不追求全量生效。
+    @MainActor
+    static func repairIfNeeded() {
+        guard !hasRepairedThisLaunch, !SafeCache.probe(container) else { return }
+        AppLog.app.error("缓存库运行中失效，尝试就地重建容器")
+        repairContainer()
+    }
 
-    private static let rebuildFlagKey = "ocCacheStoreNeedsRebuild"
-    private static let fetchExceptionCountKey = "ocCacheFetchExceptionCount"
-    /// 连续异常达到该数即标记下次启动清库（缓存可随时从 API 重拉，重建成本 ≈ 一次刷新）
-    private static let rebuildThreshold = 2
+    @MainActor private static var hasRepairedThisLaunch = false
 
-    /// fetch 抛 ObjC 异常时调用（CachePolicy.safeFetch）。计数持久化，跨启动累计。
-    static func noteFetchException() {
-        let count = UserDefaults.standard.integer(forKey: fetchExceptionCountKey) + 1
-        UserDefaults.standard.set(count, forKey: fetchExceptionCountKey)
-        if count >= rebuildThreshold {
-            UserDefaults.standard.set(true, forKey: rebuildFlagKey)
-            AppLog.app.error("缓存 fetch 连续 \(count) 次抛 ObjC 异常，已标记下次启动清库重建")
+    @MainActor
+    private static func repairContainer() {
+        hasRepairedThisLaunch = true
+        let configuration = diskConfiguration
+
+        if let rebuilt = try? ModelContainer(for: schema, configurations: [configuration]),
+           SafeCache.probe(rebuilt) {
+            container = rebuilt
+            AppLog.app.notice("缓存容器重建成功（磁盘数据保留）")
+            return
         }
+
+        destroyStoreFiles(at: configuration.url)
+        if let rebuilt = try? ModelContainer(for: schema, configurations: [configuration]),
+           SafeCache.probe(rebuilt) {
+            container = rebuilt
+            AppLog.app.notice("缓存清库重建成功")
+            return
+        }
+
+        if let memory = try? ModelContainer(for: schema, configurations: [memoryConfiguration]),
+           SafeCache.probe(memory) {
+            container = memory
+            AppLog.app.error("缓存退回内存容器（本次不落盘）")
+            return
+        }
+        // 三条路都不通：保持原容器，所有读写继续被 SafeCache 兜成「无缓存」，App 照常可用。
+        AppLog.app.error("缓存容器重建失败，本次运行按无缓存降级")
     }
 
-    /// fetch 正常完成时调用：清零连续异常计数（偶发异常不触发重建）。
-    static func noteFetchHealthy() {
-        if UserDefaults.standard.integer(forKey: fetchExceptionCountKey) != 0 {
-            UserDefaults.standard.removeObject(forKey: fetchExceptionCountKey)
-        }
-    }
+    // MARK: - 旧版遗留键（只读取清理，不再写入）
+
+    private static let legacyRebuildFlagKey = "ocCacheStoreNeedsRebuild"
+    private static let legacyExceptionCountKey = "ocCacheFetchExceptionCount"
 
     /// 删除磁盘上的 SwiftData 存储文件（含 -wal / -shm 旁文件），供损坏后清库重建。
     private static func destroyStoreFiles(at storeURL: URL) {

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CachePolicy.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/CachePolicy.swift
@@ -29,7 +29,8 @@ enum CachePolicy {
     // 1.8.2(24) 改纯谓词后同一台设备仍在崩（build 24/27 日志砸在纯谓词 fetch 本身），
     // 说明该机缓存库已损坏——Swift 的 try? 接不住 CoreData 的 NSException，必须经
     // SafeCache 的 ObjC @try 垫片兜底：异常按「缓存不新鲜」处理（触发正常重拉），
-    // 连续异常由 CacheContainer 标记下次启动清库重建。
+    // 连续异常由 CacheContainer 就地重建容器（Sentry APPLE-IOS-1：坏的是整个容器的
+    // 实体注册，非本文件的 fetch 写法，故谓词照常可用）。
     // 单账号/单域名下的缓存行数很小，内存里取 max(updatedAt) 足够。
 
     /// 某账号缓存的域名是否仍在有效期内（用于冷启动免重拉）

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/SafeCache.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Cache/SafeCache.swift
@@ -7,7 +7,7 @@
 //  冷启动早期实体解析失败 "could not locate an NSEntityDescription for entity name"），
 //  Swift 的 try/try? 只接 Swift Error，接不住 NSException。缓存是可随时从 API 重拉的
 //  非关键数据，绝不允许它把 App 崩掉——所有对缓存库的 fetch / 写入段必须经此收口，
-//  异常按「缓存缺失」处理并计入店健康（连续异常触发下次启动清库重建）。
+//  异常按「缓存缺失」处理，并在连续异常时请求 CacheContainer 就地重建容器。
 //
 
 import Foundation
@@ -28,7 +28,7 @@ enum SafeCache {
             note(exception, label: "fetch \(T.self)")
             return nil
         }
-        CacheContainer.noteFetchHealthy()
+        noteHealthy()
         return fetched
     }
 
@@ -45,7 +45,7 @@ enum SafeCache {
             note(exception, label: label)
             return false
         }
-        CacheContainer.noteFetchHealthy()
+        noteHealthy()
         if let swiftError {
             AppLog.app.info("缓存操作失败（已忽略，\(label)）：\(swiftError.localizedDescription)")
             return false
@@ -53,8 +53,42 @@ enum SafeCache {
         return true
     }
 
+    /// 容器健康探针：对给定容器做一次空谓词 fetch，看实体描述是否可解析。
+    /// 只回答「行不行」，不记日志、不计入健康计数——它本身就是修复流程的一部分。
+    static func probe(_ container: ModelContainer) -> Bool {
+        var ok = false
+        let exception = OCCatchException {
+            ok = ((try? ModelContext(container).fetch(FetchDescriptor<CachedZone>())) != nil)
+        }
+        return exception == nil && ok
+    }
+
+    // MARK: - 健康计数（进程内，不再跨启动持久化）
+
+    /// 连续异常达到该数即请求就地重建容器（Sentry APPLE-IOS-1：坏掉时是整个容器
+    /// 的实体注册失效，同一会话所有调用点一起抛，攒不到几次就该修）。
+    private static let repairThreshold = 3
+    private static var consecutiveExceptions = 0
+    /// 异常详情每进程只按 error 记一次：坏容器会让每个调用点反复抛，
+    /// 逐次记 error 会被遥测放大成成百上千条同源事件（APPLE-IOS-1 的 236 条即此）。
+    private static var hasLoggedExceptionThisLaunch = false
+
     private static func note(_ exception: NSException, label: String) {
-        AppLog.app.error("缓存 \(label) 抛 ObjC 异常（已兜住，按缓存缺失处理）：\(exception.name.rawValue) — \(exception.reason ?? "无 reason")")
-        CacheContainer.noteFetchException()
+        let line = "缓存 \(label) 抛 ObjC 异常（已兜住，按缓存缺失处理）：\(exception.name.rawValue) — \(exception.reason ?? "无 reason")"
+        if hasLoggedExceptionThisLaunch {
+            AppLog.app.info("\(line)")
+        } else {
+            hasLoggedExceptionThisLaunch = true
+            AppLog.app.error("\(line)")
+        }
+        consecutiveExceptions += 1
+        if consecutiveExceptions >= repairThreshold {
+            consecutiveExceptions = 0
+            CacheContainer.repairIfNeeded()
+        }
+    }
+
+    private static func noteHealthy() {
+        consecutiveExceptions = 0
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/APIError.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/APIError.swift
@@ -11,7 +11,10 @@ nonisolated enum APIError: LocalizedError {
     case notFound                        // 404
     case rateLimited                     // 429
     case serverError(statusCode: Int)    // 5xx
-    case cloudflareError(code: Int, message: String)  // CF 业务错误
+    /// CF 业务错误。documentationURL 是 2026-08-20 起 CF 在 4xx 错误体里回的
+    /// `documentation_url`（该端点所需角色/权限的文档），老端点没有故可选、带默认值——
+    /// 二十多处构造点无需改动。
+    case cloudflareError(code: Int, message: String, documentationURL: String? = nil)
     case decodingError(Error)            // 解析失败
     case networkError(Error)             // 网络错误
     case accountNotAuthorized            // 账户级数据集未授权（GraphQL authz；免费账号常态，无法区分无权限/计划未开通）
@@ -23,11 +26,18 @@ nonisolated enum APIError: LocalizedError {
         case .notFound:                    return String(localized: "资源不存在")
         case .rateLimited:                 return String(localized: "请求太频繁，请稍后再试")
         case .serverError(let code):       return String(localized: "服务器错误（\(code)）")
-        case .cloudflareError(_, let msg): return msg
+        case .cloudflareError(_, let msg, _): return msg
         case .decodingError:               return String(localized: "数据解析失败")
         case .networkError(let e):         return String(localized: "网络错误：\(e.localizedDescription)")
         case .accountNotAuthorized:        return String(localized: "此账号暂无账户级数据查询权限")
         }
+    }
+
+    /// CF 给出的「该端点需要什么权限」文档地址（仅 4xx 且新端点有）。
+    var documentationURL: URL? {
+        guard case .cloudflareError(_, _, let raw) = self,
+              let raw, let url = URL(string: raw) else { return nil }
+        return url
     }
 
     /// 是否为账户级数据集未授权（用于 UI 降级到「免费账号无账户级数据」态）
@@ -41,7 +51,7 @@ nonisolated enum APIError: LocalizedError {
     var isPermissionDenied: Bool {
         switch self {
         case .forbidden:                    return true
-        case .cloudflareError(let code, _): return code == 10000
+        case .cloudflareError(let code, _, _): return code == 10000
         default:                            return false
         }
     }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/Network/CFAPIClient.swift
@@ -112,7 +112,8 @@ actor CFAPIClient {
         guard (200...299).contains(http.statusCode) else {
             let data = (try? Data(contentsOf: tempURL)) ?? Data()
             try? FileManager.default.removeItem(at: tempURL)
-            AppLog.network.error("GET /\(Self.logPath(path)) -> \(http.statusCode)\(Self.cfErrorSummary(data))")
+            Self.logHTTPFailure("GET /\(Self.logPath(path)) -> \(http.statusCode)\(Self.cfErrorSummary(data))",
+                                status: http.statusCode, path: path, data: data)
             throw Self.mapHTTPError(status: http.statusCode, data: data)
         }
         // download 返回的系统临时文件在本调用返回后会被清理，须立刻搬到自管位置
@@ -165,7 +166,8 @@ actor CFAPIClient {
             return try await streamingUpload(path: path, fileURL: fileURL, contentType: contentType, onProgress: onProgress, isRetry: true)
         }
         guard (200...299).contains(http.statusCode) else {
-            AppLog.network.error("PUT /\(Self.logPath(path)) -> \(http.statusCode)\(Self.cfErrorSummary(data))")
+            Self.logHTTPFailure("PUT /\(Self.logPath(path)) -> \(http.statusCode)\(Self.cfErrorSummary(data))",
+                                status: http.statusCode, path: path, data: data)
             throw Self.mapHTTPError(status: http.statusCode, data: data)
         }
         return try Self.decode(data, path: path)
@@ -300,7 +302,8 @@ actor CFAPIClient {
             throw APIError.networkError(URLError(.badServerResponse))
         }
         guard (200...299).contains(http.statusCode) else {
-            AppLog.network.error("\(method) /\(Self.logPath(path)) (jwt) -> \(http.statusCode)\(Self.cfErrorSummary(data))")
+            Self.logHTTPFailure("\(method) /\(Self.logPath(path)) (jwt) -> \(http.statusCode)\(Self.cfErrorSummary(data))",
+                                status: http.statusCode, path: path, data: data)
             throw Self.mapHTTPError(status: http.statusCode, data: data)
         }
         return data
@@ -328,7 +331,8 @@ actor CFAPIClient {
             throw APIError.networkError(URLError(.badServerResponse))
         }
         guard (200...299).contains(http.statusCode) else {
-            AppLog.network.error("POST \(url.host ?? "")\(url.path) (external) -> \(http.statusCode)\(Self.cfErrorSummary(data))")
+            Self.logHTTPFailure("POST \(url.host ?? "")\(url.path) (external) -> \(http.statusCode)\(Self.cfErrorSummary(data))",
+                                status: http.statusCode, path: url.path, data: data)
             throw Self.mapHTTPError(status: http.statusCode, data: data)
         }
         return data
@@ -429,7 +433,8 @@ actor CFAPIClient {
             throw APIError.networkError(URLError(.badServerResponse))
         }
         guard (200...299).contains(http.statusCode) else {
-            AppLog.network.error("\(method) /\(Self.logPath(path)) (jwt mp) -> \(http.statusCode)\(Self.cfErrorSummary(data))")
+            Self.logHTTPFailure("\(method) /\(Self.logPath(path)) (jwt mp) -> \(http.statusCode)\(Self.cfErrorSummary(data))",
+                                status: http.statusCode, path: path, data: data)
             throw Self.mapHTTPError(status: http.statusCode, data: data)
         }
         return data
@@ -441,6 +446,15 @@ actor CFAPIClient {
         query: String,
         variables: V
     ) async throws -> D {
+        try await graphQLAllowingPartialAuthz(query: query, variables: variables).data
+    }
+
+    /// 同 graphQL，但把「部分字段 authz、其余字段照常返回」这一情况回给调用方，
+    /// 便于 UI 区分「整账号无账户级数据」与「只是某些时间窗/数据集缺」（见下方说明）。
+    func graphQLAllowingPartialAuthz<D: Codable & Sendable, V: Codable & Sendable>(
+        query: String,
+        variables: V
+    ) async throws -> (data: D, partialAuthz: Bool) {
         let body = try JSONEncoder().encode(GraphQLRequest(query: query, variables: variables))
         let envelope: GraphQLResponse<D> = try await request(
             method: "POST", path: "graphql", queryItems: [], body: body
@@ -448,10 +462,24 @@ actor CFAPIClient {
         if let first = envelope.errors?.first {
             // GraphQL 错误时 HTTP 仍为 200——网络层只看状态码看不到这层，这里单独记，
             // 便于排查「请求 200 但数据没出来」（如数据集权限/字段不可用）。
-            AppLog.network.error("graphQL error (\(envelope.errors?.count ?? 1)): \(first.message)")
-            // authz（账户级数据集未授权）单独抛——调用方据此降级到「免费账号无账户级数据」态，
-            // 并停发同账号其余注定失败的账户级查询。
+            // authz（免费账号查账户级数据集的常态）与限流不是故障：UI 已按降级/重试处理，
+            // 记 notice 不进遥测；其余 GraphQL 错误仍是 error（多为查询/字段写错了）。
+            let line = "graphQL error (\(envelope.errors?.count ?? 1)): \(first.message)"
+            if envelope.errors?.contains(where: \.isAuthz) == true || first.message.contains("Rate limiter") {
+                AppLog.network.notice("\(line)")
+            } else {
+                AppLog.network.error("\(line)")
+            }
             if envelope.errors?.contains(where: \.isAuthz) == true {
+                // GraphQL 允许「部分字段 authz、其余字段照常返回」——免费账号最典型：
+                // today 窗口有数据、month 窗口 authz。此时 data 已经解出来了，整包丢掉
+                // 等于把手上的数据扔了（概览用量会整块误降级成「无账户级数据」）。
+                // 故：解出 data 就返回（并标 partialAuthz），只有 data 为空才是真·整账号
+                // 无账户级数据权限 → 抛给调用方降级并停发其余注定失败的账户级查询。
+                if let data = envelope.data {
+                    AppLog.network.info("graphQL partial authz: 返回已授权字段，缺失字段按空处理")
+                    return (data, true)
+                }
                 throw APIError.accountNotAuthorized
             }
             throw APIError.cloudflareError(code: 0, message: first.message)
@@ -459,7 +487,7 @@ actor CFAPIClient {
         guard let data = envelope.data else {
             throw APIError.decodingError(URLError(.cannotDecodeContentData))
         }
-        return data
+        return (data, false)
     }
 
     // MARK: - 内部实现
@@ -549,14 +577,12 @@ actor CFAPIClient {
             )
         }
 
-        // 结果各记一行（2xx → info 带响应体大小；其余 → error 带 CF 业务错误码/消息），便于排查。
-        // 预期业务状态（未开通 R2 / 尚无 ruleset 等）降级 info，不进遥测。
+        // 结果各记一行（2xx → info 带响应体大小；其余按 failureLevel 定级），便于排查。
         if (200...299).contains(http.statusCode) {
             AppLog.network.info("\(method) /\(Self.logPath(path)) -> \(http.statusCode) (\(elapsedMs)ms, \(Self.sizeLabel(data.count)))")
-        } else if Self.isExpectedBusinessState(status: http.statusCode, path: path, data: data) {
-            AppLog.network.info("\(method) /\(Self.logPath(path)) -> \(http.statusCode) (\(elapsedMs)ms)\(Self.cfErrorSummary(data))")
         } else {
-            AppLog.network.error("\(method) /\(Self.logPath(path)) -> \(http.statusCode) (\(elapsedMs)ms)\(Self.cfErrorSummary(data))")
+            Self.logHTTPFailure("\(method) /\(Self.logPath(path)) -> \(http.statusCode) (\(elapsedMs)ms)\(Self.cfErrorSummary(data))",
+                                status: http.statusCode, path: path, data: data)
         }
 
         // 5. HTTP 错误处理（优先透出 CF 返回的业务错误信息）
@@ -621,27 +647,59 @@ actor CFAPIClient {
         return false
     }
 
-    /// 传输层失败统一记录：取消降级 info，其余保持 error
+    /// 链路环境问题（超时 / 连接中断 / 无网 / DNS / TLS 握手失败）：取决于用户当时的网络，
+    /// App 侧无可修，UI 已提示重试。记 notice——留在本地日志供反馈排查，但不进遥测。
+    private static func isEnvironmentalNetworkFailure(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .timedOut, .networkConnectionLost, .notConnectedToInternet,
+             .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+             .secureConnectionFailed, .internationalRoamingOff, .dataNotAllowed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// 传输层失败统一记录：取消降级 info，环境类降级 notice，其余保持 error
     private static func logTransportError(_ method: String, _ path: String, _ label: String, _ error: Error) {
         let line = "\(method) /\(logPath(path)) \(label): \(error.localizedDescription)"
         if isCancellation(error) {
             AppLog.network.info("\(line)")
+        } else if isEnvironmentalNetworkFailure(error) {
+            AppLog.network.notice("\(line)")
         } else {
             AppLog.network.error("\(line)")
         }
     }
 
-    /// 预期业务状态（非故障，UI 均按空态/降级处理）：
-    /// 账号未开通 R2（403 cf=10042）、zone 该阶段还没有 entrypoint ruleset
-    ///（404 cf=10003，Snippets / WAF / 速率限制首次进入的常态）、
-    /// OAuth token 无账单读权限（subscriptions 403 cf=10000）。
-    private static func isExpectedBusinessState(status: Int, path: String, data: Data) -> Bool {
-        guard let code = cfErrorCode(data) else { return false }
+    private enum FailureLogLevel { case info, notice, error }
+
+    /// 非 2xx 的记录级别。分三档：
+    /// - info：日常空态，连看都不用看——账号未开通 R2（403 cf=10042）、zone 该阶段还没有
+    ///   entrypoint ruleset（404 cf=10003，Snippets / WAF / 速率限制首次进入的常态）、
+    ///   OAuth token 无账单读权限（subscriptions 403 cf=10000）。
+    /// - notice：4xx 且 CF 给了业务错误码——接口明确告知这次操作不被接受（记录被 Email
+    ///   Routing 托管、存在非 CF 的 MX、缺 filters、邮箱未验证、token 无该权限……），
+    ///   原因已经原样展示给用户了。属预期结果而非故障，留在本地日志但不进遥测。
+    /// - error：无业务码的 4xx（接口没说为什么，多半是我们请求构造错了）与全部 5xx。
+    ///   这两类才是该在 Sentry 里看见的。
+    private static func failureLevel(status: Int, path: String, data: Data) -> FailureLogLevel {
+        guard let code = cfErrorCode(data) else { return .error }
         switch (status, code) {
-        case (403, 10042): return true
-        case (404, 10003): return true
-        case (403, 10000): return path.hasSuffix("/subscriptions")
-        default:           return false
+        case (403, 10042): return .info
+        case (404, 10003): return .info
+        case (403, 10000) where path.hasSuffix("/subscriptions"): return .info
+        default: return (400...499).contains(status) ? .notice : .error
+        }
+    }
+
+    /// 非 2xx 统一记一行，级别由 failureLevel 判定
+    private static func logHTTPFailure(_ line: String, status: Int, path: String, data: Data) {
+        switch failureLevel(status: status, path: path, data: data) {
+        case .info:   AppLog.network.info("\(line)")
+        case .notice: AppLog.network.notice("\(line)")
+        case .error:  AppLog.network.error("\(line)")
         }
     }
 
@@ -683,7 +741,12 @@ actor CFAPIClient {
     private static func cfErrorSummary(_ data: Data) -> String {
         guard let env = try? JSONDecoder().decode(CFAPIResponse<EmptyResponse>.self, from: data),
               let first = env.errors.first else { return "" }
-        return " cf=\(first.code) \(first.message)"
+        // documentation_url（2026-08-20 起 CF 在 4xx 回的所需权限文档）与 source.pointer
+        // （出错字段的 JSON Pointer）都进日志：403/权限类问题排查时这两条最省事。
+        var line = " cf=\(first.code) \(first.message)"
+        if let pointer = first.source?.pointer { line += " at \(pointer)" }
+        if let doc = first.documentationURL { line += " doc=\(doc)" }
+        return line
     }
 
     /// 响应体大小（便于发现「200 但空结果」）
@@ -695,7 +758,8 @@ actor CFAPIClient {
     private static func mapHTTPError(status: Int, data: Data) -> APIError {
         if let envelope = try? JSONDecoder().decode(CFAPIResponse<EmptyResponse>.self, from: data),
            let first = envelope.errors.first {
-            return .cloudflareError(code: first.code, message: first.message)
+            return .cloudflareError(code: first.code, message: first.message,
+                                    documentationURL: first.documentationURL)
         }
         switch status {
         case 401:       return .unauthorized

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/System/BackgroundRefresh.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/System/BackgroundRefresh.swift
@@ -44,7 +44,8 @@ enum BackgroundRefresh {
                 await run(task: refreshTask)
             }
             refreshTask.expirationHandler = {
-                AppLog.background.error("BGAppRefresh expired (system cut off)")
+                // 系统按预算收回后台时间是常态，不是故障：记 notice 不进遥测
+                AppLog.background.notice("BGAppRefresh expired (system cut off)")
                 work.cancel()
                 refreshTask.setTaskCompleted(success: false)
             }

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -75882,6 +75882,82 @@
         }
       }
     },
+    "授权页面已失效，请重新发起登录。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صفحة التفويض لم تعد صالحة. يرجى بدء تسجيل الدخول من جديد."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Autorisierungsseite ist nicht mehr gültig. Bitte starte die Anmeldung erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The authorization page is no longer valid. Please start signing in again."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La página de autorización ya no es válida. Vuelve a iniciar sesión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La page d’autorisation n’est plus valide. Veuillez relancer la connexion."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "認証ページの有効期限が切れました。もう一度ログインしてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인증 페이지가 만료되었습니다. 로그인을 다시 시작하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A página de autorização não é mais válida. Inicie o login novamente."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A página de autorização deixou de ser válida. Inicie a sessão novamente."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yetkilendirme sayfası geçerliliğini yitirdi. Lütfen oturum açmayı yeniden başlatın."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授權頁面已失效，請重新發起登入。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授權頁面已失效，請重新發起登入。"
+          }
+        }
+      }
+    },
     "授权请求包含 Cloudflare 尚未对本 App 开放的权限，无法完成登录。请更新到最新版本后重试。": {
       "localizations": {
         "ar": {
@@ -138697,6 +138773,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "部分中斷"
+          }
+        }
+      }
+    },
+    "部分周期数据需付费版 Cloudflare 账号，显示为 0 的项非加载失败": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بعض بيانات الفترة تتطلب حساب Cloudflare مدفوعًا. العناصر التي تظهر 0 ليست أخطاء تحميل."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einige Zeitraumdaten erfordern ein kostenpflichtiges Cloudflare-Konto. Einträge mit 0 sind keine Ladefehler."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some period data requires a paid Cloudflare account. Items showing 0 aren’t load failures."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algunos datos del periodo requieren una cuenta de pago de Cloudflare. Los elementos que muestran 0 no son errores de carga."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certaines données de la période nécessitent un compte Cloudflare payant. Les éléments affichant 0 ne sont pas des échecs de chargement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部の期間のデータには有料の Cloudflare アカウントが必要です。0 と表示される項目は読み込み失敗ではありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일부 주기 데이터에는 유료 Cloudflare 계정이 필요합니다. 0으로 표시된 항목은 불러오기 실패가 아닙니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguns dados do período exigem uma conta paga da Cloudflare. Os itens que mostram 0 não são falhas de carregamento."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguns dados do período requerem uma conta paga da Cloudflare. Os itens que mostram 0 não são falhas de carregamento."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bazı dönem verileri ücretli bir Cloudflare hesabı gerektirir. 0 görünen öğeler yükleme hatası değildir."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分週期數據需付費版 Cloudflare 帳戶，顯示為 0 的項目並非載入失敗"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分週期資料需付費版 Cloudflare 帳號，顯示為 0 的項目並非載入失敗"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/CFAPIResponse.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/CFAPIResponse.swift
@@ -49,6 +49,31 @@ nonisolated struct CFAPIResponseArray<T: Codable & Sendable>: Codable, Sendable 
 nonisolated struct CFAPIError: Codable, Sendable {
     let code:    Int
     let message: String
+    /// 2026-08-20 起 CF 在 4xx（尤其 403）的错误体里带上该端点所需角色/权限的文档地址。
+    /// 老端点与旧响应可能没有，故为可选。
+    let documentationURL: String?
+    /// 出错字段的 JSON Pointer（如 "/body/rules/0/action"），字段级校验失败时才有。
+    let source: CFAPIErrorSource?
+
+    enum CodingKeys: String, CodingKey {
+        case code, message, source
+        case documentationURL = "documentation_url"
+    }
+
+    /// 两个新字段一律宽容解码：它们只是排查用的附加信息，形态不合预期时也绝不能
+    /// 拖垮整条错误的解码——外层 `errors` 解不出会整体降级为空数组，把 code/message
+    /// 一起丢掉，错误信息反而不如加字段之前。
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        code    = try c.decode(Int.self, forKey: .code)
+        message = try c.decode(String.self, forKey: .message)
+        documentationURL = try? c.decodeIfPresent(String.self, forKey: .documentationURL)
+        source           = try? c.decodeIfPresent(CFAPIErrorSource.self, forKey: .source)
+    }
+}
+
+nonisolated struct CFAPIErrorSource: Codable, Sendable {
+    let pointer: String?
 }
 
 nonisolated struct CFAPIMessage: Codable, Sendable {
@@ -84,13 +109,17 @@ nonisolated struct EmptyResponse: Codable, Sendable {}
 extension CFAPIResponse {
     func toAPIError() -> APIError {
         let err = errors.first
-        return .cloudflareError(code: err?.code ?? 0, message: err?.message ?? String(localized: "未知错误"))
+        return .cloudflareError(code: err?.code ?? 0,
+                                message: err?.message ?? String(localized: "未知错误"),
+                                documentationURL: err?.documentationURL)
     }
 }
 
 extension CFAPIResponseArray {
     func toAPIError() -> APIError {
         let err = errors.first
-        return .cloudflareError(code: err?.code ?? 0, message: err?.message ?? String(localized: "未知错误"))
+        return .cloudflareError(code: err?.code ?? 0,
+                                message: err?.message ?? String(localized: "未知错误"),
+                                documentationURL: err?.documentationURL)
     }
 }

--- a/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Orange_CloudApp.swift
@@ -21,8 +21,6 @@ struct Orange_CloudApp: App {
     @AppStorage(AppAppearance.storageKey) private var appearanceRaw = AppAppearance.system.rawValue
     @AppStorage(AppMotion.storageKey) private var reduceAnimations = false
 
-    let sharedModelContainer = CacheContainer.shared
-
     init() {
         // 最先安装崩溃捕获，让启动期任意一步崩溃都能被记录、随下次反馈带出。
         CrashReporter.install()
@@ -78,7 +76,9 @@ struct Orange_CloudApp: App {
                     handleSpotlightTap(activity)
                 }
         }
-        .modelContainer(sharedModelContainer)
+        // 这里必须现取：App.init 的 warmUp 自检可能已把坏掉的容器换掉（见 CacheContainer），
+        // 提前存成属性会让 @Query 绑在旧容器上。
+        .modelContainer(CacheContainer.shared)
         .onChange(of: scenePhase) {
             AppLog.app.info("scenePhase -> \(String(describing: scenePhase))")
             if scenePhase == .background {

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/AnalyticsService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/AnalyticsService.swift
@@ -342,8 +342,15 @@ struct AnalyticsService {
 
     /// 账号用量：Workers 调用（今日/周期）。R2 拆为独立查询（见 r2Usage），
     /// 账号无 R2 / 无 R2 数据集权限时不再拖垮 Workers 用量（issue #4）。
-    func accountUsage(accountId: String, periodStart: Date? = nil) async throws -> AccountUsage {
-        let data: AccountUsageData = try await client.graphQL(
+    ///
+    /// partialAuthz = 只有部分时间窗被 authz 挡（免费账号常见：今日有数、周期没有），
+    /// 此时返回的用量里缺的那部分是 0，调用方据此给出「部分数据不可用」的温和提示，
+    /// 而不是把整块用量降级成「此账号无账户级数据查询权限」。
+    func accountUsage(
+        accountId: String,
+        periodStart: Date? = nil
+    ) async throws -> (usage: AccountUsage, partialAuthz: Bool) {
+        let (data, partialAuthz): (AccountUsageData, Bool) = try await client.graphQLAllowingPartialAuthz(
             query: AccountUsageQuery.text,
             variables: Self.usageVariables(accountId: accountId, periodStart: periodStart)
         )
@@ -359,14 +366,17 @@ struct AnalyticsService {
         let todayRequests = (account.today ?? []).reduce(0) { $0 + ($1.sum?.requests ?? 0) }
         let quantiles = account.month?.first?.quantiles
 
-        return AccountUsage(
-            workersRequestsToday: todayRequests,
-            workersRequestsMonth: monthSum.requests,
-            workersErrorsMonth:   monthSum.errors,
-            cpuP50Us:             quantiles?.cpuTimeP50,
-            cpuP99Us:             quantiles?.cpuTimeP99,
-            cpuTimeMonthUs:       nil,
-            cpuTimeTodayUs:       nil
+        return (
+            AccountUsage(
+                workersRequestsToday: todayRequests,
+                workersRequestsMonth: monthSum.requests,
+                workersErrorsMonth:   monthSum.errors,
+                cpuP50Us:             quantiles?.cpuTimeP50,
+                cpuP99Us:             quantiles?.cpuTimeP99,
+                cpuTimeMonthUs:       nil,
+                cpuTimeTodayUs:       nil
+            ),
+            partialAuthz
         )
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/BulkRedirectService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/BulkRedirectService.swift
@@ -116,9 +116,9 @@ struct BulkRedirectService {
             return ruleset
         } catch APIError.notFound {
             return nil
-        } catch let APIError.cloudflareError(code, message) {
+        } catch let APIError.cloudflareError(code, message, docURL) {
             if message.localizedCaseInsensitiveContains("could not find entrypoint") { return nil }
-            throw APIError.cloudflareError(code: code, message: message)
+            throw APIError.cloudflareError(code: code, message: message, documentationURL: docURL)
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/CacheRuleService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/CacheRuleService.swift
@@ -30,11 +30,11 @@ struct CacheRuleService {
             return ruleset
         } catch APIError.notFound {
             return nil
-        } catch let APIError.cloudflareError(code, message) {
+        } catch let APIError.cloudflareError(code, message, docURL) {
             if message.localizedCaseInsensitiveContains("could not find entrypoint") {
                 return nil
             }
-            throw APIError.cloudflareError(code: code, message: message)
+            throw APIError.cloudflareError(code: code, message: message, documentationURL: docURL)
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/RateLimitService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/RateLimitService.swift
@@ -30,11 +30,11 @@ struct RateLimitService {
             return ruleset
         } catch APIError.notFound {
             return nil
-        } catch let APIError.cloudflareError(code, message) {
+        } catch let APIError.cloudflareError(code, message, docURL) {
             if message.localizedCaseInsensitiveContains("could not find entrypoint") {
                 return nil
             }
-            throw APIError.cloudflareError(code: code, message: message)
+            throw APIError.cloudflareError(code: code, message: message, documentationURL: docURL)
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/TransformRuleService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/TransformRuleService.swift
@@ -29,11 +29,11 @@ struct TransformRuleService {
             return ruleset
         } catch APIError.notFound {
             return nil
-        } catch let APIError.cloudflareError(code, message) {
+        } catch let APIError.cloudflareError(code, message, docURL) {
             if message.localizedCaseInsensitiveContains("could not find entrypoint") {
                 return nil
             }
-            throw APIError.cloudflareError(code: code, message: message)
+            throw APIError.cloudflareError(code: code, message: message, documentationURL: docURL)
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WAFService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WAFService.swift
@@ -29,11 +29,11 @@ struct WAFService {
             return ruleset
         } catch APIError.notFound {
             return nil
-        } catch let APIError.cloudflareError(code, message) {
+        } catch let APIError.cloudflareError(code, message, docURL) {
             if message.localizedCaseInsensitiveContains("could not find entrypoint") {
                 return nil
             }
-            throw APIError.cloudflareError(code: code, message: message)
+            throw APIError.cloudflareError(code: code, message: message, documentationURL: docURL)
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/ZoneRulesetService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/ZoneRulesetService.swift
@@ -34,11 +34,11 @@ struct ZoneRulesetService {
             return ruleset
         } catch APIError.notFound {
             return nil
-        } catch let APIError.cloudflareError(code, message) {
+        } catch let APIError.cloudflareError(code, message, docURL) {
             if message.localizedCaseInsensitiveContains("could not find entrypoint") {
                 return nil
             }
-            throw APIError.cloudflareError(code: code, message: message)
+            throw APIError.cloudflareError(code: code, message: message, documentationURL: docURL)
         }
     }
 

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/DashboardViewModel.swift
@@ -32,6 +32,9 @@ final class DashboardViewModel {
     private(set) var usageLoadFailed = false
     /// 账户级数据集未授权（免费账号常态）：UI 显示「无账户级数据权限」而非重试，且停发后续账户级查询
     private(set) var accountAnalyticsUnavailable = false
+    /// 账户级数据只有部分时间窗被 authz 挡（如今日有数、本周期没有）：用量照常显示，
+    /// 只在宫格上方加一条温和提示，说明缺的那部分显示为 0 不是加载失败
+    private(set) var accountAnalyticsPartial = false
 
     // MARK: - 资源清单（命令搜索 / 跨类型置顶 / 告警中心共用）
     // 域名与 Workers 直接读 SwiftData 缓存，这里只补拉「概览页原本不持有」的四类；
@@ -263,6 +266,7 @@ final class DashboardViewModel {
         // 下拉刷新（force）会重探，便于用户升级套餐后自动恢复。
         if !force, analyticsUnavailableForAccount == accountId {
             accountAnalyticsUnavailable = true
+            accountAnalyticsPartial = false
             return
         }
 
@@ -298,13 +302,19 @@ final class DashboardViewModel {
 
         // Workers 用量（账号级 GraphQL）。注意 HTTP 200 不代表 GraphQL 成功——Cloudflare 即使
         // 数据集报错也回 200，错误在响应体 errors 里（CFAPIClient.graphQL 会记 "graphQL error"）。
-        // Workers 是账户级 analytics 的代表：命中 authz = 整账号无账户级数据权限（CF 的 authz 是
-        // 账号级、各账户级数据集同进同退）→ 直接降级并停发 R2/D1/KV/CPU 等其余注定失败的查询。
+        // Workers 是账户级 analytics 的代表：authz 且信封里连数据都没有 = 整账号无账户级数据权限
+        // → 直接降级并停发 R2/D1/KV/CPU 等其余注定失败的查询。
+        // 但 authz 也可能只挡住部分时间窗（免费账号：今日有数、本周期没有），此时 CF 照常回已授权
+        // 字段，CFAPIClient 会把它连同 partialAuthz 一起给回来——那种情况不降级，照常显示并加提示。
         let workers: AccountUsage?
+        var partialAuthz = false
         do {
-            workers = try await analyticsService.accountUsage(accountId: accountId, periodStart: periodStart)
+            let result = try await analyticsService.accountUsage(accountId: accountId, periodStart: periodStart)
+            workers = result.usage
+            partialAuthz = result.partialAuthz
         } catch let error as APIError where error.isAccountNotAuthorized {
             accountAnalyticsUnavailable = true
+            accountAnalyticsPartial = false
             analyticsUnavailableForAccount = accountId
             self.usage = nil
             usageLoadFailed = false
@@ -317,6 +327,7 @@ final class DashboardViewModel {
 
         // 账户级有权限（或仅 Workers 本次临时失败）：清除不可用态
         accountAnalyticsUnavailable = false
+        accountAnalyticsPartial = partialAuthz
         analyticsUnavailableForAccount = nil
 
         var usage = workers ?? AccountUsage(

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Dashboard/DashboardView.swift
@@ -814,6 +814,13 @@ private struct DashboardHomeView: View {
                     .padding(.vertical, 16)
                     .glassIsland(cornerRadius: OCLayout.chipRadius)
             } else if let usage = viewModel.usage {
+                if viewModel.accountAnalyticsPartial {
+                    // 部分时间窗被 authz 挡（免费账号常见）：数据照常显示，
+                    // 只说明缺的那部分为 0 是权限所致，不是加载失败
+                    Label("部分周期数据需付费版 Cloudflare 账号，显示为 0 的项非加载失败", systemImage: "info.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
                 usageGrid(usage)
             } else if viewModel.accountAnalyticsUnavailable {
                 accountAnalyticsUnavailableCard


### PR DESCRIPTION
[中文]
- 缓存容器（Sentry APPLE-IOS-1）：坏的不是 store 文件而是整个 ModelContainer 的
  实体注册——同一会话里 warmUp / syncZones / syncWorkers / dnsRecordCount 全部抛
  "could not locate an NSEntityDescription"，次数一比一对应。旧的「标记 → 下次启动
  清库」既治不好又让这批用户每次启动白丢一次缓存。改为 App.init 里探针自检，坏了
  当场三级降级：换新容器（磁盘数据保留）→ 仍坏才清库 → 再坏退内存容器。
  Orange_CloudApp 不再提前存 sharedModelContainer，改为现取，否则 @Query 会绑在
  被换掉的旧容器上。健康计数从 UserDefaults 跨启动改为进程内，异常详情每进程只按
  error 记一次（坏容器让每个调用点反复抛，逐次记会被遥测放大成成百上千条同源事件）
- 登录（Sentry APPLE-IOS-5）：授权途中后退 / 刷新导致 Hydra 的一次性 consent
  verifier 被重复消费，新增 AuthError.consentExpired 给出中文提示而非甩英文原文；
  与 stateMismatch 一起归为「重来即可」的一次性状态，记 notice 不进遥测
- CF 错误体新字段：接入 documentation_url（该端点所需权限文档）与 source.pointer
  （出错字段的 JSON Pointer），两者一律宽容解码——形态不合预期也不能拖垮整条错误的
  解码，否则 errors 整体降级为空数组会把 code/message 一起丢掉。APIError
  .cloudflareError 随之多一个带默认值的 documentationURL 参数
- 账户级用量：GraphQL 允许「部分字段 authz、其余照常返回」（免费账号常见：今日有数、
  本周期没有）。原来只要出现 authz 就抛 accountNotAuthorized，把已经解出来的 data
  一起扔掉，概览用量整块误降级。新增 graphQLAllowingPartialAuthz，解出 data 就返回
  并标 partialAuthz，只有 data 为空才是真·整账号无权限；概览加一条温和提示说明显示
  为 0 的项不是加载失败
- 遥测分级：非 2xx 从两档改为 info / notice / error 三档，带 CF 业务码的 4xx 一律
  notice（接口已明确告知不被接受，原因也已展示给用户），只有无业务码的 4xx 与全部
  5xx 才是 error；传输层的环境类失败（超时 / 断网 / DNS / TLS）与 BGAppRefresh 被
  系统按预算收回同样降 notice
- 新文案 2 键 12 语进 Localizable.xcstrings

[English]
- Cache container (Sentry APPLE-IOS-1): the store file was never the problem —
  the whole ModelContainer's entity registration is dead, with warmUp,
  syncZones, syncWorkers and the dnsRecordCount write-back all throwing
  "could not locate an NSEntityDescription" in the same session, one for one.
  The old "flag it, wipe on next launch" approach neither fixed it nor spared
  those users a discarded cache on every launch. Now App.init probes the
  container and repairs it in place: swap in a fresh container (keeping the
  data on disk), wipe the store only if that still fails, fall back to an
  in-memory container as a last resort. Orange_CloudApp no longer holds
  sharedModelContainer in a property — it reads CacheContainer.shared at use
  site, otherwise @Query stays bound to the discarded container. Health
  counting moved from cross-launch UserDefaults to per-process state, and the
  exception detail is logged at error level only once per process (a broken
  container makes every call site throw repeatedly, which telemetry would
  otherwise amplify into hundreds of identical events)
- Sign-in (Sentry APPLE-IOS-5): going back or refreshing during authorization
  makes Hydra reject the reused one-shot consent verifier. Adds
  AuthError.consentExpired with a localized message instead of the raw English
  text, grouped with stateMismatch as retriable flow states that log at notice
  and stay out of telemetry
- New CF error fields: picks up documentation_url (docs for the permissions the
  endpoint needs) and source.pointer (JSON Pointer of the offending field),
  both decoded leniently — an unexpected shape must never take down decoding of
  the whole error, since a failed errors array would drop code and message too.
  APIError.cloudflareError gains a defaulted documentationURL parameter
- Account-level usage: GraphQL can deny some fields while returning the rest
  (typical on free accounts: today has data, the billing period does not).
  Previously any authz error threw accountNotAuthorized and discarded the data
  that had already decoded, collapsing the whole usage panel. Adds
  graphQLAllowingPartialAuthz, which returns the decoded data flagged as
  partial and only throws when there is no data at all; the dashboard shows a
  quiet note that zeros are not load failures
- Telemetry levels: non-2xx responses go from two buckets to info/notice/error.
  A 4xx carrying a CF error code is now notice (the API stated the request was
  not accepted and the reason is already shown to the user); only a 4xx without
  a code and any 5xx stay error. Environmental transport failures (timeout,
  connection lost, DNS, TLS) and BGAppRefresh being cut off by the system are
  likewise downgraded to notice
- 2 new strings localized into 12 languages
