### PR TITLE
feat(ios): Snippet 触发规则可编辑，发 2.1.1 (build 43)

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
+++ b/apps/ios/Orange Cloud/Orange Cloud.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -659,7 +659,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -679,7 +679,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OrangeCloudWidgets/OrangeCloudWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrangeCloudWidgets/Info.plist;
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch Watch App/OrangeCloudWatch.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -780,7 +780,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -792,7 +792,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -814,7 +814,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud Watch/OrangeCloudWatchExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud Watch/Info.plist";
@@ -826,7 +826,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.watchkitapp.wdigets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -846,7 +846,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -858,7 +858,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud File/Orange_Cloud_File.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Orange Cloud File/Info.plist";
@@ -888,7 +888,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.Orange-Cloud-File";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -918,7 +918,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -936,7 +936,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = notification/notification.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = notification/Info.plist;
@@ -948,7 +948,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud.notification";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -988,7 +988,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1013,7 +1013,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Orange Cloud/Orange_Cloud.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEVELOPMENT_TEAM = 6G78MMY657;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jiamin.chen.orange-cloud";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings
@@ -1217,6 +1217,82 @@
         }
       }
     },
+    "Snippet 的触发规则以前只能新建、启停和删除，改一个字都得删掉重加。现在点按规则就能改表达式和描述，规则原来的顺序也不会因此变动。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A snippet’s trigger rules could only be added, toggled or deleted — changing a single character meant deleting the rule and creating it again. Now tap a rule to edit its expression and description, and it keeps its place in the order."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snippet 的觸發規則以前只能新增、啟停和刪除，改一個字都得刪掉重加。現在點按規則就能修改運算式和描述，規則原本的順序也不會因此變動。"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snippet 的觸發規則以前只能新增、啟停和刪除，改一個字都要刪掉重加。現在點按規則就能修改運算式和描述，規則原本的順序也不會因此變動。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snippet のトリガールールはこれまで追加・有効/無効・削除しかできず、一文字直すにもルールを削除して作り直す必要がありました。これからはルールをタップして式と説明をそのまま編集でき、並び順も変わりません。"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las reglas de activación de un snippet solo se podían agregar, activar o eliminar: cambiar un carácter obligaba a borrarlas y volverlas a crear. Ahora toca una regla para editar su expresión y su descripción, y conserva su posición en el orden."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snippet의 트리거 규칙은 지금까지 추가·사용/해제·삭제만 가능해 한 글자만 고쳐도 규칙을 지우고 다시 만들어야 했습니다. 이제 규칙을 탭해 표현식과 설명을 바로 수정할 수 있고 순서도 그대로 유지됩니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As regras de acionamento de um snippet só podiam ser adicionadas, ativadas ou excluídas — mudar um caractere exigia apagar e recriar a regra. Agora toque em uma regra para editar a expressão e a descrição, e ela mantém a posição na ordem."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As regras de acionamento de um snippet só podiam ser adicionadas, ativadas ou eliminadas — mudar um carácter obrigava a apagar e recriar a regra. Agora toque numa regra para editar a expressão e a descrição, mantendo a sua posição na ordem."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Trigger-Regeln eines Snippets ließen sich bisher nur hinzufügen, aktivieren oder löschen – für ein einziges Zeichen musste die Regel gelöscht und neu angelegt werden. Jetzt tippst du eine Regel an und bearbeitest Ausdruck und Beschreibung direkt; ihre Position in der Reihenfolge bleibt erhalten."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les règles de déclenchement d’un snippet ne pouvaient qu’être ajoutées, activées ou supprimées : changer un caractère obligeait à supprimer la règle puis à la recréer. Touchez désormais une règle pour modifier son expression et sa description, sans changer sa position dans l’ordre."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كانت قواعد تشغيل الـ Snippet تقبل الإضافة والتفعيل والحذف فقط، وتغيير حرف واحد يستلزم حذف القاعدة وإنشاءها من جديد. الآن انقر على القاعدة لتعديل التعبير والوصف، مع الحفاظ على ترتيبها كما هو."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir snippet’in tetikleme kuralları yalnızca eklenebiliyor, açılıp kapatılabiliyor veya silinebiliyordu; tek bir karakteri değiştirmek için kuralı silip yeniden oluşturmak gerekiyordu. Artık bir kurala dokunup ifadesini ve açıklamasını düzenleyebilirsiniz, sıradaki yeri de korunur."
+          }
+        }
+      }
+    },
     "Snippets": {
       "localizations": {
         "en": {
@@ -10637,6 +10713,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kural Merkezi"
+          }
+        }
+      }
+    },
+    "触发规则可以编辑了": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trigger rules are now editable"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "觸發規則可以編輯了"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "觸發規則可以編輯了"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トリガールールを編集できるように"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora puedes editar las reglas de activación"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트리거 규칙을 편집할 수 있습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agora dá para editar as regras de acionamento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Já é possível editar as regras de acionamento"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trigger-Regeln lassen sich jetzt bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les règles de déclenchement sont modifiables"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يمكن الآن تعديل قواعد التشغيل"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tetikleme kuralları artık düzenlenebiliyor"
           }
         }
       }

