### PR TITLE
feat(web): /guides 新增英文指南「Cloudflare Error 521: Web Server Is Down」

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-error-521-web-server-is-down/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-521-web-server-is-down/page.tsx
@@ -1,0 +1,381 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import Error521Refusal from "@/components/guides/Error521Refusal";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-error-521-web-server-is-down");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_521 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521/";
+const DOCS_522 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/";
+const DOCS_523 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-523/";
+const DOCS_5XX = "https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/";
+const DOCS_IPS = "https://www.cloudflare.com/ips/";
+const DOCS_SSL_MODES = "https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/";
+const DOCS_ORIGIN_CA = "https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What does Cloudflare error 521 mean?",
+		a: "It means the origin web server refused the connection Cloudflare tried to open. Cloudflare reached your server's address and got an immediate rejection rather than a response, so it returned error 521, web server is down, to the visitor.",
+	},
+	{
+		q: "What is the difference between error 521 and error 522?",
+		a: "Both describe the same hop between Cloudflare and your origin, but not the same behaviour. A 521 error means the origin actively refused the connection, so Cloudflare knew straight away. A 522 means the origin said nothing at all and Cloudflare gave up after 19 seconds. A firewall that rejects packets produces 521; the same firewall set to drop them produces 522.",
+	},
+	{
+		q: "Can I fix a 521 error from the Cloudflare dashboard?",
+		a: "Usually not, because the fault is at your origin rather than at Cloudflare. The one exception worth checking first is the SSL/TLS encryption mode, which decides whether Cloudflare connects to port 80 or port 443 at your origin. If the mode was changed to Full or Full (strict) and your server only listens on port 80, error 521 starts immediately and changing that setting back stops it.",
+	},
+	{
+		q: "Why do I get a 521 error only after switching to Full (strict)?",
+		a: "Because the encryption mode changes which port Cloudflare connects to. Cloudflare connects to port 80 in Flexible mode, and to port 443 in Full and Full (strict). A server configured for plain HTTP only is not listening on 443, so it refuses the connection and every request returns error 521 until HTTPS is enabled at the origin.",
+	},
+	{
+		q: "I am a visitor, not the site owner. Can I do anything about a 521?",
+		a: "No. Error 521 is generated at Cloudflare's edge because the website's own server refused the connection, and nothing on your device or network causes it. Cloudflare's support policy is that site visitors should report the problem to the site owner; reloading later is the only useful action.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/cloudflare-error-522-connection-timed-out",
+		label: "Cloudflare error 522: connection timed out",
+		note: "The silent twin of this error — same hop, same firewall, but packets dropped instead of refused.",
+	},
+	{
+		href: "/guides/cloudflare-ssl-tls-encryption-modes",
+		label: "Which Cloudflare SSL/TLS encryption mode should you use?",
+		note: "The setting that decides whether Cloudflare knocks on port 80 or port 443 — and so whether your origin refuses it.",
+	},
+	{
+		href: "/guides/cloudflare-error-1000-dns-points-to-prohibited-ip",
+		label: "Cloudflare error 1000: DNS points to prohibited IP",
+		note: "The four-digit family: what happens when the address Cloudflare resolved is Cloudflare's own.",
+	},
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "A 521 can only happen on a proxied record — here is what proxying puts in front of your origin.",
+	},
+	{
+		href: DOCS_521,
+		label: "Cloudflare docs: Error 521",
+		note: "The official reference, including the full resolution checklist to hand your hosting provider.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+const PORT_CHECK = `# On the origin, list what is actually listening
+ss -lntp | grep -E ':(80|443)\\s'
+
+# From anywhere, knock on the origin address directly
+curl -sv --connect-timeout 5 https://203.0.113.10/ --resolve example.com:443:203.0.113.10`;
+
+export default async function Error521Guide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="The error page blames your web server, and it is right — but “down” covers four different situations, and one of them is a Cloudflare setting you changed yourself."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>
+							Cloudflare error 521 means your origin server refused the connection Cloudflare tried to open.
+						</strong>{" "}
+						Something answered, and the answer was no. Either the web server is not running, or it is not
+						listening on the port your encryption mode requires.
+					</p>
+				</div>
+
+				<p>
+					Error 521 is generated at Cloudflare&rsquo;s edge, not by your application, so none of your own error
+					handling runs and none of your logs necessarily record it. That is already useful information: the
+					visitor reached Cloudflare perfectly well, so whatever is broken sits on the second hop, between
+					Cloudflare and your server. Your browser records the response as HTTP status 521, which is not a
+					standard status code at all — it is one Cloudflare defines for itself, so &ldquo;Cloudflare 521&rdquo;
+					and &ldquo;error code 521&rdquo; describe the same single thing. A 521 error also only happens on a{" "}
+					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">proxied record</Link> — on a DNS-only
+					record there is no proxy in the path to be refused, and the visitor would simply see your server&rsquo;s
+					own failure instead.
+				</p>
+
+				<h2 id="refused">Refused, not unreachable</h2>
+				<Error521Refusal />
+				<p>
+					Cloudflare defines error 521 as the origin web server{" "}
+					<a href={DOCS_521} target="_blank" rel="noopener noreferrer">
+						refusing connections
+					</a>
+					, and that word does most of the diagnostic work. A refusal is a reply. Your server, or something in
+					front of it, received Cloudflare&rsquo;s packet and sent back a TCP reset — the same thing that produces{" "}
+					<code>connection refused</code> when you run <code>curl</code> against a port with nothing behind it.
+					Because it is a reply rather than a wait, a 521 error appears almost instantly.
+				</p>
+				<p>
+					This is the cleanest way to tell it apart from its neighbours. If Cloudflare had been ignored rather
+					than refused it would have kept retrying and reported{" "}
+					<Link href="/guides/cloudflare-error-522-connection-timed-out">522 after 19 seconds</Link>. If there
+					had been no network route to your address at all, it would have reported 523. One misconfigured
+					firewall can produce either 521 or 522 depending on a single word in the rule: <code>REJECT</code>{" "}
+					sends the reset and gets you a 521, <code>DROP</code> stays quiet and gets you a 522.
+				</p>
+
+				<h2 id="ports">The cause people miss: which port Cloudflare knocks on</h2>
+				<p>
+					Before touching the firewall, check this, because it is the one cause of error 521 that originates in
+					the Cloudflare dashboard rather than at your origin. Your{" "}
+					<Link href="/guides/cloudflare-ssl-tls-encryption-modes">SSL/TLS encryption mode</Link> decides which
+					port Cloudflare opens a connection to at your server, and Cloudflare&rsquo;s own 521 documentation
+					states the mapping plainly:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Encryption mode</th>
+								<th scope="col">Origin port Cloudflare connects to</th>
+								<th scope="col">What the origin must have</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Flexible</th>
+								<td>
+									Port <code>80</code>
+								</td>
+								<td>A plain HTTP listener. No certificate needed on this hop.</td>
+							</tr>
+							<tr>
+								<th scope="row">Full</th>
+								<td>
+									Port <code>443</code>
+								</td>
+								<td>HTTPS enabled. Any certificate, including a self-signed one.</td>
+							</tr>
+							<tr>
+								<th scope="row">Full (strict)</th>
+								<td>
+									Port <code>443</code>
+								</td>
+								<td>
+									HTTPS enabled with a certificate that validates — a public CA, or a{" "}
+									<a href={DOCS_ORIGIN_CA} target="_blank" rel="noopener noreferrer">
+										Cloudflare Origin CA
+									</a>{" "}
+									certificate.
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					So a server that only ever spoke plain HTTP is refusing connections on port 443 the moment the mode
+					moves to Full or Full (strict) — nothing is bound there, so the kernel resets every incoming
+					connection, and every request returns error 521 from then on. This is why 521 errors so often start
+					right after somebody &ldquo;improved the SSL settings&rdquo;, and why the fix is either to enable HTTPS
+					at the origin or to move the mode back. Note that this is a different failure from a bad certificate:
+					if your origin does answer on 443 but presents a certificate Cloudflare will not accept, you get 526
+					rather than 521.
+				</p>
+
+				<h2 id="causes">The four causes, in the order worth checking</h2>
+				<ol>
+					<li>
+						<strong>The web server process is not running.</strong> Cloudflare lists an offlined origin
+						application as one of the two most common causes. A crashed <code>nginx</code>, an{" "}
+						<code>httpd</code> that failed to restart after a config reload, or a container that exited will
+						all refuse connections while the host itself stays perfectly reachable. Check the service status
+						and the origin error log for the crash.
+					</li>
+					<li>
+						<strong>The server is running but not on the port your mode needs.</strong> The case above: bound
+						to <code>80</code> while Cloudflare is knocking on <code>443</code>, or the reverse.
+					</li>
+					<li>
+						<strong>A firewall is rejecting Cloudflare&rsquo;s addresses.</strong> The other most common cause.
+						Security software at the origin may block legitimate connections from particular Cloudflare IPs,
+						so Cloudflare&rsquo;s advice is to allow{" "}
+						<a href={DOCS_IPS} target="_blank" rel="noopener noreferrer">
+							all Cloudflare IP ranges
+						</a>{" "}
+						at the origin rather than a subset. Rate limiting counts here too: a rule that trips after a burst
+						will produce intermittent 521 errors that look like a flapping server.
+					</li>
+					<li>
+						<strong>The origin does not support HTTPS at all.</strong> Distinct from being bound to the wrong
+						port — the service is there, but TLS was never configured. The remedy is the same as case two,
+						with more work: install a certificate, or drop back to a mode that uses port 80 while you do.
+					</li>
+				</ol>
+
+				<h2 id="confirm">Confirming it yourself</h2>
+				<p>
+					Both of the checks that matter can be run in a minute. The first asks your origin what it is actually
+					listening on; the second bypasses Cloudflare entirely and knocks on the origin address directly, so a{" "}
+					<code>connection refused</code> here reproduces the 521 error outside the proxy and proves the fault is
+					not Cloudflare&rsquo;s.
+				</p>
+				<pre>
+					<code>{PORT_CHECK}</code>
+				</pre>
+				<p>
+					If the direct request succeeds while the proxied one still returns a 521 error, the difference is
+					almost always which addresses are allowed: your own IP is permitted and Cloudflare&rsquo;s ranges are
+					not. If the direct request is refused too, the origin is at fault regardless of Cloudflare, and the
+					first two causes above are where to look.
+				</p>
+
+				<h2 id="neighbours">Where 521 sits among the origin errors</h2>
+				<p>
+					The whole 52x family describes the Cloudflare-to-origin hop, and they are distinguished only by how
+					the origin failed:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Error</th>
+								<th scope="col">What the origin did</th>
+								<th scope="col">Typical first move</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_521} target="_blank" rel="noopener noreferrer">
+										521
+									</a>
+								</th>
+								<td>Refused immediately — sent a reset</td>
+								<td>Confirm the service runs and listens on the port your encryption mode needs</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_522} target="_blank" rel="noopener noreferrer">
+										522
+									</a>
+								</th>
+								<td>Said nothing until the clock ran out</td>
+								<td>Allow Cloudflare&rsquo;s IP ranges; check whether the origin is overloaded</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_523} target="_blank" rel="noopener noreferrer">
+										523
+									</a>
+								</th>
+								<td>Could not be reached — no route to the address</td>
+								<td>Verify the A record, and the route tables between your network and Cloudflare</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					A short rule for the three: 521 is a refusal, 522 is silence, 523 is no route. When you do escalate,
+					Cloudflare asks you to give your hosting provider the specific error code, the time and timezone it
+					happened, and the exact URL — and to check the logs of any load balancer, cache, proxy or firewall
+					sitting between Cloudflare and the web server, because the cause is not always in the origin&rsquo;s own
+					log. The{" "}
+					<a href={DOCS_5XX} target="_blank" rel="noopener noreferrer">
+						5xx index
+					</a>{" "}
+					covers the rest of the family, and the{" "}
+					<a href={DOCS_SSL_MODES} target="_blank" rel="noopener noreferrer">
+						encryption modes reference
+					</a>{" "}
+					covers the setting behind the port trap above.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
@@ -53,6 +53,11 @@ const FAQ: Array<{ q: string; a: string }> = [
 
 const RELATED: RelatedLink[] = [
 	{
+		href: "/guides/cloudflare-error-521-web-server-is-down",
+		label: "Cloudflare error 521: web server is down",
+		note: "The refusal to this error's silence — same hop, same firewall, one word different in the rule.",
+	},
+	{
 		href: "/guides/cloudflare-error-1000-dns-points-to-prohibited-ip",
 		label: "Cloudflare error 1000: DNS points to prohibited IP",
 		note: "The other error that comes from the origin address in your DNS record — this one because the address is Cloudflare's own.",
@@ -183,8 +188,9 @@ export default async function Error522Guide({ params }: { params: Promise<{ loca
 				<h2 id="where">Where a 522 error happens</h2>
 				<Error522Path />
 				<p>
-					Cloudflare defines error 522 as timing out while contacting the origin web server, and error 521
-					as the origin <em>refusing</em> its connections. That difference is the most useful thing on this
+					Cloudflare defines error 522 as timing out while contacting the origin web server, and{" "}
+					<Link href="/guides/cloudflare-error-521-web-server-is-down">error 521</Link> as the origin{" "}
+					<em>refusing</em> its connections. That difference is the most useful thing on this
 					page. A firewall rule that rejects a packet sends something back, and Cloudflare reports 521; a
 					rule that drops it sends nothing, so Cloudflare keeps retrying until the clock runs out and
 					reports 522. Both are usually the same misconfiguration seen through different firewall policies.

--- a/apps/web/src/components/guides/Error521Refusal.tsx
+++ b/apps/web/src/components/guides/Error521Refusal.tsx
@@ -1,0 +1,124 @@
+/**
+ * Error 521 的位置图：请求到了 Cloudflare 边缘，边缘向源站发起 TCP 连接，
+ * 源站那一侧**主动拒绝**（RST / ECONNREFUSED）—— 于是立刻返回 521。
+ * 与 522 的分界画在同一张图上：被拒绝（有回应）是 521，被静默丢弃才是 522。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function Error521Refusal() {
+	const col = { x: 30, width: 260, rx: 14 };
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 400 404"
+				role="img"
+				aria-label="Where Cloudflare error 521 happens: a visitor reaches the Cloudflare edge normally, the edge opens a TCP connection to the origin server, and the origin answers immediately with a refusal — a TCP reset, meaning nothing is listening on that port or a firewall rejected the packet. Cloudflare returns error 521, web server is down, within a fraction of a second. Had the origin stayed silent instead of refusing, the result would be error 522 after a nineteen second timeout."
+				className="mx-auto block h-auto w-full max-w-[440px]"
+			>
+				<title>Where a Cloudflare 521 error happens on the path to your origin</title>
+
+				{/* 1 · 访客 → 边缘：这一段是通的 */}
+				<rect {...col} y="12" height="52" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="160" y="36" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Visitor
+				</text>
+				<text x="160" y="53" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					reaches Cloudflare normally
+				</text>
+
+				<defs>
+					<marker id="e521-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+					<marker
+						id="e521-arrow-back"
+						viewBox="0 0 8 8"
+						refX="6"
+						refY="4"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto"
+					>
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--t-secondary)" />
+					</marker>
+				</defs>
+
+				<path
+					d="M160 68 L160 96"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e521-arrow)"
+				/>
+
+				{/* 2 · Cloudflare 边缘：向源站发 SYN */}
+				<rect {...col} y="102" height="56" fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="160" y="127" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare edge
+				</text>
+				<text x="160" y="144" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					opens a TCP connection to the origin
+				</text>
+
+				{/* 3 · 去程 SYN + 回程 RST：一来一回，没有等待 */}
+				<path
+					d="M132 162 L132 232"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e521-arrow)"
+				/>
+				<path
+					d="M188 232 L188 162"
+					stroke="var(--t-secondary)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e521-arrow-back)"
+				/>
+				<text x="200" y="190" fontSize="11" fill="var(--t-tertiary)">
+					refused at once
+				</text>
+				<text x="200" y="207" fontSize="11" fill="var(--t-tertiary)">
+					(TCP reset)
+				</text>
+
+				{/* 4 · 源站侧：主动拒绝 */}
+				<rect {...col} y="238" height="56" fill="none" stroke="var(--divider)" strokeDasharray="5 4" />
+				<text x="160" y="263" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-secondary)">
+					Origin server
+				</text>
+				<text x="160" y="280" textAnchor="middle" fontSize="12" fill="var(--t-tertiary)">
+					answers: refused, not silent
+				</text>
+
+				{/* 5 · 结果 */}
+				<path
+					d="M160 300 L160 326"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e521-arrow)"
+				/>
+				<rect
+					{...col}
+					y="332"
+					height="56"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.7"
+					strokeDasharray="5 4"
+				/>
+				<text x="160" y="357" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Error 521
+				</text>
+				<text x="160" y="374" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					web server is down
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				A 521 arrives almost instantly, because the origin answered. Silence on the same hop produces 522 instead,
+				after Cloudflare has spent 19 seconds retrying.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -145,6 +145,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-08-28",
 		readingTime: "8 min read",
 	},
