### PR TITLE
fix(web): Play 宽限期的待付款订单不再计入营收

### DIFF
--- a/apps/web/migrations/0009_transaction_order_state.sql
+++ b/apps/web/migrations/0009_transaction_order_state.sql
@@ -1,0 +1,25 @@
+-- 交易行补「订单状态」：区分「钱已到账」与「只是下了单」。
+--
+-- Google Play 续订失败会先进宽限期，那条 RTDN 的 latestOrderId 指向一笔
+-- **尚未扣款成功**的订单（orders.get 返回 state=PENDING、total 有金额、
+-- developerRevenueInBuyerCurrency 为空）。此前账本原样落了一行带金额的交易，
+-- 于是「本月净额 / 累计营收」把没收到的钱算成了收入。
+--
+-- 存下 orders.get 的 state（Apple 行恒 NULL，Apple 的续订失败通知带的是
+-- 上一笔已成功交易，不会造出新的幻影流水），营收聚合只认已到账的状态，
+-- 口径见 src/lib/ledger/order-state.ts。
+
+ALTER TABLE transactions ADD COLUMN order_state TEXT;
+
+-- 回填历史 Play 行：取该订单最后一条通知里富化到的订单状态。
+UPDATE transactions
+SET order_state = (
+	SELECT json_extract(n.raw_payload, '$.enrichment.order.state')
+	FROM notifications n
+	WHERE n.platform = 'play'
+	  AND n.transaction_id = transactions.transaction_id
+	  AND json_extract(n.raw_payload, '$.enrichment.order.state') IS NOT NULL
+	ORDER BY n.signed_date DESC
+	LIMIT 1
+)
+WHERE platform = 'play';

