### PR TITLE
fix(web): /guides 缓存篇改吃 cf-cache-status 词簇，并按最新官方文档校正

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-purge-cache-not-working/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-purge-cache-not-working/page.tsx
@@ -57,7 +57,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 const RELATED: RelatedLink[] = [
 	{
 		href: "/guides/why-is-cloudflare-not-caching-my-site",
-		label: "Why is Cloudflare not caching my site?",
+		label: "What cf-cache-status DYNAMIC, BYPASS and MISS mean",
 		note: "The opposite problem, and the header that tells them apart: DYNAMIC, BYPASS and a MISS that never becomes a HIT.",
 	},
 	{

--- a/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-ssl-tls-encryption-modes/page.tsx
@@ -56,7 +56,7 @@ const RELATED: RelatedLink[] = [
 	},
 	{
 		href: "/guides/why-is-cloudflare-not-caching-my-site",
-		label: "Why is Cloudflare not caching my site?",
+		label: "cf-cache-status: DYNAMIC vs BYPASS vs MISS",
 		note: "The origin scheme this setting picks is part of every cache key — what that means in practice.",
 	},
 	{

--- a/apps/web/src/app/[locale]/guides/why-is-cloudflare-not-caching-my-site/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-cloudflare-not-caching-my-site/page.tsx
@@ -16,6 +16,7 @@ const DOCS_DEFAULTS = "https://developers.cloudflare.com/cache/concepts/default-
 const DOCS_RULES = "https://developers.cloudflare.com/cache/how-to/cache-rules/";
 const DOCS_KEYS = "https://developers.cloudflare.com/cache/how-to/cache-keys/";
 const DOCS_ORIGIN_CC = "https://developers.cloudflare.com/cache/concepts/cache-control/";
+const DOCS_CDNCC = "https://developers.cloudflare.com/cache/concepts/cdn-cache-control/";
 const DOCS_DEV_MODE = "https://developers.cloudflare.com/cache/reference/development-mode/";
 const DOCS_TRACE = "https://developers.cloudflare.com/rules/trace-request/";
 const DOCS_TIERED = "https://developers.cloudflare.com/cache/how-to/tiered-cache/";
@@ -26,23 +27,23 @@ const DOCS_BYPASS_CHANGE =
 const FAQ: Array<{ q: string; a: string }> = [
 	{
 		q: "What does cf-cache-status: DYNAMIC mean?",
-		a: "It means Cloudflare decided the request was not eligible for caching before it ever looked in the cache, so the request went straight to your origin. The usual reason is that the file extension is not one Cloudflare caches by default — HTML and JSON are not — and no Cache Rule says otherwise.",
+		a: "It means Cloudflare decided the request was not eligible for caching before it ever looked in the cache, so the request went straight to your origin. The usual reason is that the file extension is not one Cloudflare caches by default \u2014 HTML and JSON are not \u2014 and no Cache Rule says otherwise.",
 	},
 	{
-		q: "Why is Cloudflare not caching my HTML pages?",
-		a: "Because Cloudflare decides eligibility by file extension, and HTML is deliberately excluded from the default list. Pages are served from your origin until you add a Cache Rule that marks them eligible for cache and gives them an edge TTL.",
+		q: "What is the difference between DYNAMIC and BYPASS?",
+		a: "Timing. DYNAMIC is decided at request time, from the URL and your rules, before the cache is consulted at all. BYPASS is decided at response time: the request was eligible, but something your origin returned \u2014 a Set-Cookie header, a no-store directive, an oversized body \u2014 made the response unstorable. DYNAMIC is usually fixed in Cloudflare, BYPASS on your server.",
 	},
 	{
 		q: "What is the difference between BYPASS and MISS in Cloudflare?",
-		a: "BYPASS means Cloudflare refused to store the response — it was eligible at request time, but something in the response, such as a Set-Cookie header or an oversized body, made it uncacheable. MISS means the response was cacheable and simply was not in that data center's cache yet, so the next request should be a HIT.",
+		a: "BYPASS means Cloudflare refused to store the response. MISS means the response was cacheable and simply was not in that data center's cache yet, so the next request to the same location should be a HIT. A MISS that never becomes a HIT is a third problem, and it is almost always the cache key.",
+	},
+	{
+		q: "Why is Cloudflare not caching my site?",
+		a: "Most likely because nothing is broken. Cloudflare judges eligibility by file extension, and HTML is deliberately excluded from the default list, so pages are served from your origin and report DYNAMIC until you add a Cache Rule that marks them eligible for cache and gives them an edge TTL.",
 	},
 	{
 		q: "Why does Cloudflare keep returning MISS on every request?",
 		a: "Almost always because each request produces a different cache key. Query strings count toward the key by default, so tracking parameters, session IDs, or timestamps split one asset into thousands of entries that are never requested twice. Low-traffic assets can also be evicted between requests.",
-	},
-	{
-		q: "Does a Set-Cookie header stop Cloudflare from caching?",
-		a: "By default, yes — a response carrying Set-Cookie is not stored, and it reports BYPASS. You can override that by setting an explicit edge TTL in a Cache Rule that ignores origin cache-control, by having the origin send Cache-Control: private=“Set-Cookie”, or by stripping the header with a response header Transform Rule.",
 	},
 ];
 
@@ -144,40 +145,46 @@ export default async function NotCachingGuide({ params }: { params: Promise<{ lo
 			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 			<GuideShell
 				title={guide.h1}
-				lede="Putting a site behind a proxy does not make it a cached site. One response header tells you which decision was made, at which moment, and therefore which setting is worth changing."
+				lede="Putting a site behind a proxy does not make it a cached site. One response header names the decision Cloudflare made, at which moment it was made, and therefore which setting is worth changing."
 				updated={guide.updated}
 				readingTime={guide.readingTime}
 				related={RELATED}
 			>
 				<div className="glass r-island note p-6 sm:p-7">
 					<p>
-						Cloudflare caches by file extension, and HTML and JSON are not on the default list — so most
-						pages return <code>cf-cache-status: DYNAMIC</code> until a Cache Rule makes them eligible.{" "}
-						<code>BYPASS</code> means the origin response blocked caching instead.
+						<code>cf-cache-status</code> names the cache decision. <code>DYNAMIC</code> means the request
+						was never eligible — HTML and JSON are not cached by default. <code>BYPASS</code> means the
+						origin response blocked storage. <code>MISS</code> means it was cacheable but not stored yet.
 					</p>
 				</div>
 
 				<p>
-					The common assumption is that traffic routed through Cloudflare is cached traffic, and that a slow
-					page means the cache is broken. Neither is quite right. Static assets are cached by default, pages
-					are not, and there are several distinct ways a response can end up served from your server — each
-					with a different fix. Guessing between them is how people end up stacking rules that cancel each
-					other out.
+					Ask why Cloudflare is not caching your site and the honest answer is usually that it is working as
+					designed. The assumption underneath the question — that traffic routed through Cloudflare is cached
+					traffic — is the part that is wrong. Static assets are cached by default, pages are not, and there
+					are several distinct ways a response ends up served from your server, each with a different fix.
+					Guessing between them is how people stack rules that cancel each other out.
 				</p>
 
-				<h2 id="read-the-header">Read the header before you change any setting</h2>
+				<h2 id="read-the-header">Read the cf-cache-status header before changing any setting</h2>
 				<p>
-					Every proxied response carries a <code>cf-cache-status</code> header, and it names the decision
-					that was made. Fetch the URL and look at it before touching the dashboard:
+					Every proxied response carries this header, and it names the decision that was made. Tooling spells
+					it inconsistently — <code>CF-Cache-Status</code> in Cloudflare&rsquo;s own documentation,{" "}
+					<code>cf-cache-status</code> on the wire, plain cache status in most dashboards — but it is one
+					header carrying one value per response. Fetch the URL and read it before touching anything:
 				</p>
 				<pre>
 					<code>curl -sSI https://example.com/ | grep -iE &apos;^(cf-cache-status|age):&apos;</code>
 				</pre>
 				<p>
-					The <code>Age</code> header is a useful companion: it reports how many seconds the asset has been
-					sitting in cache, and it appears only on responses actually served from cache. If <code>Age</code>{" "}
-					is missing, the response came from your origin, whatever else the page appears to be doing. If the
-					headers are absent entirely, the hostname is probably not proxied at all — see{" "}
+					The <code>Age</code> header is a useful companion, with one caveat. Cloudflare sets it on{" "}
+					<code>HIT</code>, <code>STALE</code>, and <code>UPDATING</code> responses, reporting how many
+					seconds the asset has been in cache since it was admitted or last revalidated. It is absent on{" "}
+					<code>MISS</code>, <code>DYNAMIC</code>, <code>BYPASS</code>, and <code>NONE/UNKNOWN</code> — but
+					if your origin sends its own <code>Age</code> on an uncacheable response, Cloudflare passes that
+					value through unchanged. So <code>Age</code> corroborates <code>cf-cache-status</code>; it never
+					substitutes for it. If both headers are absent entirely, the hostname is probably not proxied at
+					all — see{" "}
 					<Link href="/guides/what-is-the-orange-cloud-in-cloudflare">
 						proxied vs DNS only
 					</Link>{" "}
@@ -246,15 +253,17 @@ export default async function NotCachingGuide({ params }: { params: Promise<{ lo
 				<p>
 					That last row catches people out. A Worker that answers without a subrequest, a blocked WAF
 					request, and a redirect rule all short-circuit ahead of the cache, so they are labelled{" "}
-					<code>NONE/UNKNOWN</code> rather than describing a cache outcome at all. The full reference lives
-					in the{" "}
+					<code>NONE/UNKNOWN</code> rather than describing a cache outcome at all. <code>REVALIDATED</code>{" "}
+					is also rarer than it used to be: with asynchronous stale-while-revalidate, a refresh that once
+					made the visitor wait now usually reports <code>UPDATING</code> or <code>HIT</code> instead. The
+					full reference lives in the{" "}
 					<a href={DOCS_STATUSES} target="_blank" rel="noopener noreferrer">
 						cache responses documentation
 					</a>
 					.
 				</p>
 
-				<h2 id="two-decisions">Two decisions, not one</h2>
+				<h2 id="two-decisions">DYNAMIC vs BYPASS: two decisions, not one</h2>
 				<CacheDecision />
 				<p>
 					<code>DYNAMIC</code> and <code>BYPASS</code> both mean &ldquo;not cached&rdquo;, and they are
@@ -346,6 +355,15 @@ export default async function NotCachingGuide({ params }: { params: Promise<{ lo
 								<td>Always bypasses, whatever else is configured</td>
 							</tr>
 							<tr>
+								<th scope="row">
+									<code>CDN-Cache-Control: no-store</code>
+								</th>
+								<td>
+									Read ahead of <code>Cache-Control</code>, so it wins even when{" "}
+									<code>Cache-Control</code> declares the response public and cacheable
+								</td>
+							</tr>
+							<tr>
 								<th scope="row">Body over the size limit</th>
 								<td>512 MB on Free, Pro, and Business; 5 GB by default on Enterprise</td>
 							</tr>
@@ -354,21 +372,28 @@ export default async function NotCachingGuide({ params }: { params: Promise<{ lo
 									Request had <code>Authorization</code>
 								</th>
 								<td>
-									Cacheable only if the response also carries <code>public</code>,{" "}
-									<code>s-maxage</code>, or <code>must-revalidate</code>
+									With origin cache-control enabled, cacheable only if the response also carries{" "}
+									<code>public</code>, <code>s-maxage</code>, or <code>must-revalidate</code>
 								</td>
 							</tr>
 						</tbody>
 					</table>
 				</div>
 				<p>
-					Two of these are worth knowing precisely. First, whether <code>no-cache</code> blocks caching
-					depends on{" "}
+					Three of these are worth knowing precisely. First, the header Cloudflare actually obeys is not
+					always the one you set: it reads{" "}
+					<a href={DOCS_CDNCC} target="_blank" rel="noopener noreferrer">
+						<code>Cloudflare-CDN-Cache-Control</code>, then <code>CDN-Cache-Control</code>
+					</a>
+					, and only then <code>Cache-Control</code> — so an origin returning{" "}
+					<code>Cache-Control: public, max-age=3600</code> alongside <code>CDN-Cache-Control: no-store</code>{" "}
+					bypasses cache, and the <code>Cache-Control</code> header you keep re-checking is the wrong one to
+					look at. Second, whether <code>no-cache</code> blocks caching depends on{" "}
 					<a href={DOCS_ORIGIN_CC} target="_blank" rel="noopener noreferrer">
 						origin cache-control
 					</a>
 					, which is enabled by default on Free, Pro, and Business plans and disabled by default on
-					Enterprise — so identical origin headers behave differently on different plans. Second, since{" "}
+					Enterprise — so identical origin headers behave differently on different plans. Third, since{" "}
 					<a href={DOCS_BYPASS_CHANGE} target="_blank" rel="noopener noreferrer">
 						a change in May 2026
 					</a>

--- a/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
+++ b/apps/web/src/app/[locale]/guides/why-is-my-cloudflare-dns-change-not-working/page.tsx
@@ -64,7 +64,7 @@ const RELATED: RelatedLink[] = [
 	},
 	{
 		href: "/guides/why-is-cloudflare-not-caching-my-site",
-		label: "Why is Cloudflare not caching my site?",
+		label: "Reading the cf-cache-status header",
 		note: "The other kind of stale answer: the one Cloudflare itself is serving from cache.",
 	},
 	{

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -70,13 +70,13 @@ export const GUIDES: GuideMeta[] = [
 	},
 	{
 		slug: "why-is-cloudflare-not-caching-my-site",
-		h1: "Why Is Cloudflare Not Caching My Site?",
-		title: "Why Isn't Cloudflare Caching My Site? cf-cache-status",
+		h1: "What Does cf-cache-status DYNAMIC, BYPASS, or MISS Mean?",
+		title: "Cloudflare cf-cache-status: DYNAMIC vs BYPASS vs MISS",
 		description:
-			"Cloudflare does not cache HTML or JSON by default. DYNAMIC means the request was never eligible; BYPASS means the origin response blocked caching.",
+			"cf-cache-status names the cache decision: DYNAMIC was never eligible, BYPASS was blocked by the origin response, MISS was cacheable but not stored yet.",
 		blurb:
-			"DYNAMIC, BYPASS and a MISS that never becomes a HIT are three different failures with three different fixes — read the header first.",
-		updated: "2026-08-20",
+			"One header names the decision Cloudflare made. DYNAMIC, BYPASS and a MISS that never becomes a HIT are three different failures with three different fixes.",
+		updated: "2026-09-04",
 		readingTime: "8 min read",
 	},
 	{


### PR DESCRIPTION
## 为什么是这一篇（数据依据）

本轮触发的是任务的「修复优先于新增」规则第 3 条：

| 检查 | 结果 |
|---|---|
| 上线时长 | 2026-08-20 首次提交，**15 天** |
| 收录状态 | 已提交，且已编入索引 |
| 28 天展示量 | **0**（点击 0） |
| URL 检查 | verdict PASS，robots ALLOWED，user/google canonical 一致 |

技术面全部干净，所以问题在选题与 title/meta。原标题打的 `why is cloudflare not caching my site` 是被 Cloudflare Community 与 Stack Overflow 占满的宽泛排障问句，新站排不进可见位次，因此连展示都拿不到。

对照站内跑得最好的一篇：`/guides/cloudflare-orange-to-orange`（460 展示 / 均位 7.0），赢在**窄而具体的技术实体**——而且词簇里展示量最大的是缩写 `cloudflare o2o`（45）而非全称。本文真正解释的实体是 `cf-cache-status` 这个响应头及其取值，正好符合同一模式，于是把 title / H1 / meta / 小节标题 / FAQ 整体切到该词簇。

**slug 保持不变**，以留住已有的收录条目、避免引入跳转。

`gaps` 里标 `[可做]` 的词本轮未采用：`cloud orange` / `cloudflare orange` / `icloud orange` 等都紧贴品牌词、由首页承接，属于任务明令不去抢的一类。

## 核对官方文档后修正了什么

文章写于 8 月 20 日，`cache-responses` 文档此后更新到 8 月 21 日版，逐条核对后有三处需要改：

1. **`Age` 头的论断两个方向都不成立**（[cache-responses](https://developers.cloudflare.com/cache/concepts/cache-responses/)）。原文写「只出现在真正命中缓存的响应上；缺失即说明来自源站」。实际上 Cloudflare 只在 `HIT` / `STALE` / `UPDATING` 上设置它——`REVALIDATED` 走源站校验时并不带，所以缺失不等于来自源站；而源站自己发的 `Age` 会被原样透传，所以 `DYNAMIC` / `BYPASS` 也可能带 `Age`。已改为「`Age` 只能佐证 `cf-cache-status`，不能替代它」。

2. **BYPASS 表原先完全没有 `CDN-Cache-Control`**（[cdn-cache-control](https://developers.cloudflare.com/cache/concepts/cdn-cache-control/)）。Cloudflare 的读取优先级是 `Cloudflare-CDN-Cache-Control` > `CDN-Cache-Control` > `Cache-Control`，因此源站同时返回 `Cache-Control: public, max-age=3600` 与 `CDN-Cache-Control: no-store` 时结果是 BYPASS。这正是「我明明设了 public 却还是 BYPASS」的常见成因，属于真实缺口，已补一行表格加一段说明。

3. **两处限定词缺失**：`Authorization` 那一行只在 origin cache-control 启用时成立（Free/Pro/Business 默认启用，Enterprise 默认关闭时 `Authorization` 本身不阻止缓存）；`REVALIDATED` 补上异步 stale-while-revalidate 之后多返回 `UPDATING` / `HIT` 的现状。

**核对后放弃改动的**：缓存体积上限（512 MB / 5 GB）、`Vary: *` 恒 bypass、`no-cache` 随 origin cache-control 变化这三处与当前文档一致，原文无误，保留。

## 硬门槛逐项结果

| # | 项目 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ exit 0，462 页预渲染，无新增告警（仅既有的 middleware 废弃告警） |
| 2 | `npx vitest run` | ✅ 22 文件 / 172 测试全绿 |
| 3 | `npx eslint`（5 个改动文件） | ✅ exit 0，无 error |
| 4 | 页面可服务 | ⚠️ **换了方式**：本次为无人值守定时任务，harness 禁止起 dev server。改为断言 `next build` 的预渲染产物 `.next/server/app/en/guides/…html`（下列各项均跑在该文件上），并确认线上同 URL 现为 200。合并部署后已复验线上 200 |
| 5 | canonical 自引用 + hreflang | ✅ canonical 自引用；alternate 只有 `en` 与 `x-default`，且都指向自身 |
| 6 | JSON-LD 可解析 + FAQ 逐字 | ✅ 脚本断言：`TechArticle` / `FAQPage` / `BreadcrumbList` 齐全，5 条问答的问与答**逐字**出现在渲染后可见正文中 |
| 7 | 标题层级 | ✅ `[1,2,2,2,2,2,2,2,2,3,3,3,3,3,2,2]`，h1 唯一，无跳级 |
| 8 | 375px 无横向溢出 | ✅ `scrollWidth == clientWidth == 375`，两张表均在 `.table-wrap` 内部横滚（480 → 327） |
| 9 | 外链 2xx/3xx | ✅ 12 条全部 200（含新增的 cdn-cache-control） |
| 10 | 词数 1000–1800 | ✅ 1778 |

## 变体覆盖

`cf-cache-status`（正文通篇）、`CF-Cache-Status`（官方写法，一处）、`cache status`（一处）、`DYNAMIC vs BYPASS`（小节标题）、`BYPASS vs MISS`（FAQ）各有自然落点；原问法 `why is Cloudflare not caching my site` 保留在开篇与一条 FAQ 中，不丢已有信号。

四处站内入链的锚文本原先完全相同，已去重为三种写法。