### PR TITLE
feat(web): /guides 新增英文指南「Cloudflare Error 526: Invalid SSL Certificate」

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-error-521-web-server-is-down/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-521-web-server-is-down/page.tsx
@@ -57,6 +57,11 @@ const RELATED: RelatedLink[] = [
 		note: "The setting that decides whether Cloudflare knocks on port 80 or port 443 — and so whether your origin refuses it.",
 	},
 	{
+		href: "/guides/cloudflare-error-526-invalid-ssl-certificate",
+		label: "Cloudflare error 526: invalid SSL certificate",
+		note: "One step further along the same hop: the origin answered on 443, and the certificate it presented was rejected.",
+	},
+	{
 		href: "/guides/cloudflare-error-1000-dns-points-to-prohibited-ip",
 		label: "Cloudflare error 1000: DNS points to prohibited IP",
 		note: "The four-digit family: what happens when the address Cloudflare resolved is Cloudflare's own.",

--- a/apps/web/src/app/[locale]/guides/cloudflare-error-526-invalid-ssl-certificate/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-526-invalid-ssl-certificate/page.tsx
@@ -1,0 +1,471 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import GuideShell, { type RelatedLink } from "@/components/guides/GuideShell";
+import Error526Validation from "@/components/guides/Error526Validation";
+import { guideBySlug, GUIDE_LOCALE } from "@/lib/guides/guides";
+
+const SITE_URL = "https://o-c.do";
+const guide = guideBySlug("cloudflare-error-526-invalid-ssl-certificate");
+const PATH = `/guides/${guide.slug}`;
+
+const DOCS_526 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526/";
+const DOCS_525 =
+	"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-525/";
+const DOCS_5XX = "https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/";
+const DOCS_SSL_MODES = "https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/";
+const DOCS_FULL = "https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full/";
+const DOCS_FULL_STRICT = "https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full-strict/";
+const DOCS_ORIGIN_CA = "https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/";
+const DOCS_COTS = "https://developers.cloudflare.com/ssl/origin-configuration/custom-origin-trust-store/";
+const DOCS_ACM = "https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/";
+const DOCS_PAUSE = "https://developers.cloudflare.com/fundamentals/manage-domains/pause-cloudflare/";
+const DOCS_COMPAT_FLAGS = "https://developers.cloudflare.com/workers/configuration/compatibility-flags/";
+const DOCS_CIPHERS = "https://developers.cloudflare.com/ssl/origin-configuration/cipher-suites/";
+
+/** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
+const FAQ: Array<{ q: string; a: string }> = [
+	{
+		q: "What does Cloudflare error 526 mean?",
+		a: "It means Cloudflare could not validate the SSL certificate your origin server presented, while your encryption mode was set to Full (strict). The TLS handshake itself worked and your server did send a certificate; Cloudflare then refused to trust it and returned error 526, invalid SSL certificate, to the visitor.",
+	},
+	{
+		q: "How do I fix Cloudflare error 526?",
+		a: "Fix the certificate rather than the symptom: install one issued by a public certificate authority or a free Cloudflare Origin CA certificate, make sure it has not expired, make sure the hostname appears in its Common Name or Subject Alternative Name, and make sure your server sends the intermediate certificates alongside the leaf. Switching the encryption mode from Full (strict) to Full also clears the error, but only because it stops Cloudflare checking at all.",
+	},
+	{
+		q: "What is the difference between Cloudflare error 525 and 526?",
+		a: "A 525 means the TLS handshake between Cloudflare and your origin failed outright, so no usable certificate was ever exchanged; common causes are no certificate installed, port 443 closed, no SNI support, or mismatched cipher suites. A 526 means the handshake got far enough for your origin to present a certificate and Cloudflare rejected it as invalid. Error 525 can occur in both Full and Full (strict), while 526 requires Full (strict).",
+	},
+	{
+		q: "Can error 526 happen in Full mode?",
+		a: "No. In Full mode Cloudflare connects to your origin over HTTPS without validating the origin certificate, so there is no validation step to fail. Cloudflare documents error 526 as occurring only when Full (strict) is set. If you are seeing 526 and believe you are not in Full (strict), check whether Automatic SSL/TLS upgraded the zone for you, or whether the request came from a Worker or from Cloudflare Gateway, both of which apply Full (strict) regardless of the zone setting.",
+	},
+	{
+		q: "I am a visitor, not the site owner. Can I fix a 526?",
+		a: "No. Error code 526 is produced at Cloudflare's edge because the website's own server presented a certificate Cloudflare would not accept, and nothing on your device or network causes it or can work around it. Reporting the problem to the site owner, and trying again later, are the only useful actions.",
+	},
+];
+
+const RELATED: RelatedLink[] = [
+	{
+		href: "/guides/cloudflare-ssl-tls-encryption-modes",
+		label: "Which Cloudflare SSL/TLS encryption mode should you use?",
+		note: "The setting that decides whether Cloudflare validates your origin certificate at all — and so whether a 526 is even possible.",
+	},
+	{
+		href: "/guides/cloudflare-error-521-web-server-is-down",
+		label: "Cloudflare error 521: web server is down",
+		note: "One step earlier on the same hop: the origin refused the connection before any certificate was exchanged.",
+	},
+	{
+		href: "/guides/cloudflare-error-522-connection-timed-out",
+		label: "Cloudflare error 522: connection timed out",
+		note: "The silent failure on that hop — no refusal, no certificate, just nineteen seconds of nothing.",
+	},
+	{
+		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
+		label: "What does the orange cloud mean in Cloudflare?",
+		note: "A 526 only exists because the record is proxied — here is what proxying puts in front of your origin.",
+	},
+	{
+		href: DOCS_526,
+		label: "Cloudflare docs: Error 526",
+		note: "The official reference, including the Zero Trust and Workers variants of the same error.",
+		external: true,
+	},
+	{
+		href: "/contact",
+		label: "Something wrong on this page?",
+		note: "Corrections and questions are welcome — we read every message.",
+	},
+];
+
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: guide.title,
+	description: guide.description,
+	alternates: {
+		canonical: PATH,
+		languages: { en: PATH, "x-default": PATH },
+	},
+	openGraph: {
+		title: guide.title,
+		description: guide.description,
+		url: PATH,
+		siteName: "Orange Cloud",
+		type: "article",
+		locale: "en_US",
+		images: [{ url: "/og/en.jpg", width: 1280, height: 640, alt: guide.h1 }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: guide.title,
+		description: guide.description,
+		images: ["/og/en.jpg"],
+	},
+};
+
+const OPENSSL_CHECK = `# Ask the origin directly what chain it serves, bypassing Cloudflare
+openssl s_client -connect 203.0.113.10:443 -servername example.com </dev/null
+
+# Look for these three lines in the output:
+#   Certificate chain      -> must include the intermediate, not just the leaf
+#   Verify return code: 0  -> anything else is what Cloudflare is rejecting
+#   notAfter=...           -> the expiry date, in UTC`;
+
+export default async function Error526Guide({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params;
+	if (locale !== GUIDE_LOCALE) notFound();
+	setRequestLocale(locale);
+
+	const jsonLd = [
+		{
+			"@context": "https://schema.org",
+			"@type": "TechArticle",
+			headline: guide.h1,
+			description: guide.description,
+			url: `${SITE_URL}${PATH}`,
+			inLanguage: "en",
+			datePublished: guide.updated,
+			dateModified: guide.updated,
+			image: `${SITE_URL}/og/en.jpg`,
+			author: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			publisher: { "@type": "Organization", name: "Orange Cloud", url: SITE_URL },
+			mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}${PATH}` },
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			mainEntity: FAQ.map((item) => ({
+				"@type": "Question",
+				name: item.q,
+				acceptedAnswer: { "@type": "Answer", text: item.a },
+			})),
+		},
+		{
+			"@context": "https://schema.org",
+			"@type": "BreadcrumbList",
+			itemListElement: [
+				{ "@type": "ListItem", position: 1, name: "Guides", item: `${SITE_URL}/guides` },
+				{ "@type": "ListItem", position: 2, name: guide.h1, item: `${SITE_URL}${PATH}` },
+			],
+		},
+	];
+
+	return (
+		<>
+			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+			<GuideShell
+				title={guide.h1}
+				lede="Unlike the rest of the 52x family, this one needs two things to be true at once — and the second is a setting in your own dashboard."
+				updated={guide.updated}
+				readingTime={guide.readingTime}
+				related={RELATED}
+			>
+				<div className="glass r-island note p-6 sm:p-7">
+					<p>
+						<strong>
+							Cloudflare error 526 means two things are true at once: your encryption mode is Full (strict),
+							and Cloudflare could not validate the certificate your origin presented.
+						</strong>{" "}
+						Fix the certificate, or change the mode.
+					</p>
+				</div>
+
+				<p>
+					Everything people find confusing about this error follows from that pairing. A certificate can be
+					broken for months without anyone noticing, because in every other mode Cloudflare does not look. So
+					&ldquo;Cloudflare 526&rdquo; is rarely a report that something just broke at your origin — more often it
+					is a report that something started being <em>checked</em>. Like the rest of the family, error code 526
+					is generated at Cloudflare&rsquo;s edge rather than by your application, so your own logs may show
+					nothing at all, and it can only occur on a{" "}
+					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">proxied record</Link>.
+				</p>
+
+				<h2 id="two-conditions">Two conditions, and both have to hold</h2>
+				<Error526Validation />
+				<p>
+					Cloudflare&rsquo;s{" "}
+					<a href={DOCS_526} target="_blank" rel="noopener noreferrer">
+						documentation for error 526
+					</a>{" "}
+					states the two conditions explicitly: Cloudflare cannot validate the SSL certificate at your origin
+					web server, <em>and</em>{" "}
+					<a href={DOCS_FULL_STRICT} target="_blank" rel="noopener noreferrer">
+						Full (strict)
+					</a>{" "}
+					is the encryption mode set for the domain. The second condition is what makes this an invalid SSL
+					certificate error rather than a connection error, because{" "}
+					<a href={DOCS_FULL} target="_blank" rel="noopener noreferrer">
+						Full mode
+					</a>{" "}
+					connects to the origin over HTTPS <em>without validating the origin&rsquo;s certificate</em> — it is
+					documented as the mode for origins with self-signed or otherwise invalid certificates. No validation,
+					no 526.
+				</p>
+
+				<h2 id="causes">What makes a certificate invalid to Cloudflare</h2>
+				<p>
+					Cloudflare&rsquo;s edge trusts certificates issued by a certificate authority in its own published
+					trust store. The 526 checklist in the docs is really a list of ways to fall outside it:
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">What is wrong with the certificate</th>
+								<th scope="col">How it usually got that way</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Expired</th>
+								<td>A renewal job that stopped running, or a certificate nobody was tracking</td>
+							</tr>
+							<tr>
+								<th scope="row">Revoked</th>
+								<td>Reissued after a key compromise, with the old certificate left installed</td>
+							</tr>
+							<tr>
+								<th scope="row">Self-signed rather than CA-issued</th>
+								<td>A default certificate shipped by the web server or control panel</td>
+							</tr>
+							<tr>
+								<th scope="row">Hostname not in the Common Name or Subject Alternative Name</th>
+								<td>A certificate issued for the apex only, then used for a subdomain</td>
+							</tr>
+							<tr>
+								<th scope="row">Incomplete chain</th>
+								<td>Only the leaf installed, without the intermediate CA certificates</td>
+							</tr>
+							<tr>
+								<th scope="row">Port 443 not accepting connections</th>
+								<td>HTTPS never enabled at the origin, or firewalled off</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					The incomplete chain is the one worth singling out, because it is the case where your site looks fine
+					in a browser and still returns 526. Cloudflare requires the origin to serve the leaf certificate
+					together with any required intermediates, so that a trusted chain up to a root CA can be built. If
+					your server only sends the leaf, there is nothing for Cloudflare to build with.
+				</p>
+
+				<h2 id="525-vs-526">526 vs 525: rejected, not un-negotiated</h2>
+				<p>
+					These two are the pair people mix up, and the split is clean: 525 is a handshake that never finished,
+					526 is a handshake that finished and produced something Cloudflare would not accept.
+				</p>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">&nbsp;</th>
+								<th scope="col">Error 525</th>
+								<th scope="col">Error 526</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Cloudflare&rsquo;s name for it</th>
+								<td>SSL handshake failed</td>
+								<td>Invalid SSL certificate</td>
+							</tr>
+							<tr>
+								<th scope="row">What failed</th>
+								<td>The TLS negotiation itself</td>
+								<td>Validation of the certificate that was negotiated</td>
+							</tr>
+							<tr>
+								<th scope="row">Modes it can occur in</th>
+								<td>Full and Full (strict)</td>
+								<td>Full (strict) only</td>
+							</tr>
+							<tr>
+								<th scope="row">Typical causes</th>
+								<td>
+									No certificate installed, port 443 closed, no SNI support, or{" "}
+									<a href={DOCS_CIPHERS} target="_blank" rel="noopener noreferrer">
+										cipher suites
+									</a>{" "}
+									the origin and Cloudflare do not share
+								</td>
+								<td>Expired, revoked, self-signed, wrong hostname, or missing intermediates</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+
+				<h2 id="out-of-nowhere">Why it started on a site nobody touched</h2>
+				<p>
+					Three mechanisms account for most &ldquo;this was working yesterday&rdquo; reports, and none of them
+					involves anyone editing a server.
+				</p>
+				<ul>
+					<li>
+						<strong>Automatic SSL/TLS moved you to Full (strict).</strong> Cloudflare&rsquo;s{" "}
+						<a href={DOCS_SSL_MODES} target="_blank" rel="noopener noreferrer">
+							encryption mode setting
+						</a>{" "}
+						now defaults to a mode chosen for you by the SSL/TLS Recommender, which upgrades gradually — 1% of
+						traffic, then 10% increments — and aborts if origin connectivity fails during the rollout. That is
+						the benign path. The trap comes later: Cloudflare states plainly that Automatic SSL/TLS{" "}
+						<em>will not</em> move you back to a less secure mode if your origin certificate later expires.
+						Once you are on Full (strict), you own that certificate&rsquo;s validity for good.
+					</li>
+					<li>
+						<strong>A Cloudflare Origin CA certificate quietly expired.</strong> These are long-lived, which
+						is the point, and Cloudflare documents that it does not currently send expiration notifications
+						for them. A certificate issued years ago by someone who has since left is exactly the kind of
+						thing that surfaces as a sudden 526.
+					</li>
+					<li>
+						<strong>A renewal reinstalled the leaf without its intermediates.</strong> Automated renewals
+						usually get this right; a hand-copied <code>.crt</code> file often does not.
+					</li>
+				</ul>
+
+				<h2 id="confirm">Confirming it yourself</h2>
+				<p>
+					Ask the origin directly, with Cloudflare out of the path, so you see the same chain Cloudflare sees:
+				</p>
+				<pre>
+					<code>{OPENSSL_CHECK}</code>
+				</pre>
+				<p>
+					Cloudflare&rsquo;s own suggestion is the browser-based equivalent:{" "}
+					<a href={DOCS_PAUSE} target="_blank" rel="noopener noreferrer">
+						pause Cloudflare
+					</a>{" "}
+					and run your hostname through an SSL checker. Either way you are looking for the same three things:
+					the chain includes an intermediate, the verification succeeds, and the expiry is in the future.
+				</p>
+
+				<h2 id="fixes">Three ways out, cheapest first</h2>
+				<ol>
+					<li>
+						<strong>
+							Install a{" "}
+							<a href={DOCS_ORIGIN_CA} target="_blank" rel="noopener noreferrer">
+								Cloudflare Origin CA certificate
+							</a>
+							.
+						</strong>{" "}
+						Free on every plan including Free, issued from the dashboard, and trusted by Cloudflare by design.
+						One caveat that catches people: these certificates encrypt only the Cloudflare-to-origin hop and
+						are not publicly trusted, so if you later switch that record to DNS only, visitors will see
+						certificate warnings.
+					</li>
+					<li>
+						<strong>
+							Upload your CA to the{" "}
+							<a href={DOCS_COTS} target="_blank" rel="noopener noreferrer">
+								Custom Origin Trust Store
+							</a>
+							.
+						</strong>{" "}
+						The route for an internal or private CA — but it requires{" "}
+						<a href={DOCS_ACM} target="_blank" rel="noopener noreferrer">
+							Advanced Certificate Manager
+						</a>{" "}
+						on the zone, and once a CA is uploaded Cloudflare ignores its default trust store for that zone
+						entirely and uses only what you supplied.
+					</li>
+					<li>
+						<strong>Drop to Full.</strong> Cloudflare lists this first as a &ldquo;potential quick fix&rdquo;,
+						and it does stop the error immediately — because the check stops happening. Traffic to your origin
+						stays encrypted but unauthenticated. Treat it as a way to buy an afternoon, not a resolution.
+					</li>
+				</ol>
+
+				<h2 id="not-your-setting">Two places where your zone setting does not apply</h2>
+				<p>
+					Both are documented, and both produce a 526 on a zone that is not in Full (strict) at all — which is
+					why they are worth knowing before you spend an hour checking a setting that is already correct.
+				</p>
+				<p>
+					<strong>Workers.</strong> A subrequest from a Worker to a hostname outside your Cloudflare zone that
+					is not proxied by Cloudflare always uses Full (strict), regardless of the zone configuration. If you
+					need such a fetch to trust a private CA, the Custom Origin Trust Store applies only once the{" "}
+					<code>cots_on_external_fetch</code>{" "}
+					<a href={DOCS_COMPAT_FLAGS} target="_blank" rel="noopener noreferrer">
+						compatibility flag
+					</a>{" "}
+					is enabled.
+				</p>
+				<p>
+					<strong>Cloudflare Gateway.</strong> In the Zero Trust path a 526 means Gateway distrusted the origin
+					— an unknown or revoked issuer, an expired certificate anywhere in the chain, a name mismatch, or a
+					name containing characters such as underscores that Chrome tolerates and Gateway does not. Gateway
+					also refuses origins that offer only insecure cipher suites, or that redirect every HTTPS request to
+					HTTP.
+				</p>
+
+				<h2 id="neighbours">Where 526 sits among the origin errors</h2>
+				<div className="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th scope="col">Error</th>
+								<th scope="col">How far the connection got</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">
+									<Link href="/guides/cloudflare-error-521-web-server-is-down">521</Link>
+								</th>
+								<td>Refused at once — no TCP connection</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<Link href="/guides/cloudflare-error-522-connection-timed-out">522</Link>
+								</th>
+								<td>Silence — no TCP connection within 19 seconds</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_525} target="_blank" rel="noopener noreferrer">
+										525
+									</a>
+								</th>
+								<td>TCP connected, TLS handshake failed</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<a href={DOCS_526} target="_blank" rel="noopener noreferrer">
+										526
+									</a>
+								</th>
+								<td>TLS handshake succeeded, certificate rejected</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>
+					Read down that column and the family becomes a single sequence: each error is the connection getting
+					one step further before failing. A 526 is the furthest of the four, which is genuinely good news — the
+					network path works, the port is open, TLS negotiates. Only the paperwork is wrong. The{" "}
+					<a href={DOCS_5XX} target="_blank" rel="noopener noreferrer">
+						5xx index
+					</a>{" "}
+					covers the rest of the family, and{" "}
+					<Link href="/guides/cloudflare-ssl-tls-encryption-modes">the guide to the encryption modes</Link>{" "}
+					covers the setting that decides whether the paperwork gets checked.
+				</p>
+
+				<h2 id="faq">FAQ</h2>
+				{FAQ.map((item) => (
+					<div key={item.q}>
+						<h3>{item.q}</h3>
+						<p>{item.a}</p>
+					</div>
+				))}
+			</GuideShell>
+		</>
+	);
+}

--- a/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
@@ -40,6 +40,11 @@ const FAQ: Array<{ q: string; a: string }> = [
 
 const RELATED: RelatedLink[] = [
 	{
+		href: "/guides/cloudflare-error-526-invalid-ssl-certificate",
+		label: "Cloudflare error 526: invalid SSL certificate",
+		note: "What Full (strict) does when the origin certificate does not check out \u2014 the error this setting exists to produce.",
+	},
+	{
 		href: "/guides/what-is-the-orange-cloud-in-cloudflare",
 		label: "What is the orange cloud in Cloudflare?",
 		note: "The prerequisite: encryption modes only apply to records that are proxied in the first place.",

--- a/apps/web/src/components/guides/Error526Validation.tsx
+++ b/apps/web/src/components/guides/Error526Validation.tsx
@@ -1,0 +1,154 @@
+/**
+ * Error 526 的位置图：TLS 握手一路走到源站把证书递出来——所以它不是 525——
+ * 卡在下一步：Cloudflare 拿证书去比对信任库。Full 模式跳过这一步，
+ * Full (strict) 才会验，验不过就是 526。两个条件必须同时成立，图上都画出来。
+ * 纯 SVG、无 JS；配色全走主题 token，亮/暗两套都成立；竖版布局，窄屏不溢出。
+ */
+export default function Error526Validation() {
+	const col = { x: 20, width: 244, rx: 14 };
+
+	return (
+		<figure className="my-8">
+			<svg
+				viewBox="0 0 400 482"
+				role="img"
+				aria-label="Where Cloudflare error 526 happens: a visitor reaches the Cloudflare edge normally, the edge opens a TLS connection to the origin on port 443, and the origin does present a certificate — so the handshake itself succeeded and this is not error 525. Cloudflare then checks that certificate against its trust store. In Full mode that check is skipped; in Full (strict) mode it is enforced, and a certificate that is expired, self-signed, name-mismatched or missing its intermediates fails, so Cloudflare returns error 526, invalid SSL certificate."
+				className="mx-auto block h-auto w-full max-w-[440px]"
+			>
+				<title>Where a Cloudflare 526 error happens on the path to your origin</title>
+
+				<defs>
+					<marker id="e526-arrow" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--oc-orange)" />
+					</marker>
+					<marker
+						id="e526-arrow-back"
+						viewBox="0 0 8 8"
+						refX="6"
+						refY="4"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto"
+					>
+						<path d="M0 0 L8 4 L0 8 z" fill="var(--t-secondary)" />
+					</marker>
+				</defs>
+
+				{/* 1 · 访客 → 边缘：这一段是通的 */}
+				<rect {...col} y="12" height="52" fill="var(--glass-bg)" stroke="var(--divider)" />
+				<text x="142" y="36" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Visitor
+				</text>
+				<text x="142" y="53" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					reaches Cloudflare normally
+				</text>
+
+				<path
+					d="M142 68 L142 96"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e526-arrow)"
+				/>
+
+				{/* 2 · Cloudflare 边缘：向源站开 TLS */}
+				<rect {...col} y="102" height="56" fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="142" y="127" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare edge
+				</text>
+				<text x="142" y="144" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					opens TLS to the origin on 443
+				</text>
+
+				{/* 3 · 去程 ClientHello + 回程证书：握手本身是成的 */}
+				<path
+					d="M118 162 L118 218"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e526-arrow)"
+				/>
+				<path
+					d="M166 218 L166 162"
+					stroke="var(--t-secondary)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e526-arrow-back)"
+				/>
+
+				{/* 4 · 源站：确实递出了证书 */}
+				<rect {...col} y="224" height="56" fill="none" stroke="var(--divider)" strokeDasharray="5 4" />
+				<text x="142" y="249" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-secondary)">
+					Origin server
+				</text>
+				<text x="142" y="266" textAnchor="middle" fontSize="12" fill="var(--t-tertiary)">
+					presents a certificate
+				</text>
+				<text x="274" y="245" fontSize="11" fill="var(--t-tertiary)">
+					it answered, so
+				</text>
+				<text x="274" y="260" fontSize="11" fill="var(--t-tertiary)">
+					this is not a
+				</text>
+				<text x="274" y="275" fontSize="11" fill="var(--t-tertiary)">
+					521, 522 or 525
+				</text>
+
+				<path
+					d="M142 286 L142 312"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e526-arrow)"
+				/>
+
+				{/* 5 · 验证这一步：模式决定验不验 */}
+				<rect {...col} y="318" height="56" fill="var(--glass-bg)" stroke="var(--oc-orange)" strokeOpacity="0.55" />
+				<text x="142" y="343" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Cloudflare checks it
+				</text>
+				<text x="142" y="360" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					against its trust store
+				</text>
+				<text x="274" y="339" fontSize="11" fill="var(--t-tertiary)">
+					Full: skipped
+				</text>
+				<text x="274" y="354" fontSize="11" fill="var(--t-tertiary)">
+					Full (strict):
+				</text>
+				<text x="274" y="369" fontSize="11" fill="var(--t-tertiary)">
+					enforced
+				</text>
+
+				<path
+					d="M142 380 L142 406"
+					stroke="var(--oc-orange)"
+					strokeWidth="1.6"
+					fill="none"
+					markerEnd="url(#e526-arrow)"
+				/>
+
+				{/* 6 · 结果 */}
+				<rect
+					{...col}
+					y="412"
+					height="56"
+					fill="none"
+					stroke="var(--oc-orange)"
+					strokeOpacity="0.7"
+					strokeDasharray="5 4"
+				/>
+				<text x="142" y="437" textAnchor="middle" fontSize="15" fontWeight="600" fill="var(--t-primary)">
+					Error 526
+				</text>
+				<text x="142" y="454" textAnchor="middle" fontSize="12" fill="var(--t-secondary)">
+					invalid SSL certificate
+				</text>
+			</svg>
+			<figcaption className="mt-3 text-center text-[13px] leading-relaxed t-tertiary">
+				The handshake reached the point where your origin handed over a certificate. Everything that goes wrong
+				after that point is a validation decision, and only Full (strict) makes it.
+			</figcaption>
+		</figure>
+	);
+}

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -156,6 +156,17 @@ export const GUIDES: GuideMeta[] = [
 		updated: "2026-09-01",
 		readingTime: "7 min read",
 	},