--- a/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Core/WhatsNew/WhatsNewReleases.generated.swift
@@ -10,6 +10,13 @@ import Foundation
 
 nonisolated enum WhatsNewGenerated {
     static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(version: "2.1.1", items: [
+            WhatsNewItem(
+                icon:   "square.and.pencil",
+                title:  String(localized: "触发规则可以编辑了", table: "WhatsNew"),
+                detail: String(localized: "Snippet 的触发规则以前只能新建、启停和删除，改一个字都得删掉重加。现在点按规则就能改表达式和描述，规则原来的顺序也不会因此变动。", table: "WhatsNew")
+            )
+        ]),
         WhatsNewRelease(version: "2.1.0", items: [
             WhatsNewItem(
                 icon:   "checkmark.shield",

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -105929,6 +105929,310 @@
         }
       }
     },
+    "编辑触发规则": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعديل قاعدة التشغيل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trigger-Regel bearbeiten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Trigger Rule"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar regla de activación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier la règle de déclenchement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トリガールールを編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트리거 규칙 편집"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar regra de acionamento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar regra de acionamento"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tetikleme kuralını düzenle"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯觸發規則"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯觸發規則"
+          }
+        }
+      }
+    },
+    "该规则已不存在，请刷新后重试。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم تعد هذه القاعدة موجودة. حدِّث ثم أعد المحاولة."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Regel existiert nicht mehr. Aktualisiere und versuche es erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This rule no longer exists. Refresh and try again."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta regla ya no existe. Actualiza e inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette règle n’existe plus. Actualisez, puis réessayez."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このルールは既に存在しません。更新してからやり直してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 규칙은 더 이상 존재하지 않습니다. 새로 고친 후 다시 시도하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta regra não existe mais. Atualize e tente novamente."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta regra já não existe. Atualize e tente novamente."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kural artık mevcut değil. Yenileyip tekrar deneyin."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此規則已不存在，請重新整理後再試。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此規則已不存在，請重新整理後再試。"
+          }
+        }
+      }
+    },
+    "轻点两下编辑规则": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انقر مرتين لتعديل القاعدة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doppeltippen, um die Regel zu bearbeiten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Double-tap to edit the rule"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulsa dos veces para editar la regla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toucher deux fois pour modifier la règle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダブルタップしてルールを編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "두 번 탭하여 규칙 편집"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque duas vezes para editar a regra"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque duas vezes para editar a regra"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuralı düzenlemek için iki kez dokunun"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點兩下以編輯規則"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點兩下以編輯規則"
+          }
+        }
+      }
+    },
+    "规则用 Cloudflare Rules 表达式匹配请求，满足时运行此 Snippet。点按规则可编辑。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطابق القواعد الطلبات باستخدام تعبيرات Cloudflare Rules؛ ويُشغَّل هذا الـ Snippet عند التطابق. انقر على قاعدة لتعديلها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regeln gleichen Anfragen mit Cloudflare-Rules-Ausdrücken ab; dieses Snippet wird bei einer Übereinstimmung ausgeführt. Tippe auf eine Regel, um sie zu bearbeiten."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rules match requests with Cloudflare Rules expressions; this snippet runs on a match. Tap a rule to edit it."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las reglas coinciden con las solicitudes mediante expresiones de Cloudflare Rules; este snippet se ejecuta cuando hay coincidencia. Toca una regla para editarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les règles font correspondre les requêtes via des expressions Cloudflare Rules ; ce snippet s’exécute en cas de correspondance. Touchez une règle pour la modifier."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ルールは Cloudflare Rules 式でリクエストを照合し、一致するとこのスニペットが実行されます。ルールをタップすると編集できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "규칙은 Cloudflare Rules 표현식으로 요청을 일치시키며, 일치하면 이 Snippet이 실행됩니다. 규칙을 탭하면 편집할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As regras correspondem às solicitações com expressões do Cloudflare Rules; este snippet é executado quando há correspondência. Toque em uma regra para editá-la."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As regras correspondem aos pedidos com expressões do Cloudflare Rules; este snippet é executado quando há correspondência. Toque numa regra para a editar."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurallar, istekleri Cloudflare Rules ifadeleriyle eşleştirir; eşleşmede bu snippet çalışır. Düzenlemek için bir kurala dokunun."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規則以 Cloudflare Rules 運算式比對請求，符合時執行此 Snippet。點按規則即可編輯。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規則以 Cloudflare Rules 運算式比對請求，相符時執行此 Snippet。點按規則即可編輯。"
+          }
+        }
+      }
+    },
     "添加触发规则": {
       "localizations": {
         "ar": {

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SnippetsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SnippetsViewModel.swift
@@ -127,7 +127,45 @@ final class SnippetsViewModel {
         let new = SnippetRuleInput(
             snippetName: snippetName, expression: expression, description: description, enabled: enabled
         )
-        let inputs = rules.map { $0.toInput() } + [new]
+        let inputs = await freshRules().map { $0.toInput() } + [new]
+        do {
+            try await service.putRules(zoneId: zoneId, rules: inputs)
+            await reloadRules()
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
+    /// 编辑已存在的规则（表达式 / 描述 / 启停）。整组回写，只替换命中的那一条。
+    func updateRule(
+        _ rule: SnippetRule,
+        expression: String,
+        description: String?,
+        enabled: Bool
+    ) async -> Bool {
+        guard !isSaving else { return false }
+        isSaving = true
+        error = nil
+        defer { isSaving = false }
+
+        let latest = await freshRules()
+        // 规则在别处被删掉时，整组回写会把它「复活」——宁可让用户刷新重来
+        guard latest.contains(where: { $0.id == rule.id }) else {
+            rules = latest
+            self.error = String(localized: "该规则已不存在，请刷新后重试。")
+            return false
+        }
+        let inputs = latest.map { current -> SnippetRuleInput in
+            guard current.id == rule.id else { return current.toInput() }
+            return SnippetRuleInput(
+                snippetName: current.snippetName,
+                expression: expression,
+                description: description,
+                enabled: enabled
+            )
+        }
         do {
             try await service.putRules(zoneId: zoneId, rules: inputs)
             await reloadRules()
@@ -147,6 +185,12 @@ final class SnippetsViewModel {
         } catch {
             self.error = error.localizedDescription
         }
+    }
+
+    /// 整组回写前取一次服务端最新全量：表单停留期间别处的改动不至于被这次 PUT 抹掉。
+    /// 取不到就退回本地缓存——宁可用旧的整组，也不能写出「半份」规则。
+    private func freshRules() async -> [SnippetRule] {
+        (try? await service.rules(zoneId: zoneId)) ?? rules
     }
 
     private func reloadSnippets() async {

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Snippets/SnippetDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Snippets/SnippetDetailView.swift
@@ -2,7 +2,7 @@
 //  SnippetDetailView.swift
 //  Orange Cloud
 //
-//  单个 Snippet：只读代码 + 触发规则（启停/增删）+ 删除 Snippet。
+//  单个 Snippet：只读代码 + 触发规则（启停/增删改）+ 删除 Snippet。
 //  写操作按 snippets.write 门控；规则改动经 ViewModel 整组回写。
 //
 
@@ -23,6 +23,7 @@ struct SnippetDetailView: View {
     @State private var showAddRule = false
     @State private var showDenied = false
     @State private var ruleToDelete: SnippetRule?
+    @State private var ruleToEdit: SnippetRule?
     @State private var showDeleteSnippet = false
 
     private var canWrite: Bool { auth.hasScope("snippets.write") }
@@ -68,6 +69,9 @@ struct SnippetDetailView: View {
                             onToggle: { enabled in
                                 Task { await viewModel.setRule(rule, enabled: enabled) }
                             },
+                            onEdit: {
+                                if canWrite { ruleToEdit = rule } else { showDenied = true }
+                            },
                             onDenied: { showDenied = true }
                         )
                         .swipeActions(edge: .trailing) {
@@ -76,6 +80,12 @@ struct SnippetDetailView: View {
                             } label: {
                                 Label("删除", systemImage: "trash")
                             }
+                            Button {
+                                if canWrite { ruleToEdit = rule } else { showDenied = true }
+                            } label: {
+                                Label("编辑", systemImage: "pencil")
+                            }
+                            .tint(.orange)
                         }
                     }
                 }
@@ -89,7 +99,7 @@ struct SnippetDetailView: View {
                     }
                 }
             } footer: {
-                Text("规则用 Cloudflare Rules 表达式匹配请求，满足时运行此 Snippet。")
+                Text("规则用 Cloudflare Rules 表达式匹配请求，满足时运行此 Snippet。点按规则可编辑。")
             }
             .glassRow()
 
@@ -122,6 +132,9 @@ struct SnippetDetailView: View {
         }
         .sheet(isPresented: $showAddRule) {
             SnippetRuleFormView(viewModel: viewModel, snippetName: snippet.snippetName)
+        }
+        .sheet(item: $ruleToEdit) { rule in
+            SnippetRuleFormView(viewModel: viewModel, snippetName: snippet.snippetName, existing: rule)
         }
         .confirmationDialog(
             "删除规则",
@@ -159,7 +172,7 @@ struct SnippetDetailView: View {
             Text("当前授权未包含 Snippets 编辑权限（snippets.write）。")
         }
         .alert("出错了", isPresented: .init(
-            get: { viewModel.error != nil && !showEditor && !showAddRule },
+            get: { viewModel.error != nil && !showEditor && !showAddRule && ruleToEdit == nil },
             set: { if !$0 { viewModel.error = nil } }
         )) {
             Button("好", role: .cancel) {}
@@ -183,59 +196,88 @@ private struct SnippetRuleRow: View {
     let canWrite: Bool
     let isToggling: Bool
     let onToggle: (Bool) -> Void
+    let onEdit: () -> Void
     let onDenied: () -> Void
 
     private var isEnabled: Bool { rule.enabled ?? true }
 
+    private var title: String {
+        rule.description.map { $0.isEmpty ? String(localized: "未命名规则") : $0 }
+            ?? String(localized: "未命名规则")
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text(rule.description.map { $0.isEmpty ? String(localized: "未命名规则") : $0 }
-                     ?? String(localized: "未命名规则"))
-                    .font(.callout.weight(.semibold))
-                    .lineLimit(1)
-                Spacer()
-                if isToggling {
-                    ProgressView().controlSize(.small)
-                } else if canWrite {
-                    Toggle("", isOn: Binding(get: { isEnabled }, set: { onToggle($0) }))
-                        .labelsHidden()
-                        .accessibilityLabel("启用规则")
-                } else {
-                    Button {
-                        onDenied()
-                    } label: {
-                        Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(isEnabled ? Color.green : Color.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(isEnabled ? "已启用" : "已停用")
-                    .accessibilityHint("需要写入权限才能修改")
+        // 文本区与开关是两个独立点击目标：点文本进编辑，开关只管启停
+        HStack(alignment: .top, spacing: 12) {
+            Button(action: onEdit) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(1)
+                    Text(rule.expression)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                        // Cloudflare Rules 表达式始终 LTR
+                        .environment(\.layoutDirection, .leftToRight)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
-            Text(rule.expression)
-                .font(.caption.monospaced())
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-                .truncationMode(.tail)
+            .buttonStyle(.plain)
+            .accessibilityHint(canWrite
+                               ? String(localized: "轻点两下编辑规则")
+                               : String(localized: "需要写入权限才能修改"))
+
+            if isToggling {
+                ProgressView().controlSize(.small)
+            } else if canWrite {
+                Toggle("", isOn: Binding(get: { isEnabled }, set: { onToggle($0) }))
+                    .labelsHidden()
+                    .accessibilityLabel("启用规则")
+            } else {
+                Button {
+                    onDenied()
+                } label: {
+                    Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(isEnabled ? Color.green : Color.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isEnabled
+                                    ? String(localized: "已启用")
+                                    : String(localized: "已停用"))
+                .accessibilityHint("需要写入权限才能修改")
+            }
         }
         .padding(.vertical, 4)
         .opacity(isEnabled ? 1 : 0.5)
     }
 }
 
-// MARK: - 添加规则表单
+// MARK: - 规则表单（新增 / 编辑共用）
 
 private struct SnippetRuleFormView: View {
 
     let viewModel: SnippetsViewModel
     let snippetName: String
+    /// nil = 新增；非 nil = 编辑这条已存在的规则
+    let existing: SnippetRule?
 
     @Environment(\.dismiss) private var dismiss
 
-    @State private var description = ""
-    @State private var expression = ""
-    @State private var enabled = true
+    @State private var description: String
+    @State private var expression: String
+    @State private var enabled: Bool
+
+    init(viewModel: SnippetsViewModel, snippetName: String, existing: SnippetRule? = nil) {
+        self.viewModel = viewModel
+        self.snippetName = snippetName
+        self.existing = existing
+        _description = State(initialValue: existing?.description ?? "")
+        _expression  = State(initialValue: existing?.expression ?? "")
+        _enabled     = State(initialValue: existing?.enabled ?? true)
+    }
 
     private var canSave: Bool {
         !expression.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !viewModel.isSaving
@@ -269,7 +311,9 @@ private struct SnippetRuleFormView: View {
                     }
                 }
             }
-            .navigationTitle("添加触发规则")
+            .navigationTitle(existing == nil
+                             ? String(localized: "添加触发规则")
+                             : String(localized: "编辑触发规则"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -295,12 +339,18 @@ private struct SnippetRuleFormView: View {
     private func save() async {
         viewModel.error = nil
         let trimmedDesc = description.trimmingCharacters(in: .whitespaces)
-        let ok = await viewModel.addRule(
-            snippetName: snippetName,
-            expression: expression.trimmingCharacters(in: .whitespacesAndNewlines),
-            description: trimmedDesc.isEmpty ? nil : trimmedDesc,
-            enabled: enabled
-        )
+        let desc = trimmedDesc.isEmpty ? nil : trimmedDesc
+        let expr = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        let ok: Bool
+        if let existing {
+            ok = await viewModel.updateRule(
+                existing, expression: expr, description: desc, enabled: enabled
+            )
+        } else {
+            ok = await viewModel.addRule(
+                snippetName: snippetName, expression: expr, description: desc, enabled: enabled
+            )
+        }
         if ok { dismiss() }
     }
 }


### PR DESCRIPTION
Closes #128（iOS 侧；Android 见 #136）

## 做了什么

Snippet 的触发规则以前只能新建、启停和删除，改一个字都得删掉重加。现在点按规则行（或左划「编辑」）进同一张表单，改表达式与描述，保存后规则**仍在原来的位置**。

## 为什么这么改

`snippet_rules` 是整组 PUT，所以「编辑一条」= 读全量 → 就地替换那一条 → 回写全量。三点讲究：

- **回写前重新拉一次服务端全量**（新增也改走它）：表单停留期间别处的改动不会被这次 PUT 抹掉；拉不到就退回本地缓存——宁可用旧的整组，也不能写出「半份」规则。
- **就地替换而非删了再加**：规则先匹配先执行，掉到队尾会改变行为。
- **目标规则若已在别处被删就拒绝提交**并提示刷新，否则整组回写会把它「复活」。

UI 上规则行拆成两个独立点击目标：文本区进编辑，开关只管启停。编辑弹层用 `.sheet(item:)` 而非 `isPresented` + 旁路 state（iOS 17 空白 sheet 的坑）。

顺带修了同一行 `accessibilityLabel` 的三元没包 `String(localized:)`——英文界面下 VoiceOver 会念中文。

## 版本 / 本地化

- `MARKETING_VERSION` 2.1.1、`CURRENT_PROJECT_VERSION` 43，各 12 处已同步（按 grep 计数核对）
- `Localizable.xcstrings` 补 4 个 key × 12 语
- What's New 走单一数据源，条目在 #134，本分支只带生成物

## 验证

`xcodebuild -scheme "Orange Cloud" build` 通过，无 error、无版本不匹配 warning。**真机未验**——改的是线上写接口，建议拿一个有 2 条以上规则的 zone 验「改其中一条，另一条不受影响、顺序不变」。