### PR TITLE
chore(changelog): iOS 2.1.1 / Android 2.1.2 发布说明（双端 13 语）

### DIFF
--- a/packages/changelog/android.json
+++ b/packages/changelog/android.json
@@ -1,5 +1,45 @@
 [
   {
+    "version": "2.1.2",
+    "date": "2026.09.02",
+    "channel": "Google Play",
+    "items": [
+      {
+        "icon": "square.and.pencil",
+        "title": {
+          "zh-Hans": "触发规则可以直接管理了",
+          "en": "Trigger rules are now editable",
+          "zh-Hant": "觸發規則可以直接管理了",
+          "zh-HK": "觸發規則可以直接管理了",
+          "ja": "トリガールールをアプリから管理",
+          "es-MX": "Ahora administras las reglas de activación",
+          "ko": "트리거 규칙을 앱에서 관리",
+          "pt-BR": "Agora você gerencia as regras de acionamento",
+          "pt-PT": "Já pode gerir as regras de acionamento",
+          "de": "Trigger-Regeln jetzt in der App verwalten",
+          "fr": "Gérez les règles de déclenchement dans l’app",
+          "ar": "إدارة قواعد التشغيل من التطبيق",
+          "tr": "Tetikleme kuralları artık uygulamadan yönetiliyor"
+        },
+        "detail": {
+          "zh-Hans": "Snippet 的触发规则以前只能看，要改得回网页端。现在可以直接添加、编辑、启停和删除，改动也会保住规则原本的顺序。",
+          "en": "A snippet’s trigger rules were read-only — any change meant a detour through the web dashboard. You can now add, edit, toggle and delete them right here, and every change keeps the rules in their original order.",
+          "zh-Hant": "Snippet 的觸發規則以前只能看，要改得回網頁端。現在可以直接新增、編輯、啟停和刪除，改動也會保住規則原本的順序。",
+          "zh-HK": "Snippet 的觸發規則以前只能看，要改就要返網頁端。現在可以直接新增、編輯、啟停和刪除，改動亦會保住規則原本的順序。",
+          "ja": "Snippet のトリガールールはこれまで表示のみで、変更するには Web 側に戻る必要がありました。これからはアプリ内で追加・編集・有効/無効・削除ができ、並び順もそのまま保たれます。",
+          "es-MX": "Las reglas de activación de un snippet solo se podían ver: cualquier cambio obligaba a volver al panel web. Ahora puedes agregarlas, editarlas, activarlas y eliminarlas desde aquí, y cada cambio conserva el orden original de las reglas.",
+          "ko": "Snippet의 트리거 규칙은 보기만 가능해 수정하려면 웹 대시보드로 돌아가야 했습니다. 이제 앱에서 바로 추가·편집·사용/해제·삭제할 수 있고 규칙 순서도 그대로 유지됩니다.",
+          "pt-BR": "As regras de acionamento de um snippet eram somente leitura: qualquer mudança exigia voltar ao painel web. Agora dá para adicionar, editar, ativar e excluir por aqui, e cada alteração mantém a ordem original das regras.",
+          "pt-PT": "As regras de acionamento de um snippet eram apenas de leitura: qualquer alteração obrigava a voltar ao painel web. Agora pode adicioná-las, editá-las, ativá-las e eliminá-las aqui, mantendo a ordem original das regras.",
+          "de": "Die Trigger-Regeln eines Snippets waren nur lesbar – jede Änderung erforderte den Umweg über das Web-Dashboard. Jetzt kannst du sie direkt hinzufügen, bearbeiten, aktivieren und löschen; die ursprüngliche Reihenfolge bleibt dabei erhalten.",
+          "fr": "Les règles de déclenchement d’un snippet étaient en lecture seule : toute modification imposait un détour par le tableau de bord web. Vous pouvez désormais les ajouter, les modifier, les activer et les supprimer ici, sans perdre leur ordre d’origine.",
+          "ar": "كانت قواعد تشغيل الـ Snippet للعرض فقط، وأي تغيير يتطلب العودة إلى لوحة التحكم على الويب. الآن يمكنك إضافتها وتعديلها وتفعيلها وحذفها من هنا، مع الحفاظ على ترتيبها الأصلي.",
+          "tr": "Bir snippet’in tetikleme kuralları yalnızca görüntülenebiliyordu; her değişiklik için web paneline dönmek gerekiyordu. Artık buradan ekleyebilir, düzenleyebilir, açıp kapatabilir ve silebilirsiniz; kuralların özgün sırası da korunur."
+        }
+      }
+    ]
+  },
+  {
     "version": "2.1.1",
     "date": "2026.08.30",
     "channel": "Google Play",

--- a/packages/changelog/ios.json
+++ b/packages/changelog/ios.json
@@ -1,5 +1,45 @@
 [
   {
+    "version": "2.1.1",
+    "date": "2026.09.02",
+    "channel": "App Store",
+    "items": [
+      {
+        "icon": "square.and.pencil",
+        "title": {
+          "zh-Hans": "触发规则可以编辑了",
+          "en": "Trigger rules are now editable",
+          "zh-Hant": "觸發規則可以編輯了",
+          "zh-HK": "觸發規則可以編輯了",
+          "ja": "トリガールールを編集できるように",
+          "es-MX": "Ahora puedes editar las reglas de activación",
+          "ko": "트리거 규칙을 편집할 수 있습니다",
+          "pt-BR": "Agora dá para editar as regras de acionamento",
+          "pt-PT": "Já é possível editar as regras de acionamento",
+          "de": "Trigger-Regeln lassen sich jetzt bearbeiten",
+          "fr": "Les règles de déclenchement sont modifiables",
+          "ar": "يمكن الآن تعديل قواعد التشغيل",
+          "tr": "Tetikleme kuralları artık düzenlenebiliyor"
+        },
+        "detail": {
+          "zh-Hans": "Snippet 的触发规则以前只能新建、启停和删除，改一个字都得删掉重加。现在点按规则就能改表达式和描述，规则原来的顺序也不会因此变动。",
+          "en": "A snippet’s trigger rules could only be added, toggled or deleted — changing a single character meant deleting the rule and creating it again. Now tap a rule to edit its expression and description, and it keeps its place in the order.",
+          "zh-Hant": "Snippet 的觸發規則以前只能新增、啟停和刪除，改一個字都得刪掉重加。現在點按規則就能修改運算式和描述，規則原本的順序也不會因此變動。",
+          "zh-HK": "Snippet 的觸發規則以前只能新增、啟停和刪除，改一個字都要刪掉重加。現在點按規則就能修改運算式和描述，規則原本的順序也不會因此變動。",
+          "ja": "Snippet のトリガールールはこれまで追加・有効/無効・削除しかできず、一文字直すにもルールを削除して作り直す必要がありました。これからはルールをタップして式と説明をそのまま編集でき、並び順も変わりません。",
+          "es-MX": "Las reglas de activación de un snippet solo se podían agregar, activar o eliminar: cambiar un carácter obligaba a borrarlas y volverlas a crear. Ahora toca una regla para editar su expresión y su descripción, y conserva su posición en el orden.",
+          "ko": "Snippet의 트리거 규칙은 지금까지 추가·사용/해제·삭제만 가능해 한 글자만 고쳐도 규칙을 지우고 다시 만들어야 했습니다. 이제 규칙을 탭해 표현식과 설명을 바로 수정할 수 있고 순서도 그대로 유지됩니다.",
+          "pt-BR": "As regras de acionamento de um snippet só podiam ser adicionadas, ativadas ou excluídas — mudar um caractere exigia apagar e recriar a regra. Agora toque em uma regra para editar a expressão e a descrição, e ela mantém a posição na ordem.",
+          "pt-PT": "As regras de acionamento de um snippet só podiam ser adicionadas, ativadas ou eliminadas — mudar um carácter obrigava a apagar e recriar a regra. Agora toque numa regra para editar a expressão e a descrição, mantendo a sua posição na ordem.",
+          "de": "Die Trigger-Regeln eines Snippets ließen sich bisher nur hinzufügen, aktivieren oder löschen – für ein einziges Zeichen musste die Regel gelöscht und neu angelegt werden. Jetzt tippst du eine Regel an und bearbeitest Ausdruck und Beschreibung direkt; ihre Position in der Reihenfolge bleibt erhalten.",
+          "fr": "Les règles de déclenchement d’un snippet ne pouvaient qu’être ajoutées, activées ou supprimées : changer un caractère obligeait à supprimer la règle puis à la recréer. Touchez désormais une règle pour modifier son expression et sa description, sans changer sa position dans l’ordre.",
+          "ar": "كانت قواعد تشغيل الـ Snippet تقبل الإضافة والتفعيل والحذف فقط، وتغيير حرف واحد يستلزم حذف القاعدة وإنشاءها من جديد. الآن انقر على القاعدة لتعديل التعبير والوصف، مع الحفاظ على ترتيبها كما هو.",
+          "tr": "Bir snippet’in tetikleme kuralları yalnızca eklenebiliyor, açılıp kapatılabiliyor veya silinebiliyordu; tek bir karakteri değiştirmek için kuralı silip yeniden oluşturmak gerekiyordu. Artık bir kurala dokunup ifadesini ve açıklamasını düzenleyebilirsiniz, sıradaki yeri de korunur."
+        }
+      }
+    ]
+  },
+  {
     "version": "2.1.0",
     "date": "2026.08.19",
     "channel": "App Store",


### PR DESCRIPTION
## 做了什么

往 `packages/changelog/{ios,android}.json` 顶部各加一条新版条目（13 语），`pnpm changelog:gen` + `pnpm changelog:check` 已过。

- **iOS 2.1.1** — Snippet 触发规则可编辑（原本只能新建 / 启停 / 删除）
- **Android 2.1.2** — Snippet 触发规则可增删改启停（原本整块只读）

两端文案按各自的起点分别写：iOS 是「补上编辑」，Android 是「从只读到可管理」。

## 分支

按 docs/11 的分平台策略，本分支**只带 changelog 源**，官网据此展示；App 内 What's New 的生成物在各自的发版分支：

- `release/ios-2.1.1`
- `release/android-2.1.2`

infra 先合。

关联 issue #128。