+	{
+		slug: "cloudflare-error-526-invalid-ssl-certificate",
+		h1: "Why Am I Getting Cloudflare Error 526: Invalid SSL Certificate?",
+		title: "Cloudflare Error 526: Invalid SSL Certificate, Explained",
+		description:
+			"Error 526 means Cloudflare could not validate your origin\u2019s certificate while the encryption mode is Full (strict). Both conditions must be true.",
+		blurb:
+			"Two conditions have to hold at once \u2014 which is why 526 differs from 525, and why a site nobody touched starts failing the day an origin certificate quietly expires.",
+		updated: "2026-09-03",
+		readingTime: "8 min read",
+	},
 ];
 
 export const GUIDES_ZH: GuideMeta[] = [


### PR DESCRIPTION
## 选题依据（来自 GSC 28 天数据）

先跑了 `gsc.py guides / gaps / owners`，并对可疑页做了 `inspect`。

**修复优先的三条判据本轮都不成立为「可修的缺陷」**，故按流程转为新增：

1. **未收录 >7 天**：`/guides/cloudflare-real-visitor-ip-cf-connecting-ip` 是「已抓取 - 尚未编入索引」，但上线仅 6 天，未达阈值。
2. **目标词被本站抢走**：`what is orange cloud in cloudflare`（展示 5）确实全被 `/`、`/guides`、`/privacy` 吃掉，专文一次都没拿到。但 `inspect` 显示该页 `lastCrawlTime = 2026-08-20`，而上一轮的意图切换（9261691）是 08-24 落地的——**Google 还没重新抓过这一版**。此时再改一次等于空转，应等待重抓后再看。
3. **0 展示且 >14 天**：`/guides/why-is-cloudflare-not-caching-my-site` 展示为 0，但 `verdict: PASS`、canonical 自引正确、`lastCrawlTime` 同样停在上线当天 2026-08-20，技术上无缺陷可修。

`gaps` 里标 `[可做]` 的词（`cloud orange` / `cloudflare orange` / `icloud orange` / `web cloud orange`）全部是品牌名的词序与拼写变体，做专文会直接违反选题第 5 条（与首页抢导航意图），本轮**未提供可用线索**。

因此按备选题库取 **Error 526**：

- 站内已有 521 / 522 / 1000 三篇错误码文，526 补上第四篇，且 **521 那篇正文里已经写了「certificate 不被接受时是 526 而不是 521」**，等于有一条现成的内链在等它；
- 与已上线的 SSL/TLS 加密模式篇天然配对（Full (strict) 正是 526 的必要条件）；
- 主词不含品牌词，无自我竞争风险；
- 变体可枚举：`error 526`、`cloudflare 526`、`error code 526`、`526 invalid ssl certificate`、`invalid SSL certificate error`，以及兄弟词 `525` / `ssl handshake failed`——正文与 FAQ 各有自然落点。

## 核对官方文档后修正 / 放弃的论断

逐条拿 `index.md` 原文核过，以下几条是核对后**改掉或补上**的：

- **「526 是证书有问题」不完整** → 官方明确写的是**两个条件同时成立**：Cloudflare 验不过源站证书 **且** 模式为 Full (strict)。据此确认「Full 模式下不可能出 526」，并把它写进 FAQ（[error-526](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526/)）。
- **525 与 526 的模式差别**：525 在 **Full 和 Full (strict) 都会发生**，526 **只在 Full (strict)**。原本以为两者模式条件相同，核对后改正（[error-525](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-525/)）。
- **「Automatic SSL/TLS 会在证书出问题时帮你降级」是错的** → 文档写明它**不会**把你换回更不安全的模式，即使源站证书过期（[ssl-modes](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/)）。这条改写成了「为什么没人动过却突然报 526」的第一条成因。
- **Custom Origin Trust Store 不是人人可用** → 需要 **Advanced Certificate Manager**；且上传自定义 CA 后 Cloudflare 会**完全忽略默认信任库**。两条都补上了（[custom-origin-trust-store](https://developers.cloudflare.com/ssl/origin-configuration/custom-origin-trust-store/)）。
- **Origin CA 的两个坑**：全部方案（含 Free）可用；但 Cloudflare **目前不发到期提醒**，且这类证书**不被公开信任**——记录改灰云后访客会看到证书告警（[origin-ca](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/)）。
- **补上两处「zone 设置不生效」**：Worker 对本 zone 外未代理主机名的子请求**恒用 Full (strict)**（需 `cots_on_external_fetch` 兼容性标志才认自定义信任库）；Gateway/Zero Trust 路径另有一套判据。这两条原本不在提纲里，是读文档时发现的。
- **放弃**了「浏览器会用 AIA 补链所以看着正常」这条机制解释——属于通用 TLS 知识而非 Cloudflare 文档所载，改为只陈述文档写明的「源站必须同时提供中间证书，Cloudflare 才能建链」。

## 硬门槛逐项结果

| # | 项 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 成功，无新增告警（仅既有的 proxy env 提示）；`/[locale]/guides/cloudflare-error-526-invalid-ssl-certificate` 已进路由表 |
| 2 | `npx vitest run` | ✅ 21 files / 166 tests 全绿 |
| 3 | `npx eslint`（5 个新增/改动文件） | ✅ 0 error |
| 4 | 新 URL 返回 200 | ✅ 预渲染产物 `en/...526....meta` 无 `status` 字段（即 200）；非 en 语种为 404，与既有指南一致。**注**：本轮是无人值守定时任务，`preview_start` 拒绝启动 dev server，故改为对 `next build` 的**生产预渲染产物**做校验（比 dev 更接近线上） |
| 5 | canonical 自引 + hreflang | ✅ canonical = `https://o-c.do/guides/cloudflare-error-526-invalid-ssl-certificate`；alternate 只有 `en` 与 `x-default`，两者同址 |
| 6 | JSON-LD 可解析 + FAQ 逐字出现 | ✅ 脚本断言：2 个 ld+json 块全部 `json.loads` 通过，`@type` = SoftwareApplication（站点布局既有）/ TechArticle / FAQPage / BreadcrumbList；5 条 FAQ 的问与答**逐字命中**渲染后可见正文，缺失 0 |
| 7 | 标题层级无跳级 | ✅ 序列 `1,2,2,2,2,2,2,2,2,2,3,3,3,3,3,2,2`，h1 恰好 1 个，跳级 0 |
| 8 | 375px 无横向滚动 | ✅ 实测 `scrollWidth == clientWidth == 375`；宽表格（495/480/480px）与代码块（670px）各自在 `overflow-x:auto` 容器内横滚，SVG 缩放至 327px 不溢出 |
| 9 | 外链 2xx/3xx | ✅ 本文新增的 13 条外链全部 200（含全部 Cloudflare 文档链接）。页面上另两条非 2xx 与本文无关：页脚既有的 ko-fi 链接 curl 被反爬挡回 403；`o-c.do/guides/...526...` 自身 404 是因为尚未部署 |
| 10 | 词数 1000–1800 | ✅ 正文 1671 词 |

## 其它

- 新增内联 SVG `Error526Validation.tsx`：竖版、纯 CSS 变量配色、`role="img"` + `aria-label` + `<title>` 齐备，窄屏已实测不溢出。
- 双向内链：本文链出 SSL/TLS 加密模式、521、522、小黄云；同时在 **521** 与 **SSL/TLS 加密模式** 两篇的「延伸阅读」中加入本文。
- sitemap 由 `GUIDES` 自动派生，已确认新 URL 出现在构建产物的 sitemap 中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
