### PR TITLE
fix(ios): AppShortcuts.xcstrings 源语言对齐 zh-Hans，修复 exportLocalizations 中断

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud/AppShortcuts.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/AppShortcuts.xcstrings
@@ -1,5 +1,5 @@
 {
-  "sourceLanguage" : "en",
+  "sourceLanguage" : "zh-Hans",
   "strings" : {
     "打开 ${applicationName}" : {
       "localizations" : {


### PR DESCRIPTION
## 问题

按 CLAUDE.md 发版清单第 3 步跑本地化覆盖核对时，导出中途失败：

```
xcodebuild: error: AppShortcuts.xcstrings: Project has development language zh-Hans but .xcstrings has sourceLocale en
    Please use the same language code for development/source.
```

导出在写出 `zh-Hans.xliff` 之前就退出，只留下 Source Contents，导致 `-exportLocalizations` 这条明文要求的核对手段不可用。

## 根因

`AppShortcuts.xcstrings` 的 `sourceLanguage` 是 `en`，而工程 `developmentRegion`（`project.pbxproj:487`）是 `zh-Hans`。仓库内 6 个 xcstrings 里，它是唯一的异类：

| catalog | 改前 sourceLanguage |
|---|---|
| `Orange Cloud/Localizable.xcstrings` | zh-Hans |
| `Orange Cloud/Core/WhatsNew/WhatsNew.xcstrings` | zh-Hans |
| `OrangeCloudWidgets/Localizable.xcstrings` | zh-Hans |
| `Orange Cloud Watch/Localizable.xcstrings` | zh-Hans |
| `Orange Cloud Watch Watch App/Localizable.xcstrings` | zh-Hans |
| **`Orange Cloud/AppShortcuts.xcstrings`** | **en** ← |

## 改法：只修字段，不迁 key

改 `sourceLanguage` 通常会让 key 与源语言错位（若 key 是英文短语，需要连同 key 一起迁成中文并把英文移进 en localization）。这里**不需要**——该 catalog 的实际形态本就正确：

- 三个 key 已是中文源文案：`打开 ${applicationName}`、`查询 ${applicationName} 域名状态`、`用 ${applicationName} 查域名`；
- 与 `OrangeCloudIntents.swift:91-100` 的短语字面量逐字一致；
- 英文早已在各自的 `en` localization 里（`Open ${applicationName}` 等）。

错的只有 `sourceLanguage` 这一个字段——此前 zh-Hans 用户是靠「取不到译文就回落到 key」歪打正着地看到中文。因此本 PR 只改该字段，key 与 en localization 一律不动，Siri 短语所需的 `${applicationName}` 占位符三条全部保留（已脚本校验）。

改动就是一行：

```diff
-  "sourceLanguage" : "en",
+  "sourceLanguage" : "zh-Hans",
```

## 验证

- `xcodebuild -exportLocalizations -project "Orange Cloud.xcodeproj" -localizationPath <out> -exportLanguage zh-Hans` → 退出码 0，产出 `zh-Hans.xcloc/Localized Contents/zh-Hans.xliff`（624,355 字节，12 个 `<file>` 段）。`AppShortcuts.xcstrings` 段头为 `source-language="zh-Hans"`，三条短语齐全，`${applicationName}` 完整（文案包在 `<mrk mtype="x-set">` 子元素中）。原报错消失。
- `xcodebuild -scheme "Orange Cloud" build` → 退出码 0，`** BUILD SUCCEEDED **`，无 error。

日志中 grep `error` 的命中全部来自既有 warning 的措辞 `this is an error in the Swift 6 language mode`（`Shared/WidgetConfigIntents.swift` 等），与本次改动无关。

## 关于 diff 洁净度

导出与构建都会**就地重写** xcstrings：`AppShortcuts.xcstrings` 的译文状态位会因源语言变更被翻牌成 `needs_review` 并新增 `extractionState`（译文一字未改），`Localizable.xcstrings` 会被整体 canonical 重排（22 万行）。这些是构建产物噪音，已按仓库约定从 HEAD 基线重注入，本 PR 仅含那一行真实改动。

提醒：以后每次跑发版清单第 3 步，这两个文件仍会被弄脏，提交前需照样 restore。