+	{
+		slug: "cloudflare-error-521-web-server-is-down",
+		h1: "Why Am I Getting Cloudflare Error 521: Web Server Is Down?",
+		title: "Cloudflare Error 521: Web Server Is Down, Explained",
+		description:
+			"Error 521 means your origin refused Cloudflare's connection. Either the web server is not running, or it is not listening on the port your SSL mode needs.",
+		blurb:
+			"A refusal, not a timeout — which is why it appears instantly. The four causes, and the one that starts the moment you change an encryption mode.",
+		updated: "2026-09-01",
+		readingTime: "7 min read",
+	},
 ];
 
 export const GUIDES_ZH: GuideMeta[] = [


### PR DESCRIPTION
## 选题依据（本轮 GSC 数据）

**先过修复优先门槛，三条都不触发：**

| 触发条件 | 现状 | 结论 |
|---|---|---|
| 未收录 > 7 天 | `error-522`（5 天）、`real-visitor-ip`（4 天）仍是「已发现 - 尚未编入索引」 | 未到线 |
| 目标词被本站他页抢走 | `what is orange cloud in cloudflare` 由 `/`、`/guides`、O2O 篇、`/privacy` 分食，专文未承接 | **真实存在，但本轮不动**（见下） |
| 零展示且上线 > 14 天 | `why-is-cloudflare-not-caching-my-site` 上线 12 天、0 展示 | 下轮到线 |

第二条虽然成立，但这篇已在 8-23、8-24 两次改打信息型意图，PR #110 又于 **8-30（2 天前）** 刚合入。其表现已从 8-24 提交里记录的 **12 次展示 / 均位 18.3** 涨到现在的 **50 次展示 / 均位 16.0** —— 方向被数据证实有效，而 8-30 那次改动几乎不在 28 天窗口（08-02..08-30）内。此时再改第三次，等于让上一次改动永远无法归因。故本轮记录在案、留待下轮用干净数据复核。

`gaps` 本轮没给出可用线索：标 `[可做]` 的 5 个词（`cloud orange`、`web cloud orange`、`icloud orange`、`one cloud orange`、`ornycloud`）全是品牌名的错拼与词序变体，不是真实选题。

**因此按备选题库出新文，选 Error 521：**

1. 真实搜索问句（"why am I getting 521 / web server is down"）；
2. 属 App 覆盖能力（代理状态、回源、SSL/TLS 模式）；
3. 官方文档可逐条核实（Error 521 页 Last updated 2026-04-23）；
4. 与站内 `error-522`、`error-1000` 同属回源错误簇，形成三向内链；
5. **零品牌词**，不与首页抢导航意图；
6. 变体可枚举且已逐个自然覆盖：`error 521` ×16、`521 error` ×10、`cloudflare error 521` ×5、`web server is down` ×5、`cloudflare 521` ×2、`error code 521` ×1。

对标已验证的成功模式（O2O 篇：窄而具体 + 官方文档之外内容稀缺 + 意图明确），521 同样满足。这也让回源错误文章达到 3 篇，下一轮可建 `/guides/cloudflare-error-codes` 枢纽页聚簇。

## 核对官方文档时的修正 / 取舍

- **端口映射的出处**：原打算引 [ssl-modes](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/) 佐证「Flexible→80、Full/Full (strict)→443」，实际拉下来该页**并未**陈述端口。改引 [Error 521 页](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521/)，它明确写了 "Port 80 for **Flexible**, or Port 443 for **Full** and **Full (Strict)**"。文中据此归因。
- **放弃「Cloudflare 按访客请求端口回源」这类说法**：官方文档未如此表述，未写入。
- **补上 521 与 526 的分界**：源站在 443 上应答但证书不被接受是 526，不是 521 —— 避免读者把证书问题误诊成 521。
- **RST / REJECT vs DROP 的因果**：与 522 文档「19 秒内收不到 SYN+ACK」对读得出，两码同因不同防火墙策略；这是本篇与 522 篇的分工点。
- **访客侧无解**：依 [5xx 索引页](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/) 的 "Cloudflare Support only assists the domain owner"，FAQ 明确告知访客只能联系站长。
- 升级排查所需材料（错误码 / 时间与时区 / 具体 URL，且要查 Cloudflare 与源站之间的 LB、缓存、代理、防火墙日志）同样取自 5xx 索引页。
- 全文未抄官方表格或列表原文，均自行组织并外链。

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警；新路由 `/[locale]/guides/cloudflare-error-521-web-server-is-down` 已生成（en 全量 94,965 B；其余 locale `status: 404`，门控生效） |
| 2 | `npx vitest run` | ✅ 21 文件 / 166 用例全绿 |
| 3 | `npx eslint`（4 个改动文件） | ✅ 无 error 无输出 |
| 4 | dev 服务器新 URL 200 | ⚠️ **本环境无法执行**：`preview_start` 在无人值守的定时任务里被禁用（"Dev servers can't be started from unattended sessions"）。替代验证：直接断言 `next build` 产出的**生产预渲染 HTML**（比 dev 更接近线上），并在合并部署后 curl 线上 URL 复核 |
| 5 | canonical 自引用 + hreflang | ✅ canonical 唯一且自引用；hreflang 恰为 `en` + `x-default`，且都指向本页 |
| 6 | JSON-LD 可解析 + FAQ 逐字一致 | ✅ 脚本断言：2 个 LD 块均 `JSON.parse` 通过，含 `TechArticle`/`FAQPage`/`BreadcrumbList`（另一块是根布局的 `SoftwareApplication`）；5 组问答**逐字**出现在渲染后可见正文 |
| 7 | 标题层级 | ✅ 单 h1，序列 `h1 h2×6 h3×5 h2×2`，无跳级 |
| 8 | 375px 无横向溢出 | ✅ 结构性核验：表格均包 `.table-wrap`（`overflow-x:auto`）、`.prose pre` 亦为 `overflow-x:auto`（长 curl 行内滚）、SVG 为 `w-full max-w-[440px] h-auto` 竖版。与已上线 9 篇同壳同结构。因第 4 项同因，未能跑实测浏览器断言 |
| 9 | 外链 2xx/3xx | ✅ 8 条全部 200（6 条 CF 文档 + cloudflare.com/ips + schema.org）。`203.0.113.10` 是代码示例里的 RFC 5737 文档保留地址，非链接 |
| 10 | 词数 1000–1800 | ✅ 1,461 词 |

附加自检：`<title>` 51 字符（≤60）、meta description 154 字符（≤155，首句即答案）、正文提及 Orange Cloud **0 处**（仅 GuideShell 页脚卡 1 处，红线内）。

## 落地内容

- 新增 `apps/web/src/app/[locale]/guides/cloudflare-error-521-web-server-is-down/page.tsx`
- 新增 `apps/web/src/components/guides/Error521Refusal.tsx`（内联 SVG，走主题 token，带 `role="img"` / `aria-label` / `<title>`，竖版窄屏不溢出）
- `guides.ts` 追加条目（sitemap 自动带上）
- 522 篇补反向内链：`RELATED` 首条 + 正文「error 521」值式内链，成对互链

## 需人工复核

新文上线后需作者本人到 Search Console 提交收录。