### PR TITLE
fix(web): 访客真实 IP 那篇改为症状式选题，修正 IP 段更新论断

### DIFF
--- a/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-error-522-connection-timed-out/page.tsx
@@ -79,7 +79,7 @@ const RELATED: RelatedLink[] = [
 	},
 	{
 		href: "/guides/cloudflare-real-visitor-ip-cf-connecting-ip",
-		label: "How do you get the real visitor IP behind Cloudflare?",
+		label: "Why do my server logs show Cloudflare\u2019s IP, not the visitor\u2019s?",
 		note: "The same published IP ranges, used at the origin for the other half of the job — deciding which requests may claim a visitor address.",
 	},
 	{

--- a/apps/web/src/app/[locale]/guides/cloudflare-hide-origin-ip/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-hide-origin-ip/page.tsx
@@ -56,7 +56,7 @@ const FAQ: Array<{ q: string; a: string }> = [
 const RELATED: RelatedLink[] = [
   {
     href: "/guides/cloudflare-real-visitor-ip-cf-connecting-ip",
-    label: "How do you get the real visitor IP behind Cloudflare?",
+    label: "Why do my server logs show Cloudflare\u2019s IP, not the visitor\u2019s?",
     note: "The mirror image of this problem — and the header you must stop trusting once your origin only accepts Cloudflare.",
   },
   {

--- a/apps/web/src/app/[locale]/guides/cloudflare-real-visitor-ip-cf-connecting-ip/page.tsx
+++ b/apps/web/src/app/[locale]/guides/cloudflare-real-visitor-ip-cf-connecting-ip/page.tsx
@@ -14,6 +14,7 @@ const DOCS_HEADERS = "https://developers.cloudflare.com/fundamentals/reference/h
 const DOCS_CF_CONNECTING_IP = `${DOCS_HEADERS}#cf-connecting-ip`;
 const DOCS_TRUE_CLIENT_IP = `${DOCS_HEADERS}#true-client-ip-enterprise-plan-only`;
 const DOCS_XFF = `${DOCS_HEADERS}#x-forwarded-for`;
+const DOCS_CF_IPCOUNTRY = `${DOCS_HEADERS}#cf-ipcountry`;
 const DOCS_RESTORE =
 	"https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/";
 const DOCS_IP_ADDRESSES = "https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/";
@@ -27,24 +28,24 @@ const APACHE_REMOTEIP = "https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
 /** FAQ 一处定义：可见文本与 FAQPage JSON-LD 同源，保证逐字一致 */
 const FAQ: Array<{ q: string; a: string }> = [
 	{
-		q: "How do I get the real visitor IP behind Cloudflare?",
-		a: "Read the CF-Connecting-IP request header instead of the address of the connection itself. Every proxied request Cloudflare forwards to your origin carries it, and it always holds exactly one address.",
+		q: "Why do my server logs show Cloudflare IP addresses instead of the visitor's?",
+		a: "Because on a proxied hostname Cloudflare is the client that connects to your origin, so the connection really does come from a Cloudflare address. Cloudflare documents that the original visitor address is moved into an appended request header called CF-Connecting-IP, and your web server has to be configured to log that header instead of the connection.",
 	},
 	{
-		q: "What is the CF-Connecting-IP header?",
-		a: "It is the header Cloudflare adds to a proxied request to give the origin the client IP address that connected to Cloudflare. Cloudflare only sends it on traffic from its own edge to your origin, so it never appears on a request that reached your server some other way.",
+		q: "Why do all my visitors appear to have the same IP address?",
+		a: "They are sharing the handful of Cloudflare addresses that served them, because Cloudflare IP addresses are shared by every proxied hostname. Anything that counts or identifies people by address — unique visitor stats, rate limits, ban lists, one-vote-per-IP logic — is really counting Cloudflare data centres until you restore the real address.",
 	},
 	{
-		q: "Should I use CF-Connecting-IP or X-Forwarded-For?",
-		a: "Cloudflare recommends CF-Connecting-IP or True-Client-IP over X-Forwarded-For, because both contain a single address in a consistent format. X-Forwarded-For is a list that grows by one entry for every proxy in front of Cloudflare, so parsing it correctly is harder than it looks.",
+		q: "How do I restore the original visitor IP in Nginx or Apache?",
+		a: "In Nginx, use the built-in real IP module with real_ip_header CF-Connecting-IP plus one set_real_ip_from line for each Cloudflare range. In Apache, Cloudflare now recommends mod_remoteip with RemoteIPHeader CF-Connecting-IP and RemoteIPTrustedProxy entries, and you must also change %h to %a in your LogFormat or the log keeps printing Cloudflare's address.",
 	},
 	{
 		q: "Can the CF-Connecting-IP header be spoofed?",
-		a: "Not through Cloudflare, but a request that reaches your origin directly can carry any header its sender likes. That is why real-IP modules take a trusted proxy list, and why Cloudflare recommends blocking traffic at the origin that does not come from its published IP ranges.",
+		a: "Not through Cloudflare, but a request that reaches your origin directly can carry any header its sender likes. That is why real IP modules take a trusted proxy list, and why Cloudflare recommends blocking traffic at the origin that does not come from its published IP ranges.",
 	},
 	{
 		q: "Why is CF-Connecting-IP missing from my requests?",
-		a: "The three documented reasons are that the record is not proxied, that the Remove visitor IP headers Managed Transform is enabled on the zone, or that Pseudo IPv4 is set to Overwrite Headers, which replaces the value with a Class E address and moves the real one into CF-Connecting-IPv6.",
+		a: "The documented reasons are that the record is not proxied, that the Remove visitor IP headers Managed Transform is enabled on the zone, or that Pseudo IPv4 is set to Overwrite Headers, which replaces the value with a Class E address and preserves the real one in CF-Connecting-IPv6.",
 	},
 ];
 
@@ -151,7 +152,7 @@ export default async function VisitorIpGuide({ params }: { params: Promise<{ loc
 			<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 			<GuideShell
 				title={guide.h1}
-				lede="Every entry in the access log is a Cloudflare address, the rate limiter is throttling continents at a time, and the ban list has stopped meaning anything. Here is where the visitor went, and how to get them back."
+				lede="Every entry in the access log is a Cloudflare address, the rate limiter is throttling continents at a time, and the ban list has stopped meaning anything. Here is where the visitor went, how to get them back, and the reaction that turns this into an outage."
 				updated={guide.updated}
 				readingTime={guide.readingTime}
 				related={RELATED}
@@ -159,10 +160,11 @@ export default async function VisitorIpGuide({ params }: { params: Promise<{ loc
 				<div className="glass r-island note p-6 sm:p-7">
 					<p>
 						<strong>
-							The visitor&rsquo;s address is in the <code>CF-Connecting-IP</code> request header.
+							Because Cloudflare is the client now. The visitor&rsquo;s address moved into the{" "}
+							<code>CF-Connecting-IP</code> request header.
 						</strong>{" "}
-						Configure your web server to read that instead of the connection&rsquo;s source address — and to
-						believe it only on connections from Cloudflare&rsquo;s published IP ranges.
+						Configure your web server to log that header instead of the connection — and to believe it only
+						on connections from Cloudflare&rsquo;s published IP ranges.
 					</p>
 				</div>
 
@@ -178,6 +180,52 @@ export default async function VisitorIpGuide({ params }: { params: Promise<{ loc
 				</p>
 
 				<VisitorIpTrust />
+
+				<h2 id="what-breaks">What breaks when every visitor shares an address</h2>
+				<p>
+					Cloudflare&rsquo;s IP addresses are shared by every proxied hostname, so this is not only a cosmetic
+					logging problem. Anything that counts, identifies or punishes by address quietly changed meaning the
+					moment the record went orange, and none of it throws an error:
+				</p>
+				<ul>
+					<li>
+						<strong>Analytics that count unique visitors</strong> now count data centres. Server-side stats
+						collapse; a JavaScript analytics tag is unaffected, because it reads the address from the
+						visitor&rsquo;s own connection.
+					</li>
+					<li>
+						<strong>Per-IP rate limits and one-vote-per-IP logic</strong> apply to everyone behind the same
+						edge address at once. The limit still fires — just against a crowd instead of a person.
+					</li>
+					<li>
+						<strong>Ban lists and blocklists</strong> either hit nobody or hit a whole region, and the
+						country rules built on <code>REMOTE_ADDR</code> now read Cloudflare&rsquo;s location rather than
+						the visitor&rsquo;s. Geolocation has its own header,{" "}
+						<a href={DOCS_CF_IPCOUNTRY} target="_blank" rel="noopener noreferrer">
+							<code>CF-IPCountry</code>
+						</a>
+						, but Cloudflare only adds it once the <em>Add visitor location headers</em> Managed Transform is
+						enabled — it is not there by default.
+					</li>
+				</ul>
+				<p>
+					The expensive one is the failure that fixes itself into an outage. Cloudflare warns that to your
+					origin&rsquo;s firewall, proxied traffic{" "}
+					<a href={DOCS_IP_ADDRESSES} target="_blank" rel="noopener noreferrer">
+						looks like a small number of sources sending a high volume of requests
+					</a>{" "}
+					— exactly the shape that automatic blocking and rate limiting are built to stop. So fail2ban, or a
+					host firewall left on its defaults, does what it was told: it bans the noisiest addresses. Those
+					addresses are Cloudflare, every visitor is behind them, and the site goes dark for everyone at once.
+					What you see next is{" "}
+					<Link href="/guides/cloudflare-error-522-connection-timed-out">error 522</Link>, because the proxy
+					can no longer reach the origin either.
+				</p>
+				<p>
+					That is the real reason to restore the visitor IP before you tune anything else: until your server
+					reads the right address, every security tool you own is aiming at the wrong target — and some of
+					them are aiming at your own traffic.
+				</p>
 
 				<h2 id="headers">The headers that carry the address</h2>
 				<p>
@@ -282,10 +330,13 @@ real_ip_header CF-Connecting-IP;`}</code>
 				<p>
 					To keep the address in the access log, Cloudflare notes that you add{" "}
 					<code>$http_cf_connecting_ip</code> — and, if you want it, <code>$http_x_forwarded_for</code> — to
-					your <code>log_format</code> directive. It is the same header throughout, spelled three ways
-					depending on where you are looking: <code>CF-Connecting-IP</code> in Cloudflare&rsquo;s reference,{" "}
-					<code>cf-connecting-ip</code> on the wire, and <code>$http_cf_connecting_ip</code> once Nginx has
-					turned it into a variable.
+					your <code>log_format</code> directive. It is one header throughout, and the spelling changes with
+					the context rather than the meaning: <code>CF-Connecting-IP</code> in Cloudflare&rsquo;s reference,{" "}
+					<code>cf-connecting-ip</code> on the wire, <code>$http_cf_connecting_ip</code> once Nginx has turned
+					it into a variable, and <code>HTTP_CF_CONNECTING_IP</code> inside PHP&rsquo;s <code>$_SERVER</code>.
+					Header names
+					are case-insensitive, so the CF Connecting IP you see written without hyphens in forum posts is the
+					same thing again.
 				</p>
 
 				<h3 id="apache">Apache</h3>
@@ -334,10 +385,10 @@ RemoteIPTrustedProxy 198.51.100.0/24   # repeat for every published range`}</cod
 						the ranges at{" "}
 						<a href={CF_IPS} target="_blank" rel="noopener noreferrer">
 							cloudflare.com/ips
-						</a>{" "}
-						and says plainly that the list needs updating regularly — a config written three years ago is
-						probably incomplete now, so pull it from the published source on a schedule rather than pasting
-						it once.
+						</a>
+						. The ranges do not change often, which is the trap: a list pasted in by hand survives long
+						enough to feel permanent, and Cloudflare publishes new ranges to that page before putting them
+						into production. Pull it from the published source — or the API — rather than from memory.
 					</li>
 					<li>
 						<strong>Refuse the connections in the first place.</strong> Cloudflare recommends blocking all
@@ -386,12 +437,6 @@ RemoteIPTrustedProxy 198.51.100.0/24   # repeat for every published range`}</cod
 						traffic passes through a Worker, verify the value rather than assuming it.
 					</li>
 				</ul>
-				<p>
-					One last trap worth knowing about, because it produces a header that vanishes for no visible reason:
-					Cloudflare may drop request headers whose <em>names</em> it considers invalid by Nginx&rsquo;s rules
-					— a custom header with a dot in the name, for instance. If you are forwarding a visitor address under
-					a name of your own devising, that is a good place to look before you suspect the proxy.
-				</p>
 
 				<h2 id="faq">FAQ</h2>
 				{FAQ.map((item) => (

--- a/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
+++ b/apps/web/src/app/[locale]/guides/what-is-the-orange-cloud-in-cloudflare/page.tsx
@@ -62,7 +62,7 @@ const RELATED: RelatedLink[] = [
 	},
 	{
 		href: "/guides/cloudflare-real-visitor-ip-cf-connecting-ip",
-		label: "How do you get the real visitor IP behind Cloudflare?",
+		label: "Why do my server logs show Cloudflare\u2019s IP, not the visitor\u2019s?",
 		note: "The first thing proxying changes at the origin: every connection now comes from Cloudflare, and the visitor moves into a header.",
 	},
 	{

--- a/apps/web/src/lib/guides/guides.ts
+++ b/apps/web/src/lib/guides/guides.ts
@@ -136,14 +136,14 @@ export const GUIDES: GuideMeta[] = [
 	},
 	{
 		slug: "cloudflare-real-visitor-ip-cf-connecting-ip",
-		h1: "How Do You Get the Real Visitor IP Behind Cloudflare?",
-		title: "Cloudflare Real Visitor IP: CF-Connecting-IP Explained",
+		h1: "Why Do My Server Logs Show Cloudflare\u2019s IP, Not the Visitor\u2019s?",
+		title: "Server Logs Show Cloudflare IPs Instead of Visitors",
 		description:
-			"The visitor's real address arrives in the CF-Connecting-IP header. Read that instead of the connection source, and trust it only from Cloudflare's IPs.",
+			"Because Cloudflare is the client now. The visitor\u2019s address moves into the CF-Connecting-IP request header, and your server has to be told to read it.",
 		blurb:
-			"Your logs fill up with Cloudflare addresses because Cloudflare is the client now. Which header carries the real one, why X-Forwarded-For is the wrong one to read, and the trust boundary every guide leaves out.",
-		updated: "2026-08-28",
-		readingTime: "8 min read",
+			"Every entry is a Cloudflare address, so the rate limiter, the ban list and the geo rules all quietly stopped meaning anything \u2014 and a firewall that reacts on its own can take the site down.",
+		updated: "2026-09-12",
+		readingTime: "9 min read",
 	},
 	{
 		slug: "cloudflare-error-521-web-server-is-down",


### PR DESCRIPTION
## 本轮为什么是「修复」而不是「新增」

`gsc.py guides --days 28` 显示 `/guides/cloudflare-real-visitor-ip-cf-connecting-ip` 上线 15 天（2026-08-28）仍为 **「已抓取 — 尚未编入索引」，0 点击 / 0 展示**，同时触发任务定义的两条修复优先规则（>7 天未收录、>14 天零展示）。全站其余 16 篇英文指南均已收录。

先排查技术面，**全部干净**，因此排除「技术问题」这一假设：

| 检查项 | 结果 |
|---|---|
| 线上 HTTP 状态 | 200 |
| canonical | 自引用且正确 |
| robots / noindex | 无 |
| sitemap.xml | 已包含 |
| 站内入链 | 3 处（522 / orange-cloud / hide-origin-ip） |

所以判定为**选题与 title/meta 问题**。根因：原页面打的是「解决方案名」——`CF-Connecting-IP`、restoring original visitor IPs——而这正是 Cloudflare 官方文档天然占据的词面；本站表现最好的几篇（`cloudflare-orange-to-orange` 499 展示、522、缓存清除）打的全是**症状问句**。这一篇是唯一的例外。

`owners` 还给了一条佐证：`cloudflare proxy origin sees cloudflare ip address`（均位 10.0）这条**字面就是本篇主题**的查询，实际由 `/guides/cloudflare-hide-origin-ip` 承接，说明本篇在自家站内也没建立起主题归属。

## 改了什么

- **标题 / 描述 / H1 / lede 切到症状意图**：`Why Do My Server Logs Show Cloudflare's IP, Not the Visitor's?`
- **新增一节「What breaks when every visitor shares an address」**——本轮主要的差异化增量：统计口径、限流、封禁名单、地理规则同时失真；重点写清最贵的那种失败：源站防火墙 / fail2ban 看到「少数来源高频请求」自动封禁，封掉的正是 Cloudflare，全站对所有人中断，随后表现为 522（与站内 522 那篇互链）。
- **FAQ 五条全部换成症状式真实搜索问句**，并补齐拼写变体覆盖（on-the-wire 小写、Nginx 变量、PHP 的 `HTTP_CF_CONNECTING_IP`、无连字符写法）。
- 三处入链锚文本同步改为新 H1。
- 删除一段关于自定义请求头命名的题外话（控词数 + 聚焦）。

## 核对官方文档后修正 / 放弃的论断

1. **修正（事实错误）**：原文写 Cloudflare「says plainly that the list needs updating regularly — a config written three years ago is probably incomplete now」。[官方文档](https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/)实际写的是 *"Cloudflare's IP ranges do not change frequently."*，新段会先发布到列表页再投产。已按文档改写，并补上「可用 API 程序化更新」这一官方说法。
2. **补充时加了限定**：`CF-IPCountry` 并非默认下发，[文档](https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-ipcountry)说明需先启用 **Add visitor location headers** Managed Transform，已在正文写明。
3. **逐条复核后保留**：`mod_cloudflare` 自 Debian 9 / Ubuntu 18.04 起停止支持并改荐 `mod_remoteip`、Apache 需把 `%h` 换成 `%a`、Pseudo IPv4 Overwrite Headers 的 Class E 行为、`X-Forwarded-For` 三跳示例、Remove visitor IP headers Managed Transform —— 均与当前文档一致，未改。

## 硬门槛逐项结果

| # | 项目 | 结果 |
|---|---|---|
| 1 | `npx next build` | ✅ 通过，无新增告警（仅既有 middleware 废弃告警） |
| 2 | `npx vitest run` | ✅ 22 文件 / 172 测试全绿 |
| 3 | `npx eslint`（5 个改动文件） | ✅ 0 error |
| 4 | dev server 起服务验 200 | ⚠️ **无法执行**：本会话为无人值守定时任务，`preview_start` 拒绝启动 dev server（任务文件亦禁止用 Bash 跑 server）。改为对 `next build` 产出的预渲染 HTML 跑全部断言 |
| 5 | canonical 自引用 + hreflang 仅 en/x-default | ✅ 脚本断言通过 |
| 6 | JSON-LD 可 `json.loads`，FAQ 逐字出现在可见正文 | ✅ TechArticle + FAQPage + BreadcrumbList 均解析成功，5 组问答逐字命中 |
| 7 | 标题层级无跳级 | ✅ `[1,2,2,2,2,3,3,2,2,2,3,3,3,3,3,2,2]`，单 h1 |
| 8 | 375px 无横向溢出 | ⚠️ **等价验证**：无浏览器可跑 JS 断言。改为静态核查——正文唯一表格已包 `.table-wrap`，article 内无 `min-width`；新增内容最长行内 `code` token 原为 33 字符（超出风险），已拆分至 **22 字符**，与线上现行版本的最长 token 完全持平，不引入新的溢出风险 |
| 9 | 外链全部 2xx/3xx | ✅ 12 条全部 200（含新加的 `#cf-ipcountry` 锚点已确认存在） |
| 10 | 词数 1000–1800 | ✅ 1754 词 |

## 需要人工复核

- 门槛 4 与 8 未能按原方式执行（原因见上表），若需严格复核请在本地 `pnpm --dir apps/web dev` 起服务后跑一次 375px 断言。
- 本篇 slug 未改（已含 `real-visitor-ip` 与 `cf-connecting-ip` 两个词面），避免引入重定向；如认为应改为症状式 slug 需另行决策。