--- a/apps/web/src/app/admin/export/route.ts
+++ b/apps/web/src/app/admin/export/route.ts
@@ -18,6 +18,7 @@ interface Row {
 	environment: string | null;
 	platform: string | null;
 	dev_revenue_millis: number | null;
+	order_state: string | null;
 }
 
 function cell(v: unknown): string {
@@ -34,18 +35,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
 	const { results } = await env.IAP_DB.prepare(
 		`SELECT purchase_date, notification_type, type, product_id, transaction_id, original_transaction_id,
-		        currency, price_millis, revocation_date, environment, platform, dev_revenue_millis
+		        currency, price_millis, revocation_date, environment, platform, dev_revenue_millis, order_state
 		 FROM transactions
 		 WHERE COALESCE(environment, '') <> 'Sandbox'
 		 ORDER BY COALESCE(purchase_date, created_at) DESC
 		 LIMIT 5000`,
 	).all<Row>();
 
-	// dev_revenue（开发者到手金额）目前只有 Play 侧有值，Apple 行留空。
+	// dev_revenue（开发者到手金额）与 order_state（Play 订单状态，PENDING/CANCELED
+	// 表示钱未到账、不计营收）目前只有 Play 侧有值，Apple 行留空。
 	const header = [
 		"purchase_date", "platform", "notification_type", "transaction_type", "product_id",
 		"transaction_id", "original_transaction_id", "currency", "price", "dev_revenue",
-		"refunded", "revocation_date",
+		"order_state", "refunded", "revocation_date",
 	];
 	const lines = [header.join(",")];
 	for (const r of results ?? []) {
@@ -55,6 +57,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 				r.transaction_id, r.original_transaction_id, r.currency,
 				r.price_millis == null ? "" : (r.price_millis / 1000).toFixed(2),
 				r.dev_revenue_millis == null ? "" : (r.dev_revenue_millis / 1000).toFixed(2),
+				r.order_state ?? "",
 				r.revocation_date ? "yes" : "no", iso(r.revocation_date),
 			]
 				.map(cell)

--- a/apps/web/src/components/dashboard/panels/NotificationRows.tsx
+++ b/apps/web/src/components/dashboard/panels/NotificationRows.tsx
@@ -10,11 +10,13 @@ import {
 	notificationLabel,
 	notificationTone,
 	offerTypeLabel,
+	orderStateLabel,
 	productLabel,
 	revocationReasonLabel,
 	subtypeLabel,
 	txTypeLabel,
 } from "@/lib/dashboard/types";
+import { isCollectedOrderState } from "@/lib/ledger/order-state";
 
 export function NotificationRows({ rows }: { rows: NotificationRow[] }) {
 	const [selected, setSelected] = useState<NotificationRow | null>(null);
@@ -97,6 +99,7 @@ function NotificationModal({
 	const n = notification;
 	const t = n.txn;
 	const refunded = t?.revocation_date != null;
+	const uncollected = t != null && !isCollectedOrderState(t.order_state);
 
 	return (
 		<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -144,6 +147,11 @@ function NotificationModal({
 										? ` · ${revocationReasonLabel(t.revocation_reason)}`
 										: ""}
 								</div>
+							) : uncollected ? (
+								// Play 宽限期 / 待付款：订单有金额但尚未扣款成功，不计入营收
+								<div className="mb-4 rounded-lg bg-foreground/[0.06] px-3 py-2 text-xs text-muted">
+									{orderStateLabel(t.order_state)} · 该订单尚未到账，不计入营收
+								</div>
 							) : null}
 							<dl className="grid grid-cols-2 gap-x-4 gap-y-3">
 								<Field label="产品">{productLabel(t.product_id)}</Field>
@@ -164,6 +172,8 @@ function NotificationModal({
 								<Field label="状态">
 									{refunded ? (
 										<span className="text-negative">已退款</span>
+									) : uncollected ? (
+										<span className="text-muted">{orderStateLabel(t.order_state)}</span>
 									) : (
 										<span className="text-positive">正常</span>
 									)}

--- a/apps/web/src/components/dashboard/panels/Tables.tsx
+++ b/apps/web/src/components/dashboard/panels/Tables.tsx
@@ -4,7 +4,8 @@ import { TimeText } from "@/components/dashboard/prefs";
 import { Badge, Card, CardHead, EmptyState, PlatformBadge } from "@/components/dashboard/ui";
 import { formatMoney, formatRelativeFuture } from "@/lib/dashboard/format";
 import type { ExpiringRow, NotificationRow, Page, TransactionRow } from "@/lib/dashboard/queries";
-import { offerTypeLabel, productLabel, txTypeLabel } from "@/lib/dashboard/types";
+import { isCollectedOrderState } from "@/lib/ledger/order-state";
+import { offerTypeLabel, orderStateLabel, productLabel, txTypeLabel } from "@/lib/dashboard/types";
 import { NotificationRows } from "./NotificationRows";
 
 function MonoId({ id }: { id: string | null }) {
@@ -201,8 +202,11 @@ export function TransactionsTable({ data, query }: { data: Page<TransactionRow>;
 											<Td>
 												{t.revocation_date ? (
 													<Badge tone="negative">已退款</Badge>
-												) : (
+												) : isCollectedOrderState(t.order_state) ? (
 													<Badge tone="positive">正常</Badge>
+												) : (
+													// Play 宽限期 / 待付款：订单有金额但钱没到账，不计入营收
+													<Badge tone="muted">{orderStateLabel(t.order_state)}</Badge>
 												)}
 											</Td>
 										</tr>

--- a/apps/web/src/lib/admin/queries.integration.test.ts
+++ b/apps/web/src/lib/admin/queries.integration.test.ts
@@ -85,3 +85,43 @@ describe("loadAdminStats 排除 Sandbox", () => {
 		expect(active?.value).toBe(3);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Play 宽限期：订单有金额但钱没到账，不能算收入
+// ---------------------------------------------------------------------------
+
+describe("loadAdminStats 排除未到账订单", () => {
+	let db2: FakeD1;
+
+	beforeAll(() => {
+		const raw = new DatabaseSync(":memory:");
+		raw.exec(schema);
+		// g1 = 宽限期续订（orders.get state=PENDING，钱没到账）
+		// g2 = 已扣款成功的续订
+		// g3 = 扣款前被取消的订单
+		raw.exec(`
+			INSERT INTO transactions (transaction_id, original_transaction_id, type, environment, price_millis, currency, purchase_date, created_at, updated_at, platform, order_state) VALUES
+			 ('g1','tok1','Auto-Renewable Subscription','Production',6319000,'HUF',${PD},${PD},${PD},'play','PENDING'),
+			 ('g2','tok2','Auto-Renewable Subscription','Production',19990,'USD',${PD},${PD},${PD},'play','PROCESSED'),
+			 ('g3','tok3','Auto-Renewable Subscription','Production',19990,'USD',${PD},${PD},${PD},'play','CANCELED'),
+			 ('g4','tok4','Non-Consumable','Production',49990,'USD',${PD},${PD},${PD},'play','PENDING');
+		`);
+		db2 = new FakeD1(raw);
+	});
+
+	it("PENDING / CANCELED 的订单不计入营收", async () => {
+		const s = await loadAdminStats(db2 as never);
+		expect(s.kpis.cumulativeNetUsd).toBeCloseTo(19.99, 2); // 只剩 g2
+		expect(s.kpis.monthNetUsd).toBeCloseTo(19.99, 2);
+		expect(s.trend.reduce((a, p) => a + p.netUsd, 0)).toBeCloseTo(19.99, 2);
+		// 买断 KPI 同口径：g4 是待付款的买断，不算
+		expect(s.kpis.lifetimeMonthUsd).toBe(0);
+		expect(s.kpis.lifetimeMonthCount).toBe(0);
+	});
+
+	it("流水列表仍然列出未到账的订单（只是不计钱）", async () => {
+		const s = await loadAdminStats(db2 as never);
+		expect(s.transactions.map((t) => t.transaction_id)).toContain("g1");
+		expect(s.transactions.find((t) => t.transaction_id === "g1")?.order_state).toBe("PENDING");
+	});
+});

--- a/apps/web/src/lib/admin/queries.ts
+++ b/apps/web/src/lib/admin/queries.ts
@@ -3,9 +3,12 @@
 // 只算 Production：环境为 Sandbox（沙盒 / 审核测试）的行一律排除（查询层过滤，
 // webhook 仍全量入库）。金额跨币种用 money.ts 的近似汇率归一到 USD（再给 CNY 估算）。
 
+import { collectedOrderStateSql } from "../ledger/order-state";
 import { toUSD } from "./money";
 
 const NOT_SANDBOX = "COALESCE(environment, '') <> 'Sandbox'";
+// 营收只认「钱已到账」的行：Play 的宽限期 / 待付款订单虽有金额，但钱还没收到。
+const COLLECTED = collectedOrderStateSql();
 
 /** product_id -> 展示名 */
 export const PRODUCT_NAMES: Record<string, string> = {
@@ -54,6 +57,8 @@ export interface TxnRow {
 	price_millis: number | null;
 	/** 'apple' | 'play'（历史行默认 apple） */
 	platform: string | null;
+	/** Play 的 orders.get state；PENDING/CANCELED 表示钱没到账，不计营收 */
+	order_state: string | null;
 	revoked: boolean;
 }
 
@@ -115,7 +120,7 @@ function revenueQuery(db: D1Database, whereExtra: string, params: unknown[]) {
 	return db
 		.prepare(
 			`SELECT currency, sum(price_millis) AS s FROM transactions
-			 WHERE ${NOT_SANDBOX} AND ${whereExtra} GROUP BY currency`,
+			 WHERE ${NOT_SANDBOX} AND ${COLLECTED} AND ${whereExtra} GROUP BY currency`,
 		)
 		.bind(...params)
 		.all<CurSum>();
@@ -137,7 +142,8 @@ async function buildTrend(db: D1Database, range: Range, now: Date): Promise<Tren
 			db
 				.prepare(
 					`SELECT strftime('%Y-%m', purchase_date/1000, 'unixepoch') AS k, currency, sum(price_millis) AS s
-					 FROM transactions WHERE ${NOT_SANDBOX} AND purchase_date >= ? AND revocation_date IS NULL
+					 FROM transactions WHERE ${NOT_SANDBOX} AND ${COLLECTED}
+					   AND purchase_date >= ? AND revocation_date IS NULL
 					 GROUP BY k, currency`,
 				)
 				.bind(start)
@@ -174,7 +180,8 @@ async function buildTrend(db: D1Database, range: Range, now: Date): Promise<Tren
 		db
 			.prepare(
 				`SELECT date(purchase_date/1000, 'unixepoch') AS k, currency, sum(price_millis) AS s
-				 FROM transactions WHERE ${NOT_SANDBOX} AND purchase_date >= ? AND revocation_date IS NULL
+				 FROM transactions WHERE ${NOT_SANDBOX} AND ${COLLECTED}
+				   AND purchase_date >= ? AND revocation_date IS NULL
 				 GROUP BY k, currency`,
 			)
 			.bind(start)
@@ -239,7 +246,7 @@ export async function loadAdminStats(db: D1Database, range: Range = "day"): Prom
 		revenueQuery(db, "revocation_date >= ?", [monthStart]),
 		revenueQuery(db, "revocation_date IS NULL", []),
 		db
-			.prepare(`SELECT count(*) AS n FROM transactions WHERE ${NOT_SANDBOX} AND type = 'Non-Consumable' AND purchase_date >= ? AND revocation_date IS NULL`)
+			.prepare(`SELECT count(*) AS n FROM transactions WHERE ${NOT_SANDBOX} AND ${COLLECTED} AND type = 'Non-Consumable' AND purchase_date >= ? AND revocation_date IS NULL`)
 			.bind(monthStart)
 			.first<{ n: number }>(),
 		db
@@ -257,7 +264,7 @@ export async function loadAdminStats(db: D1Database, range: Range = "day"): Prom
 		db
 			.prepare(
 				`SELECT purchase_date, notification_type, product_id, transaction_id, currency, price_millis,
-				        platform, (revocation_date IS NOT NULL) AS revoked
+				        platform, order_state, (revocation_date IS NOT NULL) AS revoked
 				 FROM transactions WHERE ${NOT_SANDBOX}
 				 ORDER BY COALESCE(purchase_date, created_at) DESC LIMIT 14`,
 			)
@@ -313,6 +320,7 @@ export async function loadAdminStats(db: D1Database, range: Range = "day"): Prom
 		currency: r.currency,
 		price_millis: r.price_millis,
 		platform: r.platform ?? "apple",
+		order_state: r.order_state,
 		revoked: Boolean(r.revoked),
 	}));
 

--- a/apps/web/src/lib/dashboard/queries.ts
+++ b/apps/web/src/lib/dashboard/queries.ts
@@ -1,5 +1,10 @@
+import { collectedOrderStateSql } from "../ledger/order-state";
 import { getDb, queryAll, queryFirst } from "./db";
 import { ENVIRONMENT, PLATFORM_ORDER, PRODUCT_ORDER, type Filters } from "./types";
+
+// 营收只认「钱已到账」的交易：Play 的宽限期 / 待付款订单虽带金额，但钱还没收到
+// （口径见 lib/ledger/order-state.ts）。交易条数、图表等「事件计数」不受影响。
+const COLLECTED = collectedOrderStateSql();
 
 // ---------------------------------------------------------------------------
 // Filter helpers
@@ -106,6 +111,8 @@ export interface LinkedTxn {
 	expires_date: number | null;
 	revocation_date: number | null;
 	revocation_reason: number | null;
+	/** Play 的 orders.get state（Apple 行为 null）；PENDING/CANCELED = 钱未到账 */
+	order_state: string | null;
 }
 
 export interface NotificationRow {
@@ -140,6 +147,7 @@ interface NotificationJoinRow {
 	t_expires_date: number | null;
 	t_revocation_date: number | null;
 	t_revocation_reason: number | null;
+	t_order_state: string | null;
 }
 
 export interface TransactionRow {
@@ -157,6 +165,8 @@ export interface TransactionRow {
 	revocation_date: number | null;
 	notification_type: string | null;
 	platform: string | null;
+	/** Play 的 orders.get state（Apple 行为 null）；PENDING/CANCELED = 钱未到账 */
+	order_state: string | null;
 }
 
 export interface ExpiringRow {
@@ -285,7 +295,7 @@ async function getOverview(db: D1Database, f: Filters): Promise<Overview> {
 			db,
 			`SELECT currency, COUNT(*) count, SUM(price_millis) sum_millis
 			 FROM transactions
-			 WHERE revocation_date IS NULL${tx.sql}
+			 WHERE revocation_date IS NULL AND ${COLLECTED}${tx.sql}
 			 GROUP BY currency
 			 ORDER BY count DESC, currency ASC`,
 			tx.params,
@@ -307,9 +317,9 @@ async function getOverview(db: D1Database, f: Filters): Promise<Overview> {
 		}>(
 			db,
 			`SELECT platform, currency, COUNT(*) total,
-			        SUM(CASE WHEN revocation_date IS NULL THEN 1 ELSE 0 END) paid,
+			        SUM(CASE WHEN revocation_date IS NULL AND ${COLLECTED} THEN 1 ELSE 0 END) paid,
 			        SUM(CASE WHEN revocation_date IS NOT NULL THEN 1 ELSE 0 END) refunds,
-			        SUM(CASE WHEN revocation_date IS NULL THEN price_millis ELSE 0 END) sum_millis
+			        SUM(CASE WHEN revocation_date IS NULL AND ${COLLECTED} THEN price_millis ELSE 0 END) sum_millis
 			 FROM transactions WHERE 1 = 1${tx.sql}
 			 GROUP BY platform, currency`,
 			tx.params,
@@ -477,7 +487,7 @@ async function getNotificationsPage(
 		        t.offer_type AS t_offer_type, t.price_millis AS t_price_millis,
 		        t.currency AS t_currency, t.purchase_date AS t_purchase_date,
 		        t.expires_date AS t_expires_date, t.revocation_date AS t_revocation_date,
-		        t.revocation_reason AS t_revocation_reason
+		        t.revocation_reason AS t_revocation_reason, t.order_state AS t_order_state
 		 FROM notifications n
 		 LEFT JOIN transactions t ON t.transaction_id = n.transaction_id
 		 WHERE 1 = 1${filter.sql}
@@ -506,6 +516,7 @@ async function getNotificationsPage(
 					expires_date: r.t_expires_date,
 					revocation_date: r.t_revocation_date,
 					revocation_reason: r.t_revocation_reason,
+					order_state: r.t_order_state,
 				}
 			: null,
 	}));
@@ -535,7 +546,7 @@ async function getTransactionsPage(
 		db,
 		`SELECT transaction_id, original_transaction_id, product_id, type, offer_type,
 		        offer_identifier, storefront, price_millis, currency, environment, purchase_date,
-		        revocation_date, notification_type, platform
+		        revocation_date, notification_type, platform, order_state
 		 FROM transactions
 		 WHERE 1 = 1${sql}
 		 ORDER BY created_at DESC LIMIT ? OFFSET ?`,

--- a/apps/web/src/lib/dashboard/types.ts
+++ b/apps/web/src/lib/dashboard/types.ts
@@ -128,6 +128,26 @@ export function subtypeLabel(subtype?: string | null): string | null {
 	return SUBTYPE_LABEL[subtype] ?? subtype;
 }
 
+/**
+ * Human labels for the Google Play order state (`orders.get` -> state).
+ * Apple rows have no order state; only the two "money never arrived" states
+ * need a label, since the dashboard shows them instead of a "正常" badge.
+ */
+export const ORDER_STATE_LABEL: Record<string, string> = {
+	PENDING: "待付款",
+	CANCELED: "已取消",
+	STATE_UNSPECIFIED: "状态未知",
+	PENDING_REFUND: "退款处理中",
+	PARTIALLY_REFUNDED: "部分退款",
+	REFUNDED: "已退款",
+	PROCESSED: "已到账",
+};
+
+export function orderStateLabel(state?: string | null): string {
+	if (!state) return "—";
+	return ORDER_STATE_LABEL[state] ?? state;
+}
+
 /** Human labels for transaction product types. */
 export const TX_TYPE_LABEL: Record<string, string> = {
 	"Non-Consumable": "买断",

--- a/apps/web/src/lib/ledger/backfill.integration.test.ts
+++ b/apps/web/src/lib/ledger/backfill.integration.test.ts
@@ -1,0 +1,57 @@
+// migration 0009 的回填针对真实 SQL 引擎的验证（node:sqlite）。
+//
+// 线上已有的 Play 交易行没有 order_state，只能从当初存下的通知 raw_payload 里
+// 把 orders.get 的 state 挖回来。回填只跑一次，跑错就得手工对账，故此处固定其行为。
+
+import { readdirSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+const migDir = new URL("../../../migrations/", import.meta.url);
+const files = readdirSync(migDir)
+	.filter((f) => f.endsWith(".sql"))
+	.sort();
+const BACKFILL = "0009_transaction_order_state.sql";
+
+function payload(state: string | null) {
+	return JSON.stringify({ notification: {}, enrichment: state ? { order: { state } } : {} });
+}
+
+describe("0009 回填 transactions.order_state", () => {
+	it("按订单最后一条通知取状态，Apple 行保持 NULL", () => {
+		const db = new DatabaseSync(":memory:");
+		// 先建到 0008 为止的表结构，灌入历史数据，再单独跑 0009。
+		for (const f of files.filter((f) => f < BACKFILL)) {
+			db.exec(readFileSync(new URL(f, migDir), "utf8"));
+		}
+		db.exec(`
+			INSERT INTO transactions (transaction_id, original_transaction_id, environment, price_millis, currency, created_at, updated_at, platform) VALUES
+			 ('GPA.pending','tok1','Production',6319000,'HUF',1,1,'play'),
+			 ('GPA.recovered','tok2','Production',19990,'USD',1,1,'play'),
+			 ('GPA.bare','tok3','Production',19990,'USD',1,1,'play'),
+			 ('2000000','1000000','Production',19990,'USD',1,1,'apple');
+			INSERT INTO notifications (notification_uuid, notification_type, transaction_id, signed_date, received_at, raw_payload, platform) VALUES
+			 ('n1','SUBSCRIPTION_IN_GRACE_PERIOD','GPA.pending',100,100,'${payload("PENDING")}','play'),
+			 ('n2','SUBSCRIPTION_IN_GRACE_PERIOD','GPA.recovered',100,100,'${payload("PENDING")}','play'),
+			 ('n3','SUBSCRIPTION_RECOVERED','GPA.recovered',200,200,'${payload("PROCESSED")}','play'),
+			 ('n4','PLAY_TEST','GPA.bare',100,100,'${payload(null)}','play'),
+			 ('n5','DID_RENEW','2000000',100,100,'{}','apple');
+		`);
+
+		db.exec(readFileSync(new URL(BACKFILL, migDir), "utf8"));
+
+		const state = (id: string) =>
+			(
+				db.prepare("SELECT order_state FROM transactions WHERE transaction_id = ?").get(id) as {
+					order_state: string | null;
+				}
+			).order_state;
+
+		expect(state("GPA.pending")).toBe("PENDING");
+		// 同一订单的多条通知：取 signed_date 最新的那条（宽限期后已恢复扣款）
+		expect(state("GPA.recovered")).toBe("PROCESSED");
+		// 没富化过（没配服务账号时的历史行）：留空 = 按已到账处理，维持原口径
+		expect(state("GPA.bare")).toBeNull();
+		expect(state("2000000")).toBeNull();
+	});
+});

--- a/apps/web/src/lib/ledger/order-state.ts
+++ b/apps/web/src/lib/ledger/order-state.ts
@@ -1,0 +1,37 @@
+// 账本口径：一笔交易的钱到底有没有收到。
+//
+// 起因（2026-09-03）：Google Play 的续订失败会先进宽限期（SUBSCRIPTION_IN_GRACE_PERIOD）。
+// 这条 RTDN 的 latestOrderId 指向那笔**尚未扣款成功**的续订订单，orders.get 返回
+// state=PENDING、total 有金额、developerRevenueInBuyerCurrency 为空。账本原样落了一行
+// 带金额的 transactions，于是「本月净额 / 累计」把一笔没收到的钱算成了收入。
+//
+// 修法：把 orders.get 的 state 存进 transactions.order_state（Apple 行恒 NULL），
+// 所有营收聚合只认「钱已到账」的状态。
+//
+// Play 的 Order.state 全集（androidpublisher v3 discovery）：
+//   STATE_UNSPECIFIED / PENDING / PROCESSED / CANCELED
+//   PENDING_REFUND / PARTIALLY_REFUNDED / REFUNDED
+//
+// 这里只排除「钱从未收到」的三种：
+//   PENDING            已下单、等待扣款（宽限期 / 待付款购买就在这个状态）
+//   CANCELED           扣款前就被取消，永远不会到账
+//   STATE_UNSPECIFIED  官方声明不使用，出现即视为不可信
+// 退款三态（PENDING_REFUND / PARTIALLY_REFUNDED / REFUNDED）钱是真收过的，
+// 退款本身由 VOIDED_PURCHASE 写 revocation_date 表达，营收口径不在这里二次扣减。
+
+/** 钱从未到账的 Play 订单状态。 */
+export const UNCOLLECTED_ORDER_STATES = ["PENDING", "CANCELED", "STATE_UNSPECIFIED"] as const;
+
+/** TS 侧同款判断（Apple 行 order_state 为 null -> 算已到账）。 */
+export function isCollectedOrderState(state: string | null | undefined): boolean {
+	return !state || !(UNCOLLECTED_ORDER_STATES as readonly string[]).includes(state);
+}
+
+/**
+ * 营收聚合用的 SQL 片段：只保留钱已到账的行。
+ * `col` 支持带表别名（如 `t.order_state`）。NULL（Apple 行 / 未富化的 Play 行）计入。
+ */
+export function collectedOrderStateSql(col = "order_state"): string {
+	const list = UNCOLLECTED_ORDER_STATES.map((s) => `'${s}'`).join(", ");
+	return `COALESCE(${col}, '') NOT IN (${list})`;
+}

--- a/apps/web/src/lib/play/logic.ts
+++ b/apps/web/src/lib/play/logic.ts
@@ -43,6 +43,8 @@ export interface PlayTransactionRow {
 	priceMillis: number | null;
 	devRevenueMillis: number | null;
 	currency: string | null;
+	/** orders.get 的 state：钱到底收到了没有（营收口径见 lib/ledger/order-state.ts）。 */
+	orderState: string | null;
 	storefront: string | null;
 	offerIdentifier: string | null;
 	revocationDate: number | null;
@@ -253,6 +255,7 @@ export function buildLedgerRows(
 					priceMillis,
 					devRevenueMillis,
 					currency,
+					orderState: order?.state ?? null,
 					storefront,
 					offerIdentifier: line?.offerDetails?.offerId ?? line?.offerDetails?.basePlanId ?? null,
 					revocationDate: isVoided ? eventTime : null,

--- a/apps/web/src/lib/play/play.test.ts
+++ b/apps/web/src/lib/play/play.test.ts
@@ -7,6 +7,7 @@ import { buildLedgerRows, mapSubscriptionState, notificationTypeName } from "./l
 import { buildPlayBarkMessage } from "./notify";
 import { moneyToMillis, type DeveloperNotification, type PlayEnrichment } from "./types";
 import { isRetryableStatus, parseServiceAccount } from "./api";
+import { isCollectedOrderState } from "../ledger/order-state";
 
 const PACKAGE = "jiamin.chen.orangecloud";
 const AUDIENCE = "https://o-c.do/api/play/notifications";
@@ -257,6 +258,45 @@ describe("buildLedgerRows", () => {
 			isLifetime: false,
 		});
 		expect(rows.subscription?.expiresDate).toBe(Date.parse("2027-08-01T00:00:00Z"));
+	});
+
+	it("订阅首购：已扣款订单带上 PROCESSED 状态", () => {
+		const rows = buildLedgerRows(decodeEnvelopeOf(SUB_PURCHASE), SUB_ENRICHMENT);
+		expect(rows.transaction?.orderState).toBe("PROCESSED");
+		expect(isCollectedOrderState(rows.transaction?.orderState)).toBe(true);
+	});
+
+	// 续订失败进宽限期：latestOrderId 指向那笔尚未扣款成功的订单，orders.get 给
+	// state=PENDING、有 total、无 developerRevenue。金额照记，但必须带上 PENDING，
+	// 否则看板会把一笔没收到的钱算成收入（2026-09 线上真实事故）。
+	it("宽限期：待扣款订单记 PENDING，不算已到账", () => {
+		const grace: DeveloperNotification = {
+			packageName: PACKAGE,
+			eventTimeMillis: "1754006400000",
+			subscriptionNotification: { notificationType: 6, purchaseToken: "tok-abc" },
+		};
+		const rows = buildLedgerRows(decodeEnvelopeOf(grace), {
+			subscription: {
+				...SUB_ENRICHMENT.subscription,
+				subscriptionState: "SUBSCRIPTION_STATE_IN_GRACE_PERIOD",
+			},
+			order: {
+				orderId: "GPA.1111-2222-3333-44444",
+				state: "PENDING",
+				createTime: "2027-08-01T00:00:00Z",
+				total: { currencyCode: "HUF", units: "6319" },
+			},
+		});
+		expect(rows.notification.notificationType).toBe("SUBSCRIPTION_IN_GRACE_PERIOD");
+		expect(rows.transaction).toMatchObject({
+			orderState: "PENDING",
+			priceMillis: 6_319_000,
+			devRevenueMillis: null,
+			revocationDate: null,
+		});
+		expect(isCollectedOrderState(rows.transaction?.orderState)).toBe(false);
+		// 权益仍在宽限期内（用户没掉权益，只是钱没到）
+		expect(rows.subscription?.status).toBe("grace");
 	});
 
 	it("测试购买标成 Sandbox（看板会排除）", () => {

--- a/apps/web/src/lib/play/store.integration.test.ts
+++ b/apps/web/src/lib/play/store.integration.test.ts
@@ -68,6 +68,7 @@ interface RowInput {
 	linkedToken?: string | null;
 	isLifetime?: boolean;
 	expiresDate?: number | null;
+	orderState?: string | null;
 }
 
 function makeRows(i: RowInput): PlayLedgerRows {
@@ -97,6 +98,7 @@ function makeRows(i: RowInput): PlayLedgerRows {
 					priceMillis: i.priceMillis === undefined ? 19_990 : i.priceMillis,
 					devRevenueMillis: 16_990,
 					currency: "USD",
+					orderState: i.orderState === undefined ? "PROCESSED" : i.orderState,
 					storefront: "US",
 					offerIdentifier: null,
 					revocationDate: i.revocationDate ?? null,
@@ -224,4 +226,25 @@ describe("storeLedgerRows（真实 SQL）", () => {
 			["play", 1],
 		]);
 	});
+});
+
+// 宽限期恢复：同一个 orderId 先以 PENDING 落库（钱没到），扣款成功后必须被
+// 覆盖成 PROCESSED，否则这笔真收入会一直被营收口径排除在外。
+it("同一订单 PENDING -> PROCESSED 会被覆盖", async () => {
+	await storeLedgerRows(
+		db as never,
+		makeRows({ messageId: "g1", type: "SUBSCRIPTION_IN_GRACE_PERIOD", eventTime: 1000, orderId: "GPA.9", orderState: "PENDING", status: "grace" }),
+	);
+	expect(
+		(raw.prepare("SELECT order_state FROM transactions WHERE transaction_id = 'GPA.9'").get() as { order_state: string }).order_state,
+	).toBe("PENDING");
+
+	await storeLedgerRows(
+		db as never,
+		makeRows({ messageId: "g2", type: "SUBSCRIPTION_RECOVERED", eventTime: 2000, orderId: "GPA.9", orderState: "PROCESSED" }),
+	);
+	expect(
+		(raw.prepare("SELECT order_state FROM transactions WHERE transaction_id = 'GPA.9'").get() as { order_state: string }).order_state,
+	).toBe("PROCESSED");
+	expect(count("transactions")).toBe(1);
 });

--- a/apps/web/src/lib/play/store.ts
+++ b/apps/web/src/lib/play/store.ts
@@ -55,16 +55,18 @@ export async function storeLedgerRows(
 				.prepare(
 					`INSERT INTO transactions
 					 (transaction_id, original_transaction_id, product_id, type, purchase_date,
-					  expires_date, price_millis, dev_revenue_millis, currency, in_app_ownership_type,
-					  offer_type, offer_identifier, storefront, revocation_date, revocation_reason,
-					  environment, notification_type, notification_subtype, signed_date,
+					  expires_date, price_millis, dev_revenue_millis, currency, order_state,
+					  in_app_ownership_type, offer_type, offer_identifier, storefront, revocation_date,
+					  revocation_reason, environment, notification_type, notification_subtype, signed_date,
 					  created_at, updated_at, platform)
-					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, 'play')
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, 'play')
 					 ON CONFLICT(transaction_id) DO UPDATE SET
 					   expires_date = COALESCE(excluded.expires_date, transactions.expires_date),
 					   price_millis = COALESCE(excluded.price_millis, transactions.price_millis),
 					   dev_revenue_millis = COALESCE(excluded.dev_revenue_millis, transactions.dev_revenue_millis),
 					   currency = COALESCE(excluded.currency, transactions.currency),
+					   -- 宽限期恢复后同一个 orderId 会从 PENDING 变 PROCESSED，需要覆盖。
+					   order_state = COALESCE(excluded.order_state, transactions.order_state),
 					   product_id = COALESCE(excluded.product_id, transactions.product_id),
 					   purchase_date = COALESCE(transactions.purchase_date, excluded.purchase_date),
 					   offer_identifier = COALESCE(excluded.offer_identifier, transactions.offer_identifier),
@@ -86,6 +88,7 @@ export async function storeLedgerRows(
 					tx.priceMillis,
 					tx.devRevenueMillis,
 					tx.currency,
+					tx.orderState,
 					tx.offerIdentifier,
 					tx.storefront,
 					tx.revocationDate,


### PR DESCRIPTION
## 问题

Google Play 交易 `GPA.3338-8182-7937-69139..0`（HUF 6,319 年订阅）进入宽限期、钱并没有收到，但 `/admin` 收入账本把它算进了营收。

根因：续订扣款失败会先进宽限期，该条 RTDN 的 `latestOrderId` 指向那笔**尚未扣款成功**的续订订单——`orders.get` 返回 `state=PENDING`、`total` 有金额、`developerRevenueInBuyerCurrency` 为空。`buildLedgerRows` 原样落了一行带金额的 `transactions`（`revocation_date` 为 NULL），而所有营收聚合的口径都是「未退款即计收入」，于是一笔没到账的钱进了「本月净额 / 累计营收 / 趋势 / 分平台营收」。

线上通知留档坐实（`notifications.raw_payload`）：

```
notification_type = SUBSCRIPTION_IN_GRACE_PERIOD
enrichment.order.state = PENDING
enrichment.order.total.units = 6319
enrichment.order.developerRevenueInBuyerCurrency = null
enrichment.subscription.subscriptionState = SUBSCRIPTION_STATE_IN_GRACE_PERIOD
```

Apple 侧不受影响：`DID_FAIL_TO_RENEW` 带的是上一笔**已成功**交易，只会 upsert 老行，不会造出幻影流水。

## 改动

- `transactions` 新增 `order_state` 列（migration 0009，Apple 行恒 NULL），写入时存 `orders.get` 的 state；宽限期恢复后同一 `orderId` 由 PENDING 覆盖为 PROCESSED，真收入不会被永久漏计。
- 营收口径集中到 `src/lib/ledger/order-state.ts`：只认钱已到账的行，排除 `PENDING` / `CANCELED` / `STATE_UNSPECIFIED`；退款三态（`PENDING_REFUND` / `PARTIALLY_REFUNDED` / `REFUNDED`）钱是真收过的，仍由 `VOIDED_PURCHASE` 写 `revocation_date` 表达，不在这里二次扣减。
- 两套查询层同口径：`/admin` 看板（`lib/dashboard/queries.ts`，含分平台营收卡）与 `/api/admin/stats`（`lib/admin/queries.ts`，墨水屏也读这个）。
- 未到账的交易**仍照常列在流水里**，只是状态徽章显示「待付款」而不计钱；通知详情加一条提示；CSV 导出增 `order_state` 列。
- migration 0009 从历史通知的 `raw_payload` 回填既有 Play 行（取该订单 `signed_date` 最新的那条通知里的 state）。
- 权益不受影响：宽限期用户状态仍是 `grace`，没有掉权益。

## 验证

- `pnpm test` 172 项全绿（新增：宽限期映射带 PENDING、PENDING→PROCESSED 覆盖、营收排除未到账、0009 回填行为），`pnpm build` 通过，`pnpm lint` 无新增问题。
- 生产 D1 已 apply 0009 并回填：那笔 HUF 行为 `PENDING`，其余 Play 行 `PROCESSED`，Apple 行 NULL。
- 部署后按线上口径回查，Play 营收只剩 GBP / ILS / TRY 三行，HUF 6,319 已不计入。