### PR TITLE
fix(ios): Worker 大脚本编辑不再卡死 + 新增「历史日志」

### DIFF
--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -166920,6 +166920,386 @@
           }
         }
       }
+    },
+    "当前线上脚本 %@，超出手机端就地编辑的上限，已转为只读。可以导入改好的 .js 文件整体替换。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حجم النص البرمجي الحالي %@ ويتجاوز حد التحرير على الجهاز، لذا فهو للقراءة فقط. يمكنك استيراد ملف .js معدَّل لاستبداله بالكامل."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das aktive Skript ist %@ groß und überschreitet die Grenze für die Bearbeitung auf dem Gerät; es ist daher schreibgeschützt. Du kannst eine bearbeitete .js-Datei importieren, um es vollständig zu ersetzen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The live script is %@, which exceeds the limit for editing on device, so it is read-only. You can import an edited .js file to replace it entirely."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El script en línea pesa %@ y supera el límite para editarlo en el dispositivo, así que es de solo lectura. Puedes importar un archivo .js modificado para reemplazarlo por completo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script en ligne fait %@ et dépasse la limite d’édition sur l’appareil : il est donc en lecture seule. Vous pouvez importer un fichier .js modifié pour le remplacer entièrement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のスクリプトは %@ で、端末上で直接編集できる上限を超えるため読み取り専用になっています。編集済みの .js ファイルを読み込んで全体を置き換えられます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 스크립트는 %@ 로 기기에서 직접 편집할 수 있는 한도를 초과하여 읽기 전용입니다. 수정한 .js 파일을 가져와 전체를 교체할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O script em produção tem %@ e excede o limite para edição no dispositivo, por isso está somente leitura. Você pode importar um arquivo .js editado para substituí-lo por completo."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O script em produção tem %@ e excede o limite para edição no dispositivo, pelo que está apenas de leitura. Pode importar um ficheiro .js editado para o substituir por completo."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yayındaki betik %@ boyutunda ve cihaz üzerinde düzenleme sınırını aştığı için salt okunur. Düzenlediğiniz bir .js dosyasını içe aktararak tamamını değiştirebilirsiniz."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前線上腳本 %@，超出在手機上直接編輯的上限，已轉為唯讀。可以匯入改好的 .js 檔案整份取代。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前線上指令碼 %@，超出在手機上直接編輯的上限，已轉為唯讀。可以匯入改好的 .js 檔案整份取代。"
+          }
+        }
+      }
+    },
+    "当前线上脚本是压缩过的打包产物（%@，存在超长行），不适合在手机上就地编辑，已转为只读。可以导入改好的 .js 文件整体替换。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النص البرمجي الحالي حزمة مصغَّرة (%@، وتحتوي على أسطر طويلة جدًا) لا تناسب التحرير على الجهاز، لذا فهو للقراءة فقط. يمكنك استيراد ملف .js معدَّل لاستبداله بالكامل."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das aktive Skript ist ein minifiziertes Bundle (%@, mit sehr langen Zeilen) und eignet sich nicht zur Bearbeitung auf dem Gerät; es ist daher schreibgeschützt. Du kannst eine bearbeitete .js-Datei importieren, um es vollständig zu ersetzen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The live script is a minified bundle (%@, with very long lines), which is not suitable for editing on device, so it is read-only. You can import an edited .js file to replace it entirely."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El script en línea es un paquete minificado (%@, con líneas muy largas) y no es apto para editarse en el dispositivo, así que es de solo lectura. Puedes importar un archivo .js modificado para reemplazarlo por completo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script en ligne est un bundle minifié (%@, avec des lignes très longues), inadapté à l’édition sur l’appareil : il est donc en lecture seule. Vous pouvez importer un fichier .js modifié pour le remplacer entièrement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のスクリプトは圧縮されたバンドル（%@、極端に長い行を含む）で、端末上での直接編集に向かないため読み取り専用になっています。編集済みの .js ファイルを読み込んで全体を置き換えられます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 스크립트는 압축된 번들(%@, 매우 긴 줄 포함)이라 기기에서 직접 편집하기에 적합하지 않아 읽기 전용입니다. 수정한 .js 파일을 가져와 전체를 교체할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O script em produção é um pacote minificado (%@, com linhas muito longas) e não é adequado para edição no dispositivo, por isso está somente leitura. Você pode importar um arquivo .js editado para substituí-lo por completo."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O script em produção é um pacote minificado (%@, com linhas muito longas) e não é adequado para edição no dispositivo, pelo que está apenas de leitura. Pode importar um ficheiro .js editado para o substituir por completo."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yayındaki betik küçültülmüş bir paket (%@, çok uzun satırlar içeriyor) ve cihaz üzerinde düzenlemeye uygun olmadığı için salt okunur. Düzenlediğiniz bir .js dosyasını içe aktararak tamamını değiştirebilirsiniz."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前線上腳本是壓縮過的打包產物（%@，含超長行），不適合在手機上直接編輯，已轉為唯讀。可以匯入改好的 .js 檔案整份取代。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前線上指令碼是壓縮過的封裝產物（%@，含超長行），不適合在手機上直接編輯，已轉為唯讀。可以匯入改好的 .js 檔案整份取代。"
+          }
+        }
+      }
+    },
+    "待部署文件": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الملف المراد نشره"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zu veröffentlichende Datei"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File to deploy"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivo por implementar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichier à déployer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デプロイするファイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "배포할 파일"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivo a implantar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ficheiro a implementar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dağıtılacak dosya"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待部署檔案"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待部署檔案"
+          }
+        }
+      }
+    },
+    "导入 .js 文件整体替换": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استيراد ملف .js لاستبداله بالكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit .js-Datei ersetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import a .js file to replace it"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar un archivo .js para reemplazar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer un fichier .js pour remplacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".js ファイルを読み込んで全体を置き換え"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".js 파일을 가져와 전체 교체"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar um arquivo .js para substituir"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar um ficheiro .js para substituir"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Değiştirmek için .js dosyası içe aktar"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯入 .js 檔案整份取代"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯入 .js 檔案整份取代"
+          }
+        }
+      }
+    },
+    "重新选择文件": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختيار ملف آخر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Andere Datei wählen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a different file"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir otro archivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir un autre fichier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを選び直す"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 파일 선택"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolher outro arquivo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolher outro ficheiro"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başka dosya seç"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新選擇檔案"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新選擇檔案"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
+++ b/apps/ios/Orange Cloud/Orange Cloud/Localizable.xcstrings
@@ -167300,6 +167300,842 @@
           }
         }
       }
+    },
+    "（无正文）": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(بدون محتوى)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(kein Inhalt)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(no message)"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(sin contenido)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(aucun contenu)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（本文なし）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(내용 없음)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(sem conteúdo)"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(sem conteúdo)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(içerik yok)"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（無內容）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（無內容）"
+          }
+        }
+      }
+    },
+    "3 小时": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 ساعات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Stunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 hours"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 horas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 heures"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3時間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3시간"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 horas"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 horas"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 saat"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 小時"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 小時"
+          }
+        }
+      }
+    },
+    "3 天": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 أيام"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Tage"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 days"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 días"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 jours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3日間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3일"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 dias"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 dias"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 gün"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 天"
+          }
+        }
+      }
+    },
+    "历史日志": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السجلات السابقة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlaufsprotokolle"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historical Logs"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros históricos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journaux historiques"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴ログ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록 로그"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs históricos"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registos históricos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçmiş günlükler"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歷史日誌"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歷史記錄"
+          }
+        }
+      }
+    },
+    "命中 %lld 条，已载入 %lld 条": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld مطابقة · %2$lld محمَّلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld Treffer · %2$lld geladen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld matched · %2$lld loaded"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld coincidencias · %2$lld cargados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld résultats · %2$lld chargés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 件ヒット・%2$lld 件読み込み済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld건 일치 · %2$lld건 불러옴"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld correspondências · %2$lld carregados"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld correspondências · %2$lld carregados"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld eşleşme · %2$lld yüklendi"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命中 %1$lld 條，已載入 %2$lld 條"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命中 %1$lld 筆，已載入 %2$lld 筆"
+          }
+        }
+      }
+    },
+    "这段时间没有日志": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد سجلات في هذه الفترة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Protokolle in diesem Zeitraum"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No logs in this period"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay registros en este periodo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun journal sur cette période"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間のログはありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 기간에는 로그가 없습니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum log neste período"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum registo neste período"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu dönemde günlük yok"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這段時間沒有日誌"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這段時間沒有記錄"
+          }
+        }
+      }
+    },
+    "换个时间范围看看。若这个 Worker 从未出现日志，多半是没有开启 Observability——在 wrangler.toml 里打开 [observability] 后重新部署即可。": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جرِّب نطاقًا زمنيًا آخر. إذا لم تظهر سجلات لهذا الـ Worker إطلاقًا، فالأرجح أن Observability معطَّل — فعِّل [observability] في ملف wrangler.toml ثم أعد النشر."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probiere einen anderen Zeitraum. Wenn dieser Worker nie Protokolle zeigt, ist Observability vermutlich deaktiviert – aktiviere [observability] in der wrangler.toml und veröffentliche erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try another time range. If this Worker never shows logs, Observability is probably off — enable [observability] in wrangler.toml and redeploy."
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba con otro rango de tiempo. Si este Worker nunca muestra registros, es probable que Observability esté desactivado: actívalo con [observability] en wrangler.toml y vuelve a implementar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essayez une autre période. Si ce Worker n’affiche jamais de journaux, Observability est sans doute désactivé : activez [observability] dans wrangler.toml puis redéployez."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別の期間を試してください。この Worker のログがまったく出ない場合は Observability が無効な可能性があります。wrangler.toml で [observability] を有効にして再デプロイしてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 기간을 확인해 보세요. 이 Worker의 로그가 전혀 없다면 Observability가 꺼져 있을 수 있습니다. wrangler.toml에서 [observability]를 켜고 다시 배포하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tente outro intervalo de tempo. Se este Worker nunca mostra logs, provavelmente o Observability está desativado: ative [observability] no wrangler.toml e implante novamente."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimente outro intervalo de tempo. Se este Worker nunca mostra registos, provavelmente o Observability está desativado: ative [observability] no wrangler.toml e implemente novamente."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başka bir zaman aralığı deneyin. Bu Worker hiç günlük göstermiyorsa Observability kapalı olabilir: wrangler.toml içinde [observability] ayarını açıp yeniden dağıtın."
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換個時間範圍看看。若這個 Worker 從未出現日誌，多半是沒有開啟 Observability——在 wrangler.toml 裡打開 [observability] 後重新部署即可。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換個時間範圍看看。若這個 Worker 從未出現記錄，多半是沒有開啟 Observability——在 wrangler.toml 裡打開 [observability] 後重新部署即可。"
+          }
+        }
+      }
+    },
+    "事件类型": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوع الحدث"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignistyp"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event type"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de evento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type d’événement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントタイプ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이벤트 유형"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de evento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de evento"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olay türü"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件類型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件類型"
+          }
+        }
+      }
+    },
+    "触发": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المُشغِّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trigger"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déclencheur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トリガー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트리거"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gatilho"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acionador"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tetikleyici"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "觸發"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "觸發"
+          }
+        }
+      }
+    },
+    "请求 ID": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف الطلب"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfrage-ID"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request ID"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de solicitud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de requête"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リクエスト ID"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청 ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID da requisição"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID do pedido"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İstek kimliği"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求 ID"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求 ID"
+          }
+        }
+      }
+    },
+    "Ray ID": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف Ray"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray-ID"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray ID"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de Ray"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID Ray"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray ID"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID do Ray"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID do Ray"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray kimliği"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray ID"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ray ID"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerLogModels.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Models/WorkerLogModels.swift
@@ -1,0 +1,172 @@
+//
+//  WorkerLogModels.swift
+//  Orange Cloud
+//
+//  Workers Logs（Observability）历史日志查询模型。
+//
+//  与 tail 的区别：tail 是 WebSocket 实时流，只播放连接期间发生的调用；
+//  这里查的是 Cloudflare 持久化下来的事件（网页端 Worker → Observability → Events），
+//  可以回溯。端点 POST /accounts/{id}/workers/observability/telemetry/query。
+//
+//  注意：Workers Logs 需要在 Worker 上开启 observability（wrangler.toml 的
+//  [observability] enabled = true），没开的 Worker 查出来就是空。
+//
+
+import Foundation
+
+// MARK: - 请求
+
+/// telemetry/query 请求体。必填 queryId + timeframe；view=events 取逐条日志。
+nonisolated struct ObservabilityQueryRequest: Codable, Sendable {
+    let queryId:    String
+    let timeframe:  Timeframe
+    let view:       String
+    let limit:      Int
+    let parameters: Parameters
+    /// 保持 false（与网页端一致）：dry 的语义是「执行但不持久化」，
+    /// 官方未承诺 dry 下仍回结果，这里不赌
+    let dry:        Bool
+    let offset:     String?
+    let offsetDirection: String?
+
+    nonisolated struct Timeframe: Codable, Sendable {
+        let from: Int64      // Unix 毫秒
+        let to:   Int64
+    }
+
+    nonisolated struct Parameters: Codable, Sendable {
+        let datasets: [String]          // 留空 = 查全部数据集
+        let filters:  [Filter]
+        let needle:   Needle?
+    }
+
+    nonisolated struct Filter: Codable, Sendable {
+        let key:       String
+        let operation: String
+        let type:      String
+        let value:     String
+    }
+
+    nonisolated struct Needle: Codable, Sendable {
+        let value:     String
+        let matchCase: Bool
+    }
+}
+
+// MARK: - 响应
+
+nonisolated struct ObservabilityQueryResult: Codable, Sendable {
+    let events: EventsBlock?
+
+    nonisolated struct EventsBlock: Codable, Sendable {
+        /// 命中总数（可能大于本页返回条数）
+        let count:  Double?
+        let events: [TelemetryEvent]?
+    }
+}
+
+/// 一条日志事件。字段几乎全在 `$metadata` 里，`$workers` 补事件类型与结果。
+nonisolated struct TelemetryEvent: Codable, Sendable {
+    let timestamp: Double?          // Unix 毫秒
+    let metadata:  EventMetadata?
+    let workers:   EventWorkersInfo?
+
+    enum CodingKeys: String, CodingKey {
+        case timestamp
+        case metadata = "$metadata"
+        case workers  = "$workers"
+    }
+
+    /// 事件时刻：优先 top-level timestamp，回落 $metadata.startTime
+    var date: Date {
+        let ms = timestamp ?? metadata?.startTime ?? 0
+        return Date(timeIntervalSince1970: ms / 1000)
+    }
+
+    /// 展示正文：日志消息 / 错误 / 触发描述，按可用性回落
+    var displayText: String {
+        if let message = metadata?.message, !message.isEmpty { return message }
+        if let error = metadata?.error, !error.isEmpty { return error }
+        if let trigger = metadata?.trigger, !trigger.isEmpty { return trigger }
+        if let url = metadata?.url, !url.isEmpty { return url }
+        return String(localized: "（无正文）")
+    }
+
+    /// 归一化级别，与 tail 的 LevelFilter 口径一致
+    var level: String {
+        if let level = metadata?.level?.lowercased(), !level.isEmpty { return level }
+        if metadata?.error?.isEmpty == false { return "error" }
+        return "event"
+    }
+}
+
+/// 容错解码：字段类型与文档有出入时降级为 nil，不让整条事件解码失败
+nonisolated struct EventMetadata: Codable, Sendable {
+    let id:         String?
+    let level:      String?
+    let message:    String?
+    let error:      String?
+    let service:    String?
+    let trigger:    String?
+    let origin:     String?
+    let requestId:  String?
+    let rayId:      String?
+    let region:     String?
+    let type:       String?
+    let url:        String?
+    let statusCode: Int?
+    let duration:   Double?
+    let startTime:  Double?
+
+    enum CodingKeys: String, CodingKey {
+        case id, level, message, error, service, trigger, origin
+        case requestId, rayId, region, type, url, statusCode, duration, startTime
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id         = try? c.decode(String.self, forKey: .id)
+        level      = try? c.decode(String.self, forKey: .level)
+        message    = try? c.decode(String.self, forKey: .message)
+        error      = try? c.decode(String.self, forKey: .error)
+        service    = try? c.decode(String.self, forKey: .service)
+        trigger    = try? c.decode(String.self, forKey: .trigger)
+        origin     = try? c.decode(String.self, forKey: .origin)
+        requestId  = try? c.decode(String.self, forKey: .requestId)
+        rayId      = try? c.decode(String.self, forKey: .rayId)
+        region     = try? c.decode(String.self, forKey: .region)
+        type       = try? c.decode(String.self, forKey: .type)
+        url        = try? c.decode(String.self, forKey: .url)
+        statusCode = try? c.decode(Int.self,    forKey: .statusCode)
+        duration   = try? c.decode(Double.self, forKey: .duration)
+        startTime  = try? c.decode(Double.self, forKey: .startTime)
+    }
+}
+
+nonisolated struct EventWorkersInfo: Codable, Sendable {
+    let eventType:  String?
+    let outcome:    String?
+    let scriptName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case eventType, outcome, scriptName
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        eventType  = try? c.decode(String.self, forKey: .eventType)
+        outcome    = try? c.decode(String.self, forKey: .outcome)
+        scriptName = try? c.decode(String.self, forKey: .scriptName)
+    }
+}
+
+/// 列表用包装：`$metadata.id` 缺失时兜个本地 id，保证 ForEach 稳定
+nonisolated struct IdentifiedLogEvent: Identifiable, Sendable {
+    let id: String
+    let event: TelemetryEvent
+
+    init(event: TelemetryEvent) {
+        self.id = event.metadata?.id ?? UUID().uuidString
+        self.event = event
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerLogsService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerLogsService.swift
@@ -1,0 +1,66 @@
+//
+//  WorkerLogsService.swift
+//  Orange Cloud
+//
+//  Workers Logs（Observability）历史日志查询。
+//  端点 POST /accounts/{id}/workers/observability/telemetry/query（scope: workers-observability.read）。
+//  view=events 返回逐条日志；游标是上一页最后一条的 $metadata.id。
+//
+
+import Foundation
+
+struct WorkerLogsService {
+
+    private let client: CFAPIClient
+
+    init(client: CFAPIClient) {
+        self.client = client
+    }
+
+    /// 查一页历史日志。cursor 为空取首页，非空续接更早的一页。
+    func events(
+        accountId: String,
+        scriptName: String,
+        since: Date,
+        until: Date,
+        level: String?,
+        search: String?,
+        cursor: String?,
+        limit: Int = 100
+    ) async throws -> ObservabilityQueryResult {
+        var filters: [ObservabilityQueryRequest.Filter] = [
+            .init(key: "$metadata.service", operation: "eq", type: "string", value: scriptName)
+        ]
+        if let level, !level.isEmpty {
+            filters.append(.init(key: "$metadata.level", operation: "eq", type: "string", value: level))
+        }
+
+        let trimmed = search?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let needle = (trimmed?.isEmpty == false)
+            ? ObservabilityQueryRequest.Needle(value: trimmed!, matchCase: false)
+            : nil
+
+        let body = ObservabilityQueryRequest(
+            queryId: "orange-cloud-worker-logs",
+            timeframe: .init(
+                from: Int64(since.timeIntervalSince1970 * 1000),
+                to:   Int64(until.timeIntervalSince1970 * 1000)
+            ),
+            view: "events",
+            limit: limit,
+            parameters: .init(datasets: [], filters: filters, needle: needle),
+            dry: false,
+            offset: cursor,
+            offsetDirection: cursor == nil ? nil : "next"
+        )
+
+        let response: CFAPIResponse<ObservabilityQueryResult> = try await client.post(
+            "accounts/\(accountId)/workers/observability/telemetry/query",
+            body: body
+        )
+        guard response.success, let result = response.result else {
+            throw response.toAPIError()
+        }
+        return result
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerService.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Services/WorkerService.swift
@@ -35,7 +35,10 @@ struct WorkerService {
             "accounts/\(accountId)/workers/scripts/\(scriptName)/content/v2"
         )
         let contentType = response.value(forHTTPHeaderField: "Content-Type")
-        return WorkerContent.parse(data: data, contentType: contentType)
+        // 打包产物可达数 MB，multipart 切分不放主线程（本类型默认 MainActor 隔离）
+        return await Task.detached(priority: .userInitiated) {
+            WorkerContent.parse(data: data, contentType: contentType)
+        }.value
     }
 
     /// 脚本设置（绑定 + 兼容性日期/标志）

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SessionStore.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/SessionStore.swift
@@ -18,6 +18,7 @@ final class SessionStore {
     let dnsService:        DNSService
     let workerService:     WorkerService
     let workerTailService: WorkerTailService
+    let workerLogsService: WorkerLogsService
     let analyticsService:  AnalyticsService
     let r2Service:         R2Service
     let d1Service:         D1Service
@@ -85,6 +86,7 @@ final class SessionStore {
         self.dnsService        = DNSService(client: client)
         self.workerService     = WorkerService(client: client)
         self.workerTailService = WorkerTailService(client: client)
+        self.workerLogsService = WorkerLogsService(client: client)
         self.analyticsService  = AnalyticsService(client: client)
         self.r2Service         = R2Service(client: client)
         self.d1Service         = D1Service(client: client)

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerLogsViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerLogsViewModel.swift
@@ -1,0 +1,146 @@
+//
+//  WorkerLogsViewModel.swift
+//  Orange Cloud
+//
+//  Workers 历史日志：按时间窗查 Observability 事件，游标续页（越翻越早）。
+//  级别与关键词都下推到服务端过滤，避免只在本页内筛。
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class WorkerLogsViewModel {
+
+    /// 查询时间窗。Workers Logs 的保留期有限（免费层更短），不提供超长范围。
+    nonisolated enum TimeRange: String, CaseIterable, Identifiable, Sendable {
+        case m30, h3, h24, d3
+
+        var id: String { rawValue }
+
+        var seconds: TimeInterval {
+            switch self {
+            case .m30: 30 * 60
+            case .h3:  3 * 3600
+            case .h24: 24 * 3600
+            case .d3:  3 * 24 * 3600
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .m30: String(localized: "30 分钟")
+            case .h3:  String(localized: "3 小时")
+            case .h24: String(localized: "24 小时")
+            case .d3:  String(localized: "3 天")
+            }
+        }
+    }
+
+    /// 级别筛选，与实时日志口径保持一致
+    nonisolated enum LevelFilter: String, CaseIterable, Identifiable, Sendable {
+        case all, log, debug, info, warn, error
+
+        var id: String { rawValue }
+
+        /// 下推给服务端的 $metadata.level 值；all 不下推
+        var queryValue: String? { self == .all ? nil : rawValue }
+
+        var title: String {
+            switch self {
+            case .all:   String(localized: "全部级别")
+            case .log:   "log"
+            case .debug: "debug"
+            case .info:  "info"
+            case .warn:  "warn"
+            case .error: "error"
+            }
+        }
+    }
+
+    private(set) var events: [IdentifiedLogEvent] = []
+    private(set) var totalCount: Int?
+    private(set) var canLoadMore = false
+    var isLoading = false
+    var isLoadingMore = false
+    var error: String?
+
+    /// 改这三个都要重查（服务端过滤）
+    var range: TimeRange = .h24
+    var levelFilter: LevelFilter = .all
+    var searchText = ""
+
+    private let service: WorkerLogsService
+    private let accountId: String
+    private let scriptName: String
+
+    /// 时间窗在首次加载时定住，续页复用同一窗口，避免翻页时窗口随时间漂移
+    private var since: Date?
+    private var until: Date?
+    private var cursor: String?
+
+    private static let pageSize = 100
+
+    init(service: WorkerLogsService, accountId: String, scriptName: String) {
+        self.service = service
+        self.accountId = accountId
+        self.scriptName = scriptName
+    }
+
+    func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        error = nil
+
+        let until = Date()
+        let since = until.addingTimeInterval(-range.seconds)
+        self.until = until
+        self.since = since
+        self.cursor = nil
+
+        do {
+            let result = try await service.events(
+                accountId: accountId, scriptName: scriptName,
+                since: since, until: until,
+                level: levelFilter.queryValue, search: searchText,
+                cursor: nil, limit: Self.pageSize
+            )
+            let page = (result.events?.events ?? []).map { IdentifiedLogEvent(event: $0) }
+            events = page
+            totalCount = result.events?.count.map { Int($0) }
+            cursor = page.last?.event.metadata?.id
+            canLoadMore = page.count >= Self.pageSize && cursor != nil
+        } catch {
+            self.error = error.localizedDescription
+            events = []
+            totalCount = nil
+            canLoadMore = false
+        }
+        isLoading = false
+    }
+
+    func loadMore() async {
+        guard !isLoading, !isLoadingMore, canLoadMore,
+              let since, let until, let cursor else { return }
+        isLoadingMore = true
+        do {
+            let result = try await service.events(
+                accountId: accountId, scriptName: scriptName,
+                since: since, until: until,
+                level: levelFilter.queryValue, search: searchText,
+                cursor: cursor, limit: Self.pageSize
+            )
+            let page = (result.events?.events ?? []).map { IdentifiedLogEvent(event: $0) }
+            // 服务端游标偶发回重复条目，按 id 去重再追加
+            let known = Set(events.map(\.id))
+            events.append(contentsOf: page.filter { !known.contains($0.id) })
+            self.cursor = page.last?.event.metadata?.id
+            canLoadMore = page.count >= Self.pageSize && self.cursor != nil
+        } catch {
+            self.error = error.localizedDescription
+            canLoadMore = false
+        }
+        isLoadingMore = false
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerUploadViewModel.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/ViewModels/WorkerUploadViewModel.swift
@@ -23,7 +23,30 @@ final class WorkerUploadViewModel {
 
     // 原地编辑：读现有源码预填（/content/v2，OAuth 下可读）
     var isLoadingSource = false
-    var sourceUneditable = false   // 多模块打包产物：无法安全单文件替换（会丢其它模块）
+    /// 不能就地编辑的原因；nil = 可直接改
+    var sourceIssue: SourceIssue?
+
+    /// 源码为何不能在手机上就地编辑。
+    /// multiModule 是「不能替换」（单文件回写会丢其它模块）；
+    /// 另两个只是「不能就地改」——仍可导入改好的 .js 整体替换。
+    nonisolated enum SourceIssue: Equatable, Sendable {
+        /// 多模块打包产物：单文件替换会丢其它模块
+        case multiModule
+        /// 体积过大
+        case tooLarge(bytes: Int)
+        /// 压缩产物（存在超长行）：TextKit 断行是病态复杂度，进编辑器会钉死主线程
+        case minified(bytes: Int, longestLine: Int)
+
+        /// 是否还能用「导入文件整体替换」这条路
+        var allowsFileReplacement: Bool {
+            if case .multiModule = self { false } else { true }
+        }
+    }
+
+    /// 超过这个体积就不在手机上直接编辑（wrangler 打包产物动辄数百 KB 到数 MB）
+    nonisolated static let maxEditableSourceBytes = 256 * 1024
+    /// 单行超过这个长度即判定为压缩产物
+    nonisolated static let maxEditableLineLength = 5_000
 
     // 静态资源上传进度
     var uploadedAssets = 0
@@ -162,17 +185,46 @@ final class WorkerUploadViewModel {
     /// 单文件替换会丢失其它模块，故不允许原地编辑（引导用户走多模块整体替换）。
     func fetchSource(scriptName: String) async -> WorkerContent? {
         isLoadingSource = true
-        sourceUneditable = false
+        sourceIssue = nil
         error = nil
         defer { isLoadingSource = false }
         do {
             let content = try await service.content(accountId: accountId, scriptName: scriptName)
-            sourceUneditable = !content.isEditable
+            let issue = await Self.inspect(content)
+            sourceIssue = issue
+            if let issue {
+                AppLog.app.info("worker source not inline-editable: \(String(describing: issue))")
+            }
             return content
         } catch {
             self.error = error.localizedDescription
             return nil
         }
+    }
+
+    /// 判定源码能否就地编辑。扫描放 detached task：几 MB 的正文不占主线程。
+    nonisolated static func inspect(_ content: WorkerContent) async -> SourceIssue? {
+        guard content.isEditable, let module = content.mainModule else { return .multiModule }
+        return await Task.detached(priority: .userInitiated) {
+            let body = module.body
+            let bytes = body.utf8.count
+            if bytes > maxEditableSourceBytes { return SourceIssue.tooLarge(bytes: bytes) }
+            var longest = 0
+            var current = 0
+            for byte in body.utf8 {
+                if byte == 0x0A {           // \n
+                    if current > longest { longest = current }
+                    current = 0
+                } else {
+                    current += 1
+                }
+            }
+            if current > longest { longest = current }
+            if longest > maxEditableLineLength {
+                return SourceIssue.minified(bytes: bytes, longestLine: longest)
+            }
+            return nil
+        }.value
     }
 
     /// 更新现有脚本代码：保留绑定与兼容性日期（从 /settings 读取后 inherit 回写）

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Components/CodeEditor.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Components/CodeEditor.swift
@@ -1,0 +1,89 @@
+//
+//  CodeEditor.swift
+//  Orange Cloud
+//
+//  代码文本框：UITextView 承载正文，正文不进 SwiftUI 的视图更新。
+//
+//  为什么不用 TextEditor：SwiftUI 的 TextEditor 每次按键都要把整段 String 过一遍
+//  视图更新，再叠上 wrangler 打包产物常见的「整个文件就一两行」——TextKit 对超长行
+//  断行是病态复杂度，二者叠加会直接钉死主线程（用户反馈 NodeWarden 实测卡死）。
+//  故：① UITextView 自己持有正文，SwiftUI 只在提交时取值；
+//      ② 关掉自动换行改横向滚动，超长行不再参与断行计算。
+//
+//  注意：本组件只解决「编辑器本身」的开销，不解决超大文本的加载成本。
+//  数百 KB 以上的脚本请在调用方先判定为只读（见 WorkerUploadViewModel.SourceIssue）。
+//
+
+import SwiftUI
+import UIKit
+
+struct CodeEditor: UIViewRepresentable {
+
+    @Binding var text: String
+    var isEnabled: Bool = true
+
+    /// 行容器宽度：给足横向空间让长行不折行，又不至于用 .greatestFiniteMagnitude 触发布局异常
+    private static let unwrappedWidth: CGFloat = 100_000
+
+    func makeUIView(context: Context) -> UITextView {
+        // TextKit 1：不换行这条路径在 TextKit 1 上行为确定，且超长行不会走 TextKit 2 的分段布局
+        let view = UITextView(usingTextLayoutManager: false)
+        view.delegate = context.coordinator
+        view.font = UIFont.monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .callout).pointSize,
+                                                weight: .regular)
+        view.autocapitalizationType = .none
+        view.autocorrectionType = .no
+        view.spellCheckingType = .no
+        view.smartQuotesType = .no
+        view.smartDashesType = .no
+        view.smartInsertDeleteType = .no
+        view.backgroundColor = .clear
+        view.textColor = .label
+        // 代码恒定 LTR：阿拉伯语等 RTL 语言下不镜像（SwiftUI 的 layoutDirection 管不到 UIView）
+        view.semanticContentAttribute = .forceLeftToRight
+        view.textAlignment = .left
+        view.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        view.textContainer.lineFragmentPadding = 0
+
+        // 不折行 + 横向滚动
+        view.textContainer.widthTracksTextView = false
+        view.textContainer.lineBreakMode = .byClipping
+        view.textContainer.size = CGSize(width: Self.unwrappedWidth, height: .greatestFiniteMagnitude)
+        view.isScrollEnabled = true
+        view.alwaysBounceVertical = true
+        view.showsHorizontalScrollIndicator = true
+
+        view.text = text
+        context.coordinator.lastKnownText = text
+        return view
+    }
+
+    func updateUIView(_ view: UITextView, context: Context) {
+        // 只在外部真的换了内容时回写，避免把用户正在输入的正文冲掉
+        if context.coordinator.lastKnownText != text {
+            context.coordinator.lastKnownText = text
+            if view.text != text { view.text = text }
+        }
+        view.isEditable = isEnabled
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        private let text: Binding<String>
+        /// 最近一次同步过的正文：用于区分「外部改了」和「用户在打字」
+        var lastKnownText: String = ""
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            let value = textView.text ?? ""
+            lastKnownText = value
+            text.wrappedValue = value
+        }
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Snippets/SnippetEditorView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Snippets/SnippetEditorView.swift
@@ -59,13 +59,10 @@ struct SnippetEditorView: View {
                         HStack { Spacer(); ProgressView(); Spacer() }
                             .padding(.vertical, 8)
                     } else {
-                        TextEditor(text: $code)
-                            .font(.callout.monospaced())
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .frame(minHeight: 220)
-                            // JS 代码始终 LTR，避免在 RTL 语言下镜像
-                            .environment(\.layoutDirection, .leftToRight)
+                        // UITextView 承载：正文不进 SwiftUI 更新、长行不折行，
+                        // 压缩过的片段也不会把主线程拖住（内部已恒定 LTR）
+                        CodeEditor(text: $code)
+                            .frame(height: 240)
                     }
                 } header: {
                     Text("代码")

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerDetailView.swift
@@ -141,6 +141,15 @@ struct WorkerDetailView: View {
                 ) {
                     WorkerTailView(accountId: script.accountId, scriptName: script.id, session: session)
                 }
+                // 历史日志与实时日志互补：tail 只播放连接期间的调用，这里查已落库的事件
+                ProGatedNavigationLink(
+                    label: String(localized: "历史日志"),
+                    systemImage: "clock.badge.checkmark",
+                    requiredScope: "workers-observability.read",
+                    feature: .workerTail
+                ) {
+                    WorkerLogsView(accountId: script.accountId, scriptName: script.id, session: session)
+                }
             }
             .glassRow()
         }

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerLogsView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerLogsView.swift
@@ -1,0 +1,400 @@
+//
+//  WorkerLogsView.swift
+//  Orange Cloud
+//
+//  历史日志（Workers Logs / Observability）：可回溯的日志查询。
+//  与「实时日志」互补——tail 只播放连接期间的调用，这里查已经落库的事件。
+//
+
+import SwiftUI
+import UIKit
+
+struct WorkerLogsView: View {
+
+    @State private var viewModel: WorkerLogsViewModel
+    @State private var detailEvent: IdentifiedLogEvent?
+    @State private var copyTick = 0
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(accountId: String, scriptName: String, session: SessionStore) {
+        _viewModel = State(initialValue: WorkerLogsViewModel(
+            service: session.workerLogsService,
+            accountId: accountId,
+            scriptName: scriptName
+        ))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .sensoryFeedback(.success, trigger: copyTick)
+        .sheet(item: $detailEvent) { item in
+            LogEventDetailSheet(event: item.event) { copy(item.event) }
+        }
+        .navigationTitle("历史日志")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                RefreshButton(
+                    isLoading: viewModel.isLoading,
+                    failed: viewModel.error != nil && !viewModel.events.isEmpty
+                ) {
+                    Task { await viewModel.load() }
+                }
+            }
+        }
+        // 时间窗与级别都下推给服务端，改了就重查
+        .task(id: viewModel.range) { await viewModel.load() }
+        .task(id: viewModel.levelFilter) { await viewModel.load() }
+    }
+
+    // MARK: - 顶部筛选
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            Picker("时间范围", selection: $viewModel.range) {
+                ForEach(WorkerLogsViewModel.TimeRange.allCases) { range in
+                    Text(range.label).tag(range)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            HStack(spacing: 8) {
+                searchField
+                levelMenu
+            }
+
+            if let total = viewModel.totalCount, !viewModel.events.isEmpty {
+                HStack {
+                    Text("命中 \(total) 条，已载入 \(viewModel.events.count) 条")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.regularMaterial)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            TextField("搜索日志", text: $viewModel.searchText)
+                .font(.footnote)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .onSubmit { Task { await viewModel.load() } }
+            if !viewModel.searchText.isEmpty {
+                Button {
+                    viewModel.searchText = ""
+                    Task { await viewModel.load() }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("清除搜索")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(OCGlass.fill(for: colorScheme), in: .rect(cornerRadius: 9))
+    }
+
+    private var levelMenu: some View {
+        Menu {
+            Picker("级别", selection: $viewModel.levelFilter) {
+                ForEach(WorkerLogsViewModel.LevelFilter.allCases) { level in
+                    Text(level.title).tag(level)
+                }
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Label(viewModel.levelFilter.title, systemImage: "line.3.horizontal.decrease.circle")
+                .font(.footnote)
+                .foregroundStyle(viewModel.levelFilter == .all ? Color.secondary : Color.ocOrangeText)
+        }
+        .accessibilityLabel("按级别筛选")
+    }
+
+    // MARK: - 列表
+
+    @ViewBuilder
+    private var content: some View {
+        ScrollView {
+            if viewModel.isLoading && viewModel.events.isEmpty {
+                loadingSkeleton
+            } else if let error = viewModel.error, viewModel.events.isEmpty {
+                errorHint(error)
+            } else if viewModel.events.isEmpty {
+                emptyHint
+            } else {
+                eventList
+            }
+        }
+        .background { SkyBackground() }
+        .refreshable { await viewModel.load() }
+    }
+
+    private var eventList: some View {
+        LazyVStack(alignment: .leading, spacing: 4) {
+            ForEach(viewModel.events) { item in
+                LogEventRow(
+                    event: item.event,
+                    onCopy: { copy(item.event) },
+                    onOpen: { detailEvent = item }
+                )
+            }
+            if viewModel.canLoadMore {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .task { await viewModel.loadMore() }
+            }
+        }
+        .padding(12)
+        // 日志正文恒定 LTR，避免 RTL 语言下 URL / JSON 被镜像
+        .environment(\.layoutDirection, .leftToRight)
+    }
+
+    private var loadingSkeleton: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(0..<8, id: \.self) { index in
+                HStack(spacing: 8) {
+                    SkeletonBlock(width: 56, height: 10)
+                    SkeletonBlock(width: 120 + CGFloat((index * 37) % 90), height: 10)
+                    Spacer()
+                }
+            }
+        }
+        .skeletonPulse()
+        .padding(16)
+    }
+
+    private var emptyHint: some View {
+        ContentUnavailableView {
+            Label("这段时间没有日志", systemImage: "clock.badge.questionmark")
+        } description: {
+            Text("换个时间范围看看。若这个 Worker 从未出现日志，多半是没有开启 Observability——在 wrangler.toml 里打开 [observability] 后重新部署即可。")
+        }
+        .padding(.top, 60)
+    }
+
+    private func errorHint(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label("查询失败", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("重试") { Task { await viewModel.load() } }
+                .buttonStyle(.bordered)
+                .tint(Color.ocOrange)
+        }
+        .padding(.top, 60)
+    }
+
+    private func copy(_ event: TelemetryEvent) {
+        UIPasteboard.general.string = event.displayText
+        copyTick += 1
+    }
+}
+
+// MARK: - 单条事件行
+
+private struct LogEventRow: View {
+    let event: TelemetryEvent
+    let onCopy: () -> Void
+    let onOpen: () -> Void
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(event.date, format: .dateTime.month(.twoDigits).day(.twoDigits)
+                        .hour(.twoDigits(amPM: .omitted)).minute(.twoDigits).second(.twoDigits))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+
+                Text(event.displayText)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(LogEventStyle.color(for: event))
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let status = event.metadata?.statusCode {
+                    Text(String(status))
+                        .font(.caption2.monospaced().weight(.semibold))
+                        .foregroundStyle(LogEventStyle.statusColor(status))
+                }
+            }
+            .padding(.vertical, 1)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("复制此行", systemImage: "doc.on.doc", action: onCopy)
+        }
+        .accessibilityHint(Text("轻点查看详情，长按复制整行"))
+    }
+}
+
+private enum LogEventStyle {
+    static func color(for event: TelemetryEvent) -> Color {
+        switch event.level {
+        case "error", "exception": .red
+        case "warn":               .orange
+        case "event":              .secondary
+        default:                   .primary
+        }
+    }
+
+    static func statusColor(_ code: Int) -> Color {
+        switch code {
+        case 500...: .red
+        case 400...: .orange
+        default:     .secondary
+        }
+    }
+}
+
+// MARK: - 事件详情
+
+private struct LogEventDetailSheet: View {
+    let event: TelemetryEvent
+    let onCopy: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    metaSection
+                    requestSection
+                    bodySection
+                }
+                .padding(16)
+            }
+            .background { SkyBackground() }
+            .navigationTitle("日志详情")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("完成") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("复制全部", systemImage: "doc.on.doc", action: onCopy)
+                        .tint(Color.ocOrange)
+                }
+            }
+        }
+    }
+
+    private var metaSection: some View {
+        island {
+            fieldRow(title: Text("级别"), value: event.level, tint: LogEventStyle.color(for: event))
+            Divider().opacity(0.4)
+            fieldRow(title: Text("时间"),
+                     value: event.date.formatted(date: .abbreviated, time: .standard),
+                     tint: .secondary)
+            if let outcome = event.workers?.outcome, !outcome.isEmpty {
+                Divider().opacity(0.4)
+                fieldRow(title: Text("结果"), value: outcome, tint: .secondary)
+            }
+            if let eventType = event.workers?.eventType, !eventType.isEmpty {
+                Divider().opacity(0.4)
+                fieldRow(title: Text("事件类型"), value: eventType, tint: .secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var requestSection: some View {
+        let metadata = event.metadata
+        if metadata?.trigger != nil || metadata?.url != nil || metadata?.statusCode != nil
+            || metadata?.requestId != nil || metadata?.rayId != nil || metadata?.duration != nil {
+            island {
+                if let trigger = metadata?.trigger, !trigger.isEmpty {
+                    fieldRow(title: Text("触发"), value: trigger, tint: .primary)
+                }
+                if let url = metadata?.url, !url.isEmpty {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("请求地址"), value: url, tint: .primary)
+                }
+                if let status = metadata?.statusCode {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("状态码"), value: String(status),
+                             tint: LogEventStyle.statusColor(status))
+                }
+                if let duration = metadata?.duration {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("耗时"), value: String(format: "%.1f ms", duration), tint: .secondary)
+                }
+                if let requestId = metadata?.requestId, !requestId.isEmpty {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("请求 ID"), value: requestId, tint: .secondary)
+                }
+                if let rayId = metadata?.rayId, !rayId.isEmpty {
+                    Divider().opacity(0.4)
+                    fieldRow(title: Text("Ray ID"), value: rayId, tint: .secondary)
+                }
+            }
+        }
+    }
+
+    private var bodySection: some View {
+        island {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("完整内容")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(event.displayText)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(LogEventStyle.color(for: event))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .environment(\.layoutDirection, .leftToRight)
+                Text("长按可选中其中的片段单独复制")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func fieldRow(title: Text, value: String, tint: Color) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            title
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+            Text(value)
+                .font(.footnote.monospaced())
+                .foregroundStyle(tint)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .environment(\.layoutDirection, .leftToRight)
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// 玻璃岛：OCGlass 纯色近似，不用真材质（backdrop blur 会掉帧）
+    @ViewBuilder
+    private func island<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(OCGlass.fill(for: colorScheme), in: .rect(cornerRadius: 16))
+    }
+}

--- a/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerUploadView.swift
+++ b/apps/ios/Orange Cloud/Orange Cloud/Views/Workers/WorkerUploadView.swift
@@ -45,6 +45,8 @@ struct WorkerUploadView: View {
     @State private var isModule = true
     @State private var showCodeImporter = false
     @State private var didLoadSource = false   // 原地编辑：只预填一次
+    /// 源码只读时导入的替换文件（名称 + 字节数），用于回显「已选好要部署的文件」
+    @State private var replacementFile: (name: String, bytes: Int)?
 
     // 多模块
     @State private var modules: [WorkerUploadModule] = []
@@ -68,8 +70,11 @@ struct WorkerUploadView: View {
 
     private var canSubmit: Bool {
         guard nameValid, !viewModel.isUploading else { return false }
-        if case .replace = mode, viewModel.isLoadingSource || viewModel.sourceUneditable {
-            return false   // 原地编辑：源码未就绪 / 多模块不可替换时禁止部署
+        if case .replace = mode {
+            // 源码未就绪、或多模块产物（单文件回写会丢模块）时禁止部署。
+            // 超大 / 压缩产物只是不能就地改，导入文件后仍可整体替换。
+            if viewModel.isLoadingSource { return false }
+            if viewModel.sourceIssue?.allowsFileReplacement == false { return false }
         }
         switch effectiveKind {
         case .single:  return !code.isEmpty
@@ -191,17 +196,13 @@ struct WorkerUploadView: View {
                         ProgressView()
                         Text("正在读取源码…").font(.callout).foregroundStyle(.secondary)
                     }
-                } else if !isCreate && viewModel.sourceUneditable {
-                    Label("这是多模块打包 Worker，无法在此原地编辑（会丢失其它模块）。可在「新建」里用多模块方式整体替换。", systemImage: "exclamationmark.triangle")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+                } else if !isCreate, let issue = viewModel.sourceIssue {
+                    readOnlySource(issue)
                 } else {
-                    TextEditor(text: $code)
-                        .font(.callout.monospaced())
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .frame(minHeight: 220)
-                        .disabled(viewModel.isUploading)
+                    // 用 UITextView 承载：正文不进 SwiftUI 更新、长行不折行，
+                    // 避免大脚本按键卡顿（TextEditor 在打包产物上会钉死主线程）
+                    CodeEditor(text: $code, isEnabled: !viewModel.isUploading)
+                        .frame(height: 260)
                     Button { showCodeImporter = true } label: {
                         Label("从 .js 文件导入", systemImage: "doc.badge.plus")
                     }
@@ -210,21 +211,62 @@ struct WorkerUploadView: View {
             } header: {
                 Text("代码")
             } footer: {
-                if !isCreate && !viewModel.sourceUneditable && !viewModel.isLoadingSource {
+                if !isCreate && viewModel.sourceIssue == nil && !viewModel.isLoadingSource {
                     Text("已载入当前线上源码，可直接修改后部署。现有变量 / 密钥 / 绑定会自动保留。")
                 }
             }
         }
     }
 
-    /// 原地编辑：进 sheet 时读取现有源码预填（仅 .replace 单文件模式，只做一次）
+    /// 源码不可就地编辑时的说明与出路
+    @ViewBuilder
+    private func readOnlySource(_ issue: WorkerUploadViewModel.SourceIssue) -> some View {
+        switch issue {
+        case .multiModule:
+            Label("这是多模块打包 Worker，无法在此原地编辑（会丢失其它模块）。可在「新建」里用多模块方式整体替换。",
+                  systemImage: "exclamationmark.triangle")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        case .tooLarge(let bytes):
+            Label("当前线上脚本 \(Int64(bytes).ocBytes)，超出手机端就地编辑的上限，已转为只读。可以导入改好的 .js 文件整体替换。",
+                  systemImage: "doc.text.magnifyingglass")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        case .minified(let bytes, _):
+            Label("当前线上脚本是压缩过的打包产物（\(Int64(bytes).ocBytes)，存在超长行），不适合在手机上就地编辑，已转为只读。可以导入改好的 .js 文件整体替换。",
+                  systemImage: "doc.text.magnifyingglass")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+
+        if issue.allowsFileReplacement {
+            if let replacementFile {
+                LabeledContent("待部署文件") {
+                    Text("\(replacementFile.name) · \(Int64(replacementFile.bytes).ocBytes)")
+                        .font(.caption.monospaced())
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            Button { showCodeImporter = true } label: {
+                Label(replacementFile == nil
+                      ? String(localized: "导入 .js 文件整体替换")
+                      : String(localized: "重新选择文件"),
+                      systemImage: "doc.badge.plus")
+            }
+            .disabled(viewModel.isUploading)
+        }
+    }
+
+    /// 原地编辑：进 sheet 时读取现有源码预填（仅 .replace 单文件模式，只做一次）。
+    /// 只有确认可就地编辑才把正文交给编辑器——超大 / 压缩产物进编辑器会钉死主线程。
     private func loadSourceIfNeeded() async {
         guard case .replace(let scriptName) = mode, !didLoadSource else { return }
         didLoadSource = true
-        if let content = await viewModel.fetchSource(scriptName: scriptName),
-           let main = content.mainModule {
+        guard let content = await viewModel.fetchSource(scriptName: scriptName) else { return }
+        isModule = content.isModule
+        if viewModel.sourceIssue == nil, let main = content.mainModule {
             code = main.body
-            isModule = content.isModule
         }
     }
 
@@ -328,7 +370,12 @@ struct WorkerUploadView: View {
     private func importCode(_ result: Result<[URL], Error>) {
         guard case .success(let urls) = result, let url = urls.first else { return }
         guard let text = readText(url) else { importError = String(localized: "无法以文本读取该文件"); return }
+        importError = nil
         code = text
+        // 只读态下正文不进编辑器，改在表单里回显文件名与体积
+        replacementFile = viewModel.sourceIssue == nil
+            ? nil
+            : (name: url.lastPathComponent, bytes: text.utf8.count)
         if isCreate, trimmedName.isEmpty {
             name = url.deletingPathExtension().lastPathComponent.lowercased()
         }


### PR DESCRIPTION
用户邮件反馈两条（evan_public@qq.com，2026-09-03），一条是真 bug，一条是数据源理解差异暴露出的功能缺口。两条各一个提交。

## ① 更新代码卡死 —— 真 bug（`d4f57ab`）

反馈者在 CF 上用 Workers 部署了 [NodeWarden](https://github.com/shuaiplus/nodewarden)（Workers 上的 Bitwarden 第三方服务端），App 里点「更新代码」整个页面卡住。

**根因**：「更新代码」先把线上完整源码从 `/content/v2` 拉回，直接绑进 `Form` 里的 `TextEditor`，**全程无体积上限、无长行处理**。NodeWarden 是 wrangler 打包的单文件产物（源码树 211 KB ~ 4 MB+，压缩后常常整个文件只有一两行）——TextKit 对超长行断行是病态复杂度，叠加 SwiftUI 每次按键过一遍整段 String，主线程直接钉死。

**同一类问题 Android 早修过**（issue #61，1.6.6 换 `BasicTextField + TextFieldState`），iOS 侧此前漏了同步修复；`WorkerUploadView.swift` 最后一次改动停在 1.9.0，现版本 2.1.1。所以这不是个例——任何人编辑一个真实体量的 Worker 都会中招。

**改法**：

1. 新增 `Views/Components/CodeEditor.swift`——`UITextView` 承载正文（TextKit 1），正文不进 SwiftUI 的视图更新；关掉自动换行改横向滚动，超长行不再参与断行（`contentSize` 取 usedRect，短行不会多出空白横滚区）。组件内部固定 `forceLeftToRight`：**SwiftUI 的 `layoutDirection` 环境值管不到内嵌 UIView**，阿拉伯语下必须这样写。
2. 加载前判定能否就地编辑：`> 256 KB` 或**存在 > 5000 字符的单行**，都不把正文交给编辑器，转只读 + 只留「导入 .js 文件整体替换」（变量/密钥/绑定仍按 inherit 保留）。多模块产物维持原状，仍完全禁止替换（单文件回写会丢模块）。长行扫描放 detached task。
3. `/content/v2` 的 multipart 解析移出主线程——本工程默认 MainActor 隔离，`WorkerService` 是 struct，解析原本就在主线程跑，是第二个拖累。

Snippets 编辑器同为「远端拉回源码塞进 TextEditor」，一并换用 `CodeEditor`（CF 侧 32 KiB 封顶，到不了致命，但同类）。Pages 部署页是纯手输路径，未动。

## ② 实时日志刷不出 —— 不是 bug，但暴露了真实缺口（`4532f8a`）

反馈者对照的是网页端 Worker → Observability → **Events**。核对下来是两套数据源：App 的「实时日志」走 Workers **tail**，只播放连接期间新发生的调用、不回补历史；网页那一栏是 **Workers Logs**，持久化可回溯。tail 的实现（trace-v1 子协议、连接后声明过滤器、心跳、断线重建一次）逐项对过 wrangler，没有缺陷。NodeWarden 作为密码库服务端只在客户端同步时才有请求，盯着看确实可能零流量。

**但 App 此前完全没有历史日志能力**，本 PR 补上：

Worker 详情「调试」区新增「历史日志」，走 `POST /accounts/{id}/workers/observability/telemetry/query`（`view=events`），`workers-observability.read` 门控（该 scope 随「流量分析」权限组授予），Pro 闸门复用 `.workerTail`。支持 30 分钟 / 3 小时 / 24 小时 / 3 天时间窗、级别筛选、全文搜索（三者均下推服务端）、游标翻页（时间窗定住不漂移 + 按 id 去重）、点行看详情（触发 / 请求地址 / 状态码 / 耗时 / 请求 ID / Ray ID）。

按接口实际形态做的几处取舍：
- `datasets` 传空 = 查全部，不猜数据集名；
- **`dry` 保持 false**——语义是「执行但不持久化」，官方没承诺 dry 下仍回结果，不赌；
- 事件字段几乎都在 `$metadata` 且类型与文档时有出入，故**逐字段容错解码**，单字段对不上不会让整条事件失败。

空态直接说明成因：Worker 没开 observability 就查不到，需在 `wrangler.toml` 打开 `[observability]` 后重新部署。

## 验证

- `xcodebuild -scheme "Orange Cloud" build` → `** BUILD SUCCEEDED **`，改动文件零 warning。
- 新增 16 条文案已补齐 **12 语**；用编译产物 `.stringsdata` 反查验证：**代码提取出的 key 与 catalog 零缺口，新增的 16 条也零冗余**（含 `%@` / `%lld` 插值 key 的形状）。
- catalog diff 为**纯新增**（+1216 / -0），按仓库约定从 HEAD 基线重注入，未夹带构建产生的 canonical 重排与无关空壳 key。
- `d4f57ab` 单独 checkout 自洽（树内无任何对历史日志符号的引用），bisect 不会踩空。

## 未验证 / 待办

- 历史日志的 `$metadata.service` + `eq` 过滤条件与响应字段形状是照 CF OpenAPI 写的，**没有真账号实测**，首次真机跑一次最稳（解码层已容错，字段对不上不会炸，但过滤条件写错会查不到数据）。
- Android / 鸿蒙没有历史日志功能，要对齐需各自移植